### PR TITLE
Phase 1a: Fact Schema and Binary Format

### DIFF
--- a/extract/db/reader.go
+++ b/extract/db/reader.go
@@ -27,6 +27,17 @@ func ReadDB(r io.ReaderAt, size int64) (*DB, error) {
 	relCount := le.Uint32(hdr[8:12])
 	strCount := le.Uint32(hdr[12:16])
 
+	const (
+		maxRelations = 1024
+		maxStrings   = 1 << 24 // 16M strings
+	)
+	if relCount > maxRelations {
+		return nil, fmt.Errorf("db: relation count %d exceeds maximum %d", relCount, maxRelations)
+	}
+	if strCount > maxStrings {
+		return nil, fmt.Errorf("db: string count %d exceeds maximum %d", strCount, maxStrings)
+	}
+
 	// Read directory
 	dirBuf := make([]byte, relCount*32)
 	if _, err := r.ReadAt(dirBuf, 16); err != nil {

--- a/extract/db/reader.go
+++ b/extract/db/reader.go
@@ -1,2 +1,160 @@
-// Package db implements the tsq binary columnar fact database format.
 package db
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/Gjdoalfnrxu/tsq/extract/schema"
+)
+
+// ReadDB reads a binary columnar fact database from r.
+func ReadDB(r io.ReaderAt, size int64) (*DB, error) {
+	le := binary.LittleEndian
+
+	// Read header (16 bytes)
+	hdr := make([]byte, 16)
+	if _, err := r.ReadAt(hdr, 0); err != nil {
+		return nil, fmt.Errorf("db: read header: %w", err)
+	}
+	if string(hdr[0:4]) != Magic {
+		return nil, fmt.Errorf("db: invalid magic %q", hdr[0:4])
+	}
+	schemaVer := le.Uint32(hdr[4:8])
+	if schemaVer != SchemaVersion {
+		return nil, fmt.Errorf("db: schema version mismatch: file has %d, reader expects %d", schemaVer, SchemaVersion)
+	}
+	relCount := le.Uint32(hdr[8:12])
+	strCount := le.Uint32(hdr[12:16])
+
+	// Read directory
+	dirBuf := make([]byte, relCount*32)
+	if _, err := r.ReadAt(dirBuf, 16); err != nil {
+		return nil, fmt.Errorf("db: read directory: %w", err)
+	}
+
+	type dirEntry struct {
+		nameOffset uint32
+		tupleCount uint32
+		colCount   uint32
+		dataOffset uint64
+	}
+	entries := make([]dirEntry, relCount)
+	for i := range entries {
+		base := i * 32
+		entries[i] = dirEntry{
+			nameOffset: le.Uint32(dirBuf[base : base+4]),
+			tupleCount: le.Uint32(dirBuf[base+4 : base+8]),
+			colCount:   le.Uint32(dirBuf[base+8 : base+12]),
+			dataOffset: le.Uint64(dirBuf[base+12 : base+20]),
+		}
+	}
+
+	// Find string table offset: it follows all relation data.
+	// Compute by finding the max (dataOffset + tupleCount * colCount * 4).
+	var strTableStart int64
+	for _, e := range entries {
+		dataEnd := int64(e.dataOffset) + int64(e.tupleCount)*int64(e.colCount)*4
+		if dataEnd > strTableStart {
+			strTableStart = dataEnd
+		}
+	}
+	// If no relations, string table starts right after directory
+	if relCount == 0 {
+		strTableStart = 16
+	}
+
+	// Read string table
+	strTable, err := readStringTable(r, size, strCount, strTableStart, le)
+	if err != nil {
+		return nil, fmt.Errorf("db: read string table: %w", err)
+	}
+
+	db := &DB{
+		relations: make(map[string]*Relation),
+		strings:   strTable,
+		stringIdx: make(map[string]uint32, len(strTable)),
+	}
+	for i, s := range strTable {
+		db.stringIdx[s] = uint32(i)
+	}
+
+	// Now read each relation
+	for _, entry := range entries {
+		if entry.nameOffset >= uint32(len(strTable)) {
+			return nil, fmt.Errorf("db: relation name offset %d out of range", entry.nameOffset)
+		}
+		name := strTable[entry.nameOffset]
+		def, ok := schema.Lookup(name)
+		if !ok {
+			// Unknown relation — skip gracefully (forward compat)
+			continue
+		}
+		if uint32(len(def.Columns)) != entry.colCount {
+			return nil, fmt.Errorf("db: relation %q: expected %d columns, got %d", name, len(def.Columns), entry.colCount)
+		}
+
+		rel := &Relation{
+			Def:     def,
+			columns: make([]column, len(def.Columns)),
+			size:    int(entry.tupleCount),
+		}
+
+		offset := int64(entry.dataOffset)
+		for i, colDef := range def.Columns {
+			data := make([]byte, entry.tupleCount*4)
+			if _, err := r.ReadAt(data, offset); err != nil {
+				return nil, fmt.Errorf("db: relation %q column %q: %w", name, colDef.Name, err)
+			}
+			switch colDef.Type {
+			case schema.TypeInt32, schema.TypeEntityRef:
+				rel.columns[i].ints = make([]int32, entry.tupleCount)
+				for j := range rel.columns[i].ints {
+					rel.columns[i].ints[j] = int32(le.Uint32(data[j*4 : j*4+4]))
+				}
+			case schema.TypeString:
+				rel.columns[i].strIdxs = make([]uint32, entry.tupleCount)
+				for j := range rel.columns[i].strIdxs {
+					rel.columns[i].strIdxs[j] = le.Uint32(data[j*4 : j*4+4])
+				}
+			}
+			offset += int64(entry.tupleCount * 4)
+		}
+		db.relations[name] = rel
+	}
+	return db, nil
+}
+
+func readStringTable(r io.ReaderAt, fileSize int64, strCount uint32, strTableStart int64, le binary.ByteOrder) ([]string, error) {
+	strData := make([]byte, fileSize-strTableStart)
+	if _, err := r.ReadAt(strData, strTableStart); err != nil {
+		return nil, err
+	}
+
+	if len(strData) < 4 {
+		return nil, fmt.Errorf("string table too short")
+	}
+	count := le.Uint32(strData[0:4])
+	if count != strCount {
+		return nil, fmt.Errorf("string count mismatch: header says %d, table says %d", strCount, count)
+	}
+
+	strs := make([]string, 0, count)
+	pos := 4
+	for i := uint32(0); i < count; i++ {
+		if pos+4 > len(strData) {
+			return nil, fmt.Errorf("string table truncated at string %d", i)
+		}
+		slen := int(le.Uint32(strData[pos : pos+4]))
+		pos += 4
+		if slen > MaxStringLen {
+			return nil, fmt.Errorf("string %d length %d exceeds limit", i, slen)
+		}
+		if pos+slen > len(strData) {
+			return nil, fmt.Errorf("string %d data truncated", i)
+		}
+		strs = append(strs, string(strData[pos:pos+slen]))
+		pos += slen
+	}
+	return strs, nil
+}

--- a/extract/db/reader_test.go
+++ b/extract/db/reader_test.go
@@ -1,0 +1,195 @@
+package db
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestRoundTrip(t *testing.T) {
+	db := NewDB()
+	r := db.Relation("Node")
+	err := r.AddTuple(db, int32(1), int32(1), "CallExpression", int32(10), int32(5), int32(10), int32(30))
+	if err != nil {
+		t.Fatalf("AddTuple: %v", err)
+	}
+	err = r.AddTuple(db, int32(2), int32(1), "Identifier", int32(10), int32(5), int32(10), int32(15))
+	if err != nil {
+		t.Fatalf("AddTuple: %v", err)
+	}
+
+	// Also add a File relation
+	fr := db.Relation("File")
+	err = fr.AddTuple(db, int32(1), "/src/main.ts", "sha256:abc")
+	if err != nil {
+		t.Fatalf("AddTuple File: %v", err)
+	}
+
+	// Write
+	var buf bytes.Buffer
+	if err := db.Encode(&buf); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	// Read back
+	data := buf.Bytes()
+	reader := bytes.NewReader(data)
+	db2, err := ReadDB(reader, int64(len(data)))
+	if err != nil {
+		t.Fatalf("ReadDB: %v", err)
+	}
+
+	// Verify Node relation
+	node := db2.relations["Node"]
+	if node == nil {
+		t.Fatal("Node relation not found after round-trip")
+	}
+	if node.Tuples() != 2 {
+		t.Fatalf("expected 2 tuples, got %d", node.Tuples())
+	}
+
+	// Check first tuple
+	id, err := node.GetInt(0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != 1 {
+		t.Fatalf("expected id=1, got %d", id)
+	}
+
+	kind, err := node.GetString(db2, 0, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if kind != "CallExpression" {
+		t.Fatalf("expected kind=CallExpression, got %q", kind)
+	}
+
+	startLine, err := node.GetInt(0, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if startLine != 10 {
+		t.Fatalf("expected startLine=10, got %d", startLine)
+	}
+
+	// Check second tuple
+	kind2, err := node.GetString(db2, 1, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if kind2 != "Identifier" {
+		t.Fatalf("expected kind=Identifier, got %q", kind2)
+	}
+
+	// Verify File relation
+	file := db2.relations["File"]
+	if file == nil {
+		t.Fatal("File relation not found after round-trip")
+	}
+	if file.Tuples() != 1 {
+		t.Fatalf("expected 1 tuple, got %d", file.Tuples())
+	}
+	path, err := file.GetString(db2, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != "/src/main.ts" {
+		t.Fatalf("expected path=/src/main.ts, got %q", path)
+	}
+}
+
+func TestRoundTrip_MultipleRelations(t *testing.T) {
+	db := NewDB()
+
+	// Add Contains tuples
+	c := db.Relation("Contains")
+	if err := c.AddTuple(db, int32(1), int32(2)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.AddTuple(db, int32(1), int32(3)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add Symbol tuples
+	s := db.Relation("Symbol")
+	if err := s.AddTuple(db, int32(100), "myFunc", int32(5), int32(1)); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := db.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+
+	data := buf.Bytes()
+	db2, err := ReadDB(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify Contains
+	cr := db2.relations["Contains"]
+	if cr == nil || cr.Tuples() != 2 {
+		t.Fatalf("expected 2 Contains tuples, got %v", cr)
+	}
+	v, _ := cr.GetInt(1, 1)
+	if v != 3 {
+		t.Fatalf("expected child=3, got %d", v)
+	}
+
+	// Verify Symbol
+	sr := db2.relations["Symbol"]
+	if sr == nil || sr.Tuples() != 1 {
+		t.Fatal("expected 1 Symbol tuple")
+	}
+	name, _ := sr.GetString(db2, 0, 1)
+	if name != "myFunc" {
+		t.Fatalf("expected myFunc, got %q", name)
+	}
+}
+
+func TestReadDB_BadMagic(t *testing.T) {
+	data := make([]byte, 16)
+	copy(data[0:4], "NOPE")
+	_, err := ReadDB(bytes.NewReader(data), 16)
+	if err == nil {
+		t.Fatal("expected error for bad magic")
+	}
+}
+
+func TestReadDB_SchemaVersionMismatch(t *testing.T) {
+	data := make([]byte, 16)
+	copy(data[0:4], Magic)
+	binary.LittleEndian.PutUint32(data[4:8], 99) // wrong version
+	binary.LittleEndian.PutUint32(data[8:12], 0)
+	binary.LittleEndian.PutUint32(data[12:16], 0)
+	_, err := ReadDB(bytes.NewReader(data), 16)
+	if err == nil {
+		t.Fatal("expected error for schema version mismatch")
+	}
+}
+
+func TestReadDB_EmptyDB(t *testing.T) {
+	db := NewDB()
+	var buf bytes.Buffer
+	if err := db.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	data := buf.Bytes()
+	db2, err := ReadDB(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("ReadDB empty: %v", err)
+	}
+	if len(db2.relations) != 0 {
+		t.Fatalf("expected 0 relations, got %d", len(db2.relations))
+	}
+}
+
+func TestReadDB_TruncatedHeader(t *testing.T) {
+	data := []byte("TSQ")
+	_, err := ReadDB(bytes.NewReader(data), int64(len(data)))
+	if err == nil {
+		t.Fatal("expected error for truncated header")
+	}
+}

--- a/extract/db/reader_test.go
+++ b/extract/db/reader_test.go
@@ -193,3 +193,81 @@ func TestReadDB_TruncatedHeader(t *testing.T) {
 		t.Fatal("expected error for truncated header")
 	}
 }
+
+func TestReadDB_MalformedRelCount(t *testing.T) {
+	// Build a minimal valid header with relCount = maxRelations+1.
+	// maxRelations = 1024, so set relCount = 1025.
+	data := make([]byte, 16)
+	copy(data[0:4], Magic)
+	binary.LittleEndian.PutUint32(data[4:8], SchemaVersion)
+	binary.LittleEndian.PutUint32(data[8:12], 1025)  // relCount > maxRelations
+	binary.LittleEndian.PutUint32(data[12:16], 0)    // strCount
+	_, err := ReadDB(bytes.NewReader(data), int64(len(data)))
+	if err == nil {
+		t.Fatal("expected error for relCount exceeding maximum")
+	}
+}
+
+func TestReadDB_MalformedStrCount(t *testing.T) {
+	// Build a minimal valid header with strCount = maxStrings+1.
+	// maxStrings = 1<<24 = 16777216.
+	data := make([]byte, 16)
+	copy(data[0:4], Magic)
+	binary.LittleEndian.PutUint32(data[4:8], SchemaVersion)
+	binary.LittleEndian.PutUint32(data[8:12], 0)          // relCount
+	binary.LittleEndian.PutUint32(data[12:16], 1<<24+1)   // strCount > maxStrings
+	_, err := ReadDB(bytes.NewReader(data), int64(len(data)))
+	if err == nil {
+		t.Fatal("expected error for strCount exceeding maximum")
+	}
+}
+
+func TestReadDB_ForwardCompat_UnknownRelation(t *testing.T) {
+	// Write a real DB, then hand-craft a second relation entry in the
+	// directory that references a name not in the schema registry.
+	// ReadDB should succeed and simply omit the unknown relation.
+
+	// Start from an encoded empty DB to get a valid string table base.
+	base := NewDB()
+	var buf bytes.Buffer
+	if err := base.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+
+	// Build a fresh binary from scratch:
+	//   header: magic + version + relCount=1 + strCount=2
+	//   directory: one entry pointing to an empty relation with name "GhostRelation"
+	//   relation data: nothing (0 tuples)
+	//   string table: ["", "GhostRelation"]
+
+	le := binary.LittleEndian
+	strTable := buildStringTable([]string{"", "GhostRelation"})
+
+	// directory entry: nameOffset=1, tupleCount=0, colCount=0, dataOffset=16+32=48
+	dirEntry := make([]byte, 32)
+	le.PutUint32(dirEntry[0:4], 1)  // nameOffset -> "GhostRelation"
+	le.PutUint32(dirEntry[4:8], 0)  // tupleCount
+	le.PutUint32(dirEntry[8:12], 0) // colCount
+	le.PutUint64(dirEntry[12:20], 48) // dataOffset
+
+	hdr := make([]byte, 16)
+	copy(hdr[0:4], Magic)
+	le.PutUint32(hdr[4:8], SchemaVersion)
+	le.PutUint32(hdr[8:12], 1) // relCount
+	le.PutUint32(hdr[12:16], 2) // strCount: "", "GhostRelation"
+
+	var out bytes.Buffer
+	out.Write(hdr)
+	out.Write(dirEntry)
+	// no relation data
+	out.Write(strTable)
+
+	data := out.Bytes()
+	db2, err := ReadDB(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("ReadDB should succeed for unknown relation, got: %v", err)
+	}
+	if _, ok := db2.relations["GhostRelation"]; ok {
+		t.Fatal("unknown relation should be absent from result")
+	}
+}

--- a/extract/db/reader_test.go
+++ b/extract/db/reader_test.go
@@ -200,8 +200,8 @@ func TestReadDB_MalformedRelCount(t *testing.T) {
 	data := make([]byte, 16)
 	copy(data[0:4], Magic)
 	binary.LittleEndian.PutUint32(data[4:8], SchemaVersion)
-	binary.LittleEndian.PutUint32(data[8:12], 1025)  // relCount > maxRelations
-	binary.LittleEndian.PutUint32(data[12:16], 0)    // strCount
+	binary.LittleEndian.PutUint32(data[8:12], 1025) // relCount > maxRelations
+	binary.LittleEndian.PutUint32(data[12:16], 0)   // strCount
 	_, err := ReadDB(bytes.NewReader(data), int64(len(data)))
 	if err == nil {
 		t.Fatal("expected error for relCount exceeding maximum")
@@ -214,8 +214,8 @@ func TestReadDB_MalformedStrCount(t *testing.T) {
 	data := make([]byte, 16)
 	copy(data[0:4], Magic)
 	binary.LittleEndian.PutUint32(data[4:8], SchemaVersion)
-	binary.LittleEndian.PutUint32(data[8:12], 0)          // relCount
-	binary.LittleEndian.PutUint32(data[12:16], 1<<24+1)   // strCount > maxStrings
+	binary.LittleEndian.PutUint32(data[8:12], 0)        // relCount
+	binary.LittleEndian.PutUint32(data[12:16], 1<<24+1) // strCount > maxStrings
 	_, err := ReadDB(bytes.NewReader(data), int64(len(data)))
 	if err == nil {
 		t.Fatal("expected error for strCount exceeding maximum")
@@ -245,15 +245,15 @@ func TestReadDB_ForwardCompat_UnknownRelation(t *testing.T) {
 
 	// directory entry: nameOffset=1, tupleCount=0, colCount=0, dataOffset=16+32=48
 	dirEntry := make([]byte, 32)
-	le.PutUint32(dirEntry[0:4], 1)  // nameOffset -> "GhostRelation"
-	le.PutUint32(dirEntry[4:8], 0)  // tupleCount
-	le.PutUint32(dirEntry[8:12], 0) // colCount
+	le.PutUint32(dirEntry[0:4], 1)    // nameOffset -> "GhostRelation"
+	le.PutUint32(dirEntry[4:8], 0)    // tupleCount
+	le.PutUint32(dirEntry[8:12], 0)   // colCount
 	le.PutUint64(dirEntry[12:20], 48) // dataOffset
 
 	hdr := make([]byte, 16)
 	copy(hdr[0:4], Magic)
 	le.PutUint32(hdr[4:8], SchemaVersion)
-	le.PutUint32(hdr[8:12], 1) // relCount
+	le.PutUint32(hdr[8:12], 1)  // relCount
 	le.PutUint32(hdr[12:16], 2) // strCount: "", "GhostRelation"
 
 	var out bytes.Buffer

--- a/extract/db/writer.go
+++ b/extract/db/writer.go
@@ -1,2 +1,276 @@
 // Package db implements the tsq binary columnar fact database format.
 package db
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/Gjdoalfnrxu/tsq/extract/schema"
+)
+
+const (
+	Magic         = "TSQ\x00"
+	SchemaVersion = 1
+	MaxTuples     = math.MaxUint32
+	MaxStringLen  = 1 << 20 // 1MB per string — sanity limit
+)
+
+// Relation holds in-memory columnar data for a single fact relation.
+type Relation struct {
+	Def     schema.RelationDef
+	columns []column
+	size    int // number of tuples
+}
+
+type column struct {
+	ints    []int32  // for TypeInt32, TypeEntityRef
+	strIdxs []uint32 // for TypeString (indexes into writer's string table)
+}
+
+// DB holds all relations for writing.
+type DB struct {
+	relations map[string]*Relation
+	strings   []string
+	stringIdx map[string]uint32
+}
+
+// NewDB creates an empty fact database.
+func NewDB() *DB {
+	return &DB{
+		relations: make(map[string]*Relation),
+		stringIdx: make(map[string]uint32),
+		strings:   []string{""}, // index 0 = empty string
+	}
+}
+
+// Relation returns or creates the named relation. Panics if the name is not in the registry.
+func (db *DB) Relation(name string) *Relation {
+	if r, ok := db.relations[name]; ok {
+		return r
+	}
+	def, ok := schema.Lookup(name)
+	if !ok {
+		panic(fmt.Sprintf("db.Relation: unknown relation %q", name))
+	}
+	r := &Relation{
+		Def:     def,
+		columns: make([]column, len(def.Columns)),
+	}
+	db.relations[name] = r
+	return r
+}
+
+// intern returns the string table index for s, adding it if necessary.
+func (db *DB) intern(s string) uint32 {
+	if idx, ok := db.stringIdx[s]; ok {
+		return idx
+	}
+	if len(db.strings) > int(MaxTuples) {
+		panic("string table overflow")
+	}
+	idx := uint32(len(db.strings))
+	db.strings = append(db.strings, s)
+	db.stringIdx[s] = idx
+	return idx
+}
+
+// Tuples returns the number of tuples in the relation.
+func (r *Relation) Tuples() int { return r.size }
+
+// GetInt returns the int32 value at (tuple, col) for an Int32/EntityRef column.
+func (r *Relation) GetInt(tuple, col int) (int32, error) {
+	if col >= len(r.columns) {
+		return 0, fmt.Errorf("col %d out of range", col)
+	}
+	if tuple >= r.size {
+		return 0, fmt.Errorf("tuple %d out of range", tuple)
+	}
+	return r.columns[col].ints[tuple], nil
+}
+
+// GetString returns the string value at (tuple, col) for a String column.
+func (r *Relation) GetString(db *DB, tuple, col int) (string, error) {
+	if col >= len(r.columns) {
+		return "", fmt.Errorf("col %d out of range", col)
+	}
+	if tuple >= r.size {
+		return "", fmt.Errorf("tuple %d out of range", tuple)
+	}
+	idx := r.columns[col].strIdxs[tuple]
+	if int(idx) >= len(db.strings) {
+		return "", fmt.Errorf("string index %d out of range", idx)
+	}
+	return db.strings[idx], nil
+}
+
+// AddTuple appends a tuple to the relation. Values must match the column types.
+// Int32/EntityRef columns take int32. String columns take string.
+func (r *Relation) AddTuple(db *DB, vals ...interface{}) error {
+	if len(vals) != len(r.Def.Columns) {
+		return fmt.Errorf("relation %q: expected %d values, got %d", r.Def.Name, len(r.Def.Columns), len(vals))
+	}
+	for i, val := range vals {
+		col := &r.columns[i]
+		switch r.Def.Columns[i].Type {
+		case schema.TypeInt32, schema.TypeEntityRef:
+			v, ok := toInt32(val)
+			if !ok {
+				return fmt.Errorf("relation %q column %q: expected int-like, got %T", r.Def.Name, r.Def.Columns[i].Name, val)
+			}
+			col.ints = append(col.ints, v)
+		case schema.TypeString:
+			s, ok := val.(string)
+			if !ok {
+				return fmt.Errorf("relation %q column %q: expected string, got %T", r.Def.Name, r.Def.Columns[i].Name, val)
+			}
+			if len(s) > MaxStringLen {
+				return fmt.Errorf("relation %q column %q: string length %d exceeds limit", r.Def.Name, r.Def.Columns[i].Name, len(s))
+			}
+			col.strIdxs = append(col.strIdxs, db.intern(s))
+		}
+	}
+	r.size++
+	return nil
+}
+
+func toInt32(v interface{}) (int32, bool) {
+	switch x := v.(type) {
+	case int32:
+		return x, true
+	case int:
+		return int32(x), true
+	case uint32:
+		return int32(x), true
+	case int64:
+		return int32(x), true
+	}
+	return 0, false
+}
+
+// Encode serialises the DB in binary columnar format to w.
+func (db *DB) Encode(w io.Writer) error {
+	// build ordered relation list from registry (consistent ordering)
+	var rels []*Relation
+	for _, def := range schema.Registry {
+		if r, ok := db.relations[def.Name]; ok {
+			rels = append(rels, r)
+		}
+	}
+
+	le := binary.LittleEndian
+
+	// Pre-intern all relation names so they are in the string table
+	// before we build it or write the header.
+	type relMeta struct {
+		nameOffset uint32
+		dataOffset uint64
+	}
+	metas := make([]relMeta, len(rels))
+	for i, r := range rels {
+		metas[i].nameOffset = db.intern(r.Def.Name)
+	}
+
+	// Header
+	if _, err := io.WriteString(w, Magic); err != nil {
+		return err
+	}
+	hdr := make([]byte, 12)
+	le.PutUint32(hdr[0:4], SchemaVersion)
+	le.PutUint32(hdr[4:8], uint32(len(rels)))
+	le.PutUint32(hdr[8:12], uint32(len(db.strings)))
+	if _, err := w.Write(hdr); err != nil {
+		return err
+	}
+
+	// Compute data offsets
+	dirSize := uint64(len(rels)) * 32
+	baseOffset := uint64(16) + dirSize
+
+	// Build string table bytes
+	strTable := buildStringTable(db.strings)
+
+	// Compute per-relation data offsets
+	offset := baseOffset
+	for i, r := range rels {
+		metas[i].dataOffset = offset
+		offset += relDataSize(r)
+	}
+
+	// Write directory
+	dir := make([]byte, 32)
+	for i, r := range rels {
+		le.PutUint32(dir[0:4], metas[i].nameOffset)
+		le.PutUint32(dir[4:8], uint32(r.size))
+		le.PutUint32(dir[8:12], uint32(len(r.Def.Columns)))
+		le.PutUint64(dir[12:20], metas[i].dataOffset)
+		// padding [20:32] = zero
+		for j := 20; j < 32; j++ {
+			dir[j] = 0
+		}
+		if _, err := w.Write(dir); err != nil {
+			return err
+		}
+	}
+
+	// Write relation data
+	for _, r := range rels {
+		if err := writeRelationData(w, r, le); err != nil {
+			return err
+		}
+	}
+
+	// Write string table
+	_, err := w.Write(strTable)
+	return err
+}
+
+func relDataSize(r *Relation) uint64 {
+	sz := uint64(0)
+	for i, col := range r.Def.Columns {
+		switch col.Type {
+		case schema.TypeInt32, schema.TypeEntityRef:
+			sz += uint64(len(r.columns[i].ints)) * 4
+		case schema.TypeString:
+			sz += uint64(len(r.columns[i].strIdxs)) * 4
+		}
+	}
+	return sz
+}
+
+func writeRelationData(w io.Writer, r *Relation, le binary.ByteOrder) error {
+	buf := make([]byte, 4)
+	for i, col := range r.Def.Columns {
+		switch col.Type {
+		case schema.TypeInt32, schema.TypeEntityRef:
+			for _, v := range r.columns[i].ints {
+				le.PutUint32(buf, uint32(v))
+				if _, err := w.Write(buf); err != nil {
+					return err
+				}
+			}
+		case schema.TypeString:
+			for _, idx := range r.columns[i].strIdxs {
+				le.PutUint32(buf, idx)
+				if _, err := w.Write(buf); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func buildStringTable(strings []string) []byte {
+	var out []byte
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, uint32(len(strings)))
+	out = append(out, buf...)
+	for _, s := range strings {
+		binary.LittleEndian.PutUint32(buf, uint32(len(s)))
+		out = append(out, buf...)
+		out = append(out, s...)
+	}
+	return out
+}

--- a/extract/db/writer.go
+++ b/extract/db/writer.go
@@ -87,6 +87,9 @@ func (r *Relation) GetInt(tuple, col int) (int32, error) {
 	if tuple >= r.size {
 		return 0, fmt.Errorf("tuple %d out of range", tuple)
 	}
+	if r.Def.Columns[col].Type == schema.TypeString {
+		return 0, fmt.Errorf("column %q is TypeString, not an integer type", r.Def.Columns[col].Name)
+	}
 	return r.columns[col].ints[tuple], nil
 }
 
@@ -97,6 +100,9 @@ func (r *Relation) GetString(db *DB, tuple, col int) (string, error) {
 	}
 	if tuple >= r.size {
 		return "", fmt.Errorf("tuple %d out of range", tuple)
+	}
+	if r.Def.Columns[col].Type != schema.TypeString {
+		return "", fmt.Errorf("column %q is not TypeString", r.Def.Columns[col].Name)
 	}
 	idx := r.columns[col].strIdxs[tuple]
 	if int(idx) >= len(db.strings) {

--- a/extract/db/writer_test.go
+++ b/extract/db/writer_test.go
@@ -1,0 +1,134 @@
+package db
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNewDB(t *testing.T) {
+	db := NewDB()
+	if db == nil {
+		t.Fatal("NewDB returned nil")
+	}
+	// Should have empty string at index 0
+	if len(db.strings) != 1 || db.strings[0] != "" {
+		t.Fatalf("expected strings=[\"\"]; got %v", db.strings)
+	}
+}
+
+func TestRelation_UnknownPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for unknown relation")
+		}
+	}()
+	db := NewDB()
+	db.Relation("TotallyFakeRelation")
+}
+
+func TestAddTuple_OK(t *testing.T) {
+	db := NewDB()
+	r := db.Relation("Contains")
+	err := r.AddTuple(db, int32(1), int32(2))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Tuples() != 1 {
+		t.Fatalf("expected 1 tuple, got %d", r.Tuples())
+	}
+}
+
+func TestAddTuple_WrongArity(t *testing.T) {
+	db := NewDB()
+	r := db.Relation("Contains") // 2 columns
+	err := r.AddTuple(db, int32(1))
+	if err == nil {
+		t.Fatal("expected error for wrong arity")
+	}
+}
+
+func TestAddTuple_WrongType(t *testing.T) {
+	db := NewDB()
+	r := db.Relation("File") // id=EntityRef, path=String, contentHash=String
+	err := r.AddTuple(db, int32(1), 42, "abc")
+	if err == nil {
+		t.Fatal("expected error for wrong type (int instead of string)")
+	}
+}
+
+func TestAddTuple_WrongTypeInt(t *testing.T) {
+	db := NewDB()
+	r := db.Relation("Contains") // parent=EntityRef, child=EntityRef
+	err := r.AddTuple(db, "notAnInt", int32(2))
+	if err == nil {
+		t.Fatal("expected error for string in int column")
+	}
+}
+
+func TestEncode_Empty(t *testing.T) {
+	db := NewDB()
+	var buf bytes.Buffer
+	err := db.Encode(&buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should have valid header at minimum
+	data := buf.Bytes()
+	if len(data) < 16 {
+		t.Fatalf("output too short: %d bytes", len(data))
+	}
+	if string(data[0:4]) != Magic {
+		t.Fatalf("bad magic: %q", data[0:4])
+	}
+}
+
+func TestGetInt(t *testing.T) {
+	db := NewDB()
+	r := db.Relation("Contains")
+	if err := r.AddTuple(db, int32(10), int32(20)); err != nil {
+		t.Fatal(err)
+	}
+	v, err := r.GetInt(0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != 10 {
+		t.Fatalf("expected 10, got %d", v)
+	}
+	v, err = r.GetInt(0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != 20 {
+		t.Fatalf("expected 20, got %d", v)
+	}
+}
+
+func TestGetString(t *testing.T) {
+	db := NewDB()
+	r := db.Relation("File")
+	if err := r.AddTuple(db, int32(1), "/src/main.ts", "abc123"); err != nil {
+		t.Fatal(err)
+	}
+	s, err := r.GetString(db, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != "/src/main.ts" {
+		t.Fatalf("expected /src/main.ts, got %q", s)
+	}
+}
+
+func TestGetInt_OutOfRange(t *testing.T) {
+	db := NewDB()
+	r := db.Relation("Contains")
+	if err := r.AddTuple(db, int32(1), int32(2)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.GetInt(5, 0); err == nil {
+		t.Fatal("expected error for out-of-range tuple")
+	}
+	if _, err := r.GetInt(0, 5); err == nil {
+		t.Fatal("expected error for out-of-range col")
+	}
+}

--- a/extract/db/writer_test.go
+++ b/extract/db/writer_test.go
@@ -132,3 +132,41 @@ func TestGetInt_OutOfRange(t *testing.T) {
 		t.Fatal("expected error for out-of-range col")
 	}
 }
+
+func TestGetIntWrongType(t *testing.T) {
+	// File has col 1 = path (TypeString). Calling GetInt on it must return
+	// an error, not panic on nil ints slice.
+	db := NewDB()
+	r := db.Relation("File")
+	if err := r.AddTuple(db, int32(1), "/src/main.ts", "abc123"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := r.GetInt(0, 1) // col 1 is TypeString
+	if err == nil {
+		t.Fatal("expected error when calling GetInt on a TypeString column")
+	}
+}
+
+func TestGetStringWrongType(t *testing.T) {
+	// Contains has col 0 = parent (TypeEntityRef). Calling GetString on it must
+	// return an error, not panic on nil strIdxs slice.
+	db := NewDB()
+	r := db.Relation("Contains")
+	if err := r.AddTuple(db, int32(1), int32(2)); err != nil {
+		t.Fatal(err)
+	}
+	_, err := r.GetString(db, 0, 0) // col 0 is TypeEntityRef
+	if err == nil {
+		t.Fatal("expected error when calling GetString on a non-TypeString column")
+	}
+}
+
+func TestAddTuple_StringTooLong(t *testing.T) {
+	db := NewDB()
+	r := db.Relation("File")
+	longStr := string(make([]byte, MaxStringLen+1))
+	err := r.AddTuple(db, int32(1), longStr, "hash")
+	if err == nil {
+		t.Fatal("expected error for string exceeding MaxStringLen")
+	}
+}

--- a/extract/schema/registry.go
+++ b/extract/schema/registry.go
@@ -1,2 +1,77 @@
 // Package schema defines the tsq fact relation registry and column types.
 package schema
+
+import "fmt"
+
+// ColumnType identifies the type of a relation column.
+type ColumnType uint8
+
+const (
+	TypeInt32     ColumnType = iota // signed 32-bit integer
+	TypeEntityRef                   // unsigned 32-bit entity ID (alias for Int32 in storage)
+	TypeString                      // interned string (stored as uint32 index into string table)
+)
+
+// ColumnDef describes one column of a relation.
+type ColumnDef struct {
+	Name string
+	Type ColumnType
+}
+
+// RelationDef describes a fact relation in the schema.
+type RelationDef struct {
+	Name    string
+	Columns []ColumnDef
+	Version int // schema version when this relation was introduced
+}
+
+// Arity returns the number of columns in the relation.
+func (r RelationDef) Arity() int { return len(r.Columns) }
+
+// Validate returns an error if the RelationDef is malformed.
+func (r RelationDef) Validate() error {
+	if r.Name == "" {
+		return fmt.Errorf("relation name must not be empty")
+	}
+	if len(r.Columns) == 0 {
+		return fmt.Errorf("relation %q must have at least one column", r.Name)
+	}
+	if r.Version < 1 {
+		return fmt.Errorf("relation %q version must be >= 1", r.Name)
+	}
+	seen := make(map[string]bool, len(r.Columns))
+	for i, col := range r.Columns {
+		if col.Name == "" {
+			return fmt.Errorf("relation %q column %d has empty name", r.Name, i)
+		}
+		if seen[col.Name] {
+			return fmt.Errorf("relation %q has duplicate column name %q", r.Name, col.Name)
+		}
+		seen[col.Name] = true
+	}
+	return nil
+}
+
+// Registry is the global relation registry. All relations must be registered here.
+var Registry []RelationDef
+
+// RegisterRelation adds a relation to the global registry. Panics on duplicates.
+// Called from relations.go init().
+func RegisterRelation(def RelationDef) {
+	for _, existing := range Registry {
+		if existing.Name == def.Name {
+			panic(fmt.Sprintf("duplicate relation registration: %q", def.Name))
+		}
+	}
+	Registry = append(Registry, def)
+}
+
+// Lookup returns the RelationDef for a given name, or false if not found.
+func Lookup(name string) (RelationDef, bool) {
+	for _, r := range Registry {
+		if r.Name == name {
+			return r, true
+		}
+	}
+	return RelationDef{}, false
+}

--- a/extract/schema/registry_test.go
+++ b/extract/schema/registry_test.go
@@ -1,0 +1,93 @@
+package schema
+
+import (
+	"testing"
+)
+
+func TestValidate_EmptyName(t *testing.T) {
+	r := RelationDef{Name: "", Version: 1, Columns: []ColumnDef{{Name: "a", Type: TypeInt32}}}
+	if err := r.Validate(); err == nil {
+		t.Fatal("expected error for empty name")
+	}
+}
+
+func TestValidate_NoColumns(t *testing.T) {
+	r := RelationDef{Name: "Foo", Version: 1, Columns: nil}
+	if err := r.Validate(); err == nil {
+		t.Fatal("expected error for no columns")
+	}
+}
+
+func TestValidate_ZeroVersion(t *testing.T) {
+	r := RelationDef{Name: "Foo", Version: 0, Columns: []ColumnDef{{Name: "a", Type: TypeInt32}}}
+	if err := r.Validate(); err == nil {
+		t.Fatal("expected error for version 0")
+	}
+}
+
+func TestValidate_EmptyColumnName(t *testing.T) {
+	r := RelationDef{Name: "Foo", Version: 1, Columns: []ColumnDef{{Name: "", Type: TypeInt32}}}
+	if err := r.Validate(); err == nil {
+		t.Fatal("expected error for empty column name")
+	}
+}
+
+func TestValidate_DuplicateColumnName(t *testing.T) {
+	r := RelationDef{Name: "Foo", Version: 1, Columns: []ColumnDef{
+		{Name: "a", Type: TypeInt32},
+		{Name: "a", Type: TypeString},
+	}}
+	if err := r.Validate(); err == nil {
+		t.Fatal("expected error for duplicate column name")
+	}
+}
+
+func TestValidate_OK(t *testing.T) {
+	r := RelationDef{Name: "Foo", Version: 1, Columns: []ColumnDef{
+		{Name: "a", Type: TypeInt32},
+		{Name: "b", Type: TypeString},
+	}}
+	if err := r.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestArity(t *testing.T) {
+	r := RelationDef{Name: "X", Version: 1, Columns: []ColumnDef{
+		{Name: "a", Type: TypeInt32},
+		{Name: "b", Type: TypeInt32},
+		{Name: "c", Type: TypeString},
+	}}
+	if r.Arity() != 3 {
+		t.Fatalf("expected arity 3, got %d", r.Arity())
+	}
+}
+
+func TestLookup_Found(t *testing.T) {
+	// "Node" is registered in init()
+	def, ok := Lookup("Node")
+	if !ok {
+		t.Fatal("expected Node to be in registry")
+	}
+	if def.Name != "Node" {
+		t.Fatalf("expected name Node, got %q", def.Name)
+	}
+}
+
+func TestLookup_NotFound(t *testing.T) {
+	_, ok := Lookup("NoSuchRelation")
+	if ok {
+		t.Fatal("expected not found")
+	}
+}
+
+func TestRegisterRelation_DuplicatePanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on duplicate registration")
+		}
+	}()
+	// "File" is already registered
+	RegisterRelation(RelationDef{Name: "File", Version: 1, Columns: []ColumnDef{{Name: "x", Type: TypeInt32}}})
+}

--- a/extract/schema/relations.go
+++ b/extract/schema/relations.go
@@ -1,1 +1,179 @@
 package schema
+
+func init() {
+	// Structural
+	RegisterRelation(RelationDef{Name: "File", Version: 1, Columns: []ColumnDef{
+		{Name: "id", Type: TypeEntityRef},
+		{Name: "path", Type: TypeString},
+		{Name: "contentHash", Type: TypeString},
+	}})
+	RegisterRelation(RelationDef{Name: "Node", Version: 1, Columns: []ColumnDef{
+		{Name: "id", Type: TypeEntityRef},
+		{Name: "file", Type: TypeEntityRef},
+		{Name: "kind", Type: TypeString},
+		{Name: "startLine", Type: TypeInt32},
+		{Name: "startCol", Type: TypeInt32},
+		{Name: "endLine", Type: TypeInt32},
+		{Name: "endCol", Type: TypeInt32},
+	}})
+	RegisterRelation(RelationDef{Name: "Contains", Version: 1, Columns: []ColumnDef{
+		{Name: "parent", Type: TypeEntityRef},
+		{Name: "child", Type: TypeEntityRef},
+	}})
+	// Symbols
+	RegisterRelation(RelationDef{Name: "Symbol", Version: 1, Columns: []ColumnDef{
+		{Name: "id", Type: TypeEntityRef},
+		{Name: "name", Type: TypeString},
+		{Name: "declNode", Type: TypeEntityRef},
+		{Name: "declFile", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "FunctionSymbol", Version: 1, Columns: []ColumnDef{
+		{Name: "sym", Type: TypeEntityRef},
+		{Name: "fn", Type: TypeEntityRef},
+	}})
+	// Functions
+	RegisterRelation(RelationDef{Name: "Function", Version: 1, Columns: []ColumnDef{
+		{Name: "id", Type: TypeEntityRef},
+		{Name: "name", Type: TypeString},
+		{Name: "isArrow", Type: TypeInt32},
+		{Name: "isAsync", Type: TypeInt32},
+		{Name: "isGenerator", Type: TypeInt32},
+		{Name: "isMethod", Type: TypeInt32},
+	}})
+	RegisterRelation(RelationDef{Name: "Parameter", Version: 1, Columns: []ColumnDef{
+		{Name: "fn", Type: TypeEntityRef},
+		{Name: "idx", Type: TypeInt32},
+		{Name: "name", Type: TypeString},
+		{Name: "paramNode", Type: TypeEntityRef},
+		{Name: "sym", Type: TypeEntityRef},
+		{Name: "typeText", Type: TypeString},
+	}})
+	RegisterRelation(RelationDef{Name: "ParameterRest", Version: 1, Columns: []ColumnDef{
+		{Name: "fn", Type: TypeEntityRef},
+		{Name: "idx", Type: TypeInt32},
+	}})
+	RegisterRelation(RelationDef{Name: "ParameterOptional", Version: 1, Columns: []ColumnDef{
+		{Name: "fn", Type: TypeEntityRef},
+		{Name: "idx", Type: TypeInt32},
+	}})
+	RegisterRelation(RelationDef{Name: "ParamIsFunctionType", Version: 1, Columns: []ColumnDef{
+		{Name: "fn", Type: TypeEntityRef},
+		{Name: "idx", Type: TypeInt32},
+	}})
+	// Calls
+	RegisterRelation(RelationDef{Name: "Call", Version: 1, Columns: []ColumnDef{
+		{Name: "id", Type: TypeEntityRef},
+		{Name: "calleeNode", Type: TypeEntityRef},
+		{Name: "arity", Type: TypeInt32},
+	}})
+	RegisterRelation(RelationDef{Name: "CallArg", Version: 1, Columns: []ColumnDef{
+		{Name: "call", Type: TypeEntityRef},
+		{Name: "idx", Type: TypeInt32},
+		{Name: "argNode", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "CallArgSpread", Version: 1, Columns: []ColumnDef{
+		{Name: "call", Type: TypeEntityRef},
+		{Name: "idx", Type: TypeInt32},
+	}})
+	RegisterRelation(RelationDef{Name: "CallCalleeSym", Version: 1, Columns: []ColumnDef{
+		{Name: "call", Type: TypeEntityRef},
+		{Name: "sym", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "CallResultSym", Version: 1, Columns: []ColumnDef{
+		{Name: "call", Type: TypeEntityRef},
+		{Name: "sym", Type: TypeEntityRef},
+	}})
+	// Variables
+	RegisterRelation(RelationDef{Name: "VarDecl", Version: 1, Columns: []ColumnDef{
+		{Name: "id", Type: TypeEntityRef},
+		{Name: "sym", Type: TypeEntityRef},
+		{Name: "initExpr", Type: TypeEntityRef},
+		{Name: "isConst", Type: TypeInt32},
+	}})
+	RegisterRelation(RelationDef{Name: "Assign", Version: 1, Columns: []ColumnDef{
+		{Name: "lhsNode", Type: TypeEntityRef},
+		{Name: "rhsExpr", Type: TypeEntityRef},
+		{Name: "lhsSym", Type: TypeEntityRef},
+	}})
+	// Expressions
+	RegisterRelation(RelationDef{Name: "ExprMayRef", Version: 1, Columns: []ColumnDef{
+		{Name: "expr", Type: TypeEntityRef},
+		{Name: "sym", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "ExprIsCall", Version: 1, Columns: []ColumnDef{
+		{Name: "expr", Type: TypeEntityRef},
+		{Name: "call", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "FieldRead", Version: 1, Columns: []ColumnDef{
+		{Name: "expr", Type: TypeEntityRef},
+		{Name: "baseSym", Type: TypeEntityRef},
+		{Name: "fieldName", Type: TypeString},
+	}})
+	RegisterRelation(RelationDef{Name: "FieldWrite", Version: 1, Columns: []ColumnDef{
+		{Name: "assignNode", Type: TypeEntityRef},
+		{Name: "baseSym", Type: TypeEntityRef},
+		{Name: "fieldName", Type: TypeString},
+		{Name: "rhsExpr", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "Await", Version: 1, Columns: []ColumnDef{
+		{Name: "expr", Type: TypeEntityRef},
+		{Name: "innerExpr", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "Cast", Version: 1, Columns: []ColumnDef{
+		{Name: "expr", Type: TypeEntityRef},
+		{Name: "innerExpr", Type: TypeEntityRef},
+	}})
+	// Destructuring
+	RegisterRelation(RelationDef{Name: "DestructureField", Version: 1, Columns: []ColumnDef{
+		{Name: "parent", Type: TypeEntityRef},
+		{Name: "sourceField", Type: TypeString},
+		{Name: "bindName", Type: TypeString},
+		{Name: "bindSym", Type: TypeEntityRef},
+		{Name: "idx", Type: TypeInt32},
+	}})
+	RegisterRelation(RelationDef{Name: "ArrayDestructure", Version: 1, Columns: []ColumnDef{
+		{Name: "parent", Type: TypeEntityRef},
+		{Name: "idx", Type: TypeInt32},
+		{Name: "bindSym", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "DestructureRest", Version: 1, Columns: []ColumnDef{
+		{Name: "parent", Type: TypeEntityRef},
+		{Name: "bindSym", Type: TypeEntityRef},
+	}})
+	// Modules
+	RegisterRelation(RelationDef{Name: "ImportBinding", Version: 1, Columns: []ColumnDef{
+		{Name: "localSym", Type: TypeEntityRef},
+		{Name: "moduleSpec", Type: TypeString},
+		{Name: "importedName", Type: TypeString},
+	}})
+	RegisterRelation(RelationDef{Name: "ExportBinding", Version: 1, Columns: []ColumnDef{
+		{Name: "exportedName", Type: TypeString},
+		{Name: "localSym", Type: TypeEntityRef},
+		{Name: "file", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "TypeFromLib", Version: 1, Columns: []ColumnDef{
+		{Name: "sym", Type: TypeEntityRef},
+		{Name: "libName", Type: TypeString},
+	}})
+	// JSX
+	RegisterRelation(RelationDef{Name: "JsxElement", Version: 1, Columns: []ColumnDef{
+		{Name: "id", Type: TypeEntityRef},
+		{Name: "tagNode", Type: TypeEntityRef},
+		{Name: "tagSym", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "JsxAttribute", Version: 1, Columns: []ColumnDef{
+		{Name: "element", Type: TypeEntityRef},
+		{Name: "name", Type: TypeString},
+		{Name: "valueExpr", Type: TypeEntityRef},
+	}})
+	// Diagnostics
+	RegisterRelation(RelationDef{Name: "ExtractError", Version: 1, Columns: []ColumnDef{
+		{Name: "file", Type: TypeEntityRef},
+		{Name: "nodeStartLine", Type: TypeInt32},
+		{Name: "phase", Type: TypeString},
+		{Name: "message", Type: TypeString},
+	}})
+	RegisterRelation(RelationDef{Name: "SchemaVersion", Version: 1, Columns: []ColumnDef{
+		{Name: "version", Type: TypeInt32},
+	}})
+}

--- a/extract/schema/relations_test.go
+++ b/extract/schema/relations_test.go
@@ -1,0 +1,72 @@
+package schema
+
+import (
+	"testing"
+)
+
+func TestAllRelationsRegistered(t *testing.T) {
+	expected := []string{
+		"File", "Node", "Contains",
+		"Symbol", "FunctionSymbol",
+		"Function", "Parameter", "ParameterRest", "ParameterOptional", "ParamIsFunctionType",
+		"Call", "CallArg", "CallArgSpread", "CallCalleeSym", "CallResultSym",
+		"VarDecl", "Assign",
+		"ExprMayRef", "ExprIsCall", "FieldRead", "FieldWrite", "Await", "Cast",
+		"DestructureField", "ArrayDestructure", "DestructureRest",
+		"ImportBinding", "ExportBinding", "TypeFromLib",
+		"JsxElement", "JsxAttribute",
+		"ExtractError", "SchemaVersion",
+	}
+	for _, name := range expected {
+		def, ok := Lookup(name)
+		if !ok {
+			t.Errorf("relation %q not found in registry", name)
+			continue
+		}
+		if err := def.Validate(); err != nil {
+			t.Errorf("relation %q fails validation: %v", name, err)
+		}
+	}
+}
+
+func TestRelationCount(t *testing.T) {
+	if len(Registry) != 33 {
+		t.Fatalf("expected 33 relations in registry, got %d", len(Registry))
+	}
+}
+
+func TestNodeRelationColumns(t *testing.T) {
+	def, ok := Lookup("Node")
+	if !ok {
+		t.Fatal("Node not found")
+	}
+	if def.Arity() != 7 {
+		t.Fatalf("expected 7 columns, got %d", def.Arity())
+	}
+	// Check column types
+	expectedTypes := []ColumnType{
+		TypeEntityRef, TypeEntityRef, TypeString,
+		TypeInt32, TypeInt32, TypeInt32, TypeInt32,
+	}
+	for i, col := range def.Columns {
+		if col.Type != expectedTypes[i] {
+			t.Errorf("column %d (%q): expected type %d, got %d", i, col.Name, expectedTypes[i], col.Type)
+		}
+	}
+}
+
+func TestFileRelationColumns(t *testing.T) {
+	def, ok := Lookup("File")
+	if !ok {
+		t.Fatal("File not found")
+	}
+	if def.Arity() != 3 {
+		t.Fatalf("expected 3 columns, got %d", def.Arity())
+	}
+	expectedNames := []string{"id", "path", "contentHash"}
+	for i, col := range def.Columns {
+		if col.Name != expectedNames[i] {
+			t.Errorf("column %d: expected name %q, got %q", i, expectedNames[i], col.Name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `extract/schema`: ColumnType, ColumnDef, RelationDef, Registry, RegisterRelation, Lookup, Validate
- `extract/schema/relations`: all 33 fact relations registered (structural, symbols, functions, calls, variables, expressions, destructuring, modules, JSX, diagnostics)
- `extract/db`: DB, Relation, NewDB, AddTuple, Encode (writer), ReadDB (reader) with forward-compat for unknown relations
- Full round-trip tests, schema validation tests, error path tests (30 tests total)

## Test plan
- [x] `go test ./extract/...` passes (30/30)
- [x] `go vet ./...` clean
- [x] Round-trip: write DB, read DB, verify identical tuples
- [x] Forward compat: unknown relations skipped without error
- [x] Schema version mismatch: returns error
- [x] Wrong arity/type: AddTuple returns error
- [x] Truncated header: returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)