### PR TITLE
Phase 1b: QL Lexer and Parser

### DIFF
--- a/ql/ast/ast.go
+++ b/ql/ast/ast.go
@@ -1,2 +1,287 @@
 // Package ast defines the QL abstract syntax tree produced by the parser.
 package ast
+
+// Span represents a source location range.
+type Span struct {
+	File      string
+	StartLine int
+	StartCol  int
+	EndLine   int
+	EndCol    int
+}
+
+// Module is the top-level AST node for a .ql or .qll file.
+type Module struct {
+	Imports    []ImportDecl
+	Classes    []ClassDecl
+	Predicates []PredicateDecl
+	Select     *SelectClause // nil for library modules (.qll)
+	Span       Span
+}
+
+// ImportDecl represents `import <module> as <alias>` or `import <module>`.
+type ImportDecl struct {
+	Path  string // e.g. "javascript" or "DataFlow::PathGraph"
+	Alias string // optional alias; empty if no `as` clause
+	Span  Span
+}
+
+// ClassDecl represents a QL class declaration.
+type ClassDecl struct {
+	Name       string
+	SuperTypes []TypeRef    // types listed in `extends` clause
+	CharPred   *Formula     // characteristic predicate body (the Foo() { ... } block)
+	Members    []MemberDecl
+	Span       Span
+}
+
+// MemberDecl is a method or field declaration inside a class.
+type MemberDecl struct {
+	Name       string
+	ReturnType *TypeRef  // nil for predicates (no return type)
+	Params     []ParamDecl
+	Body       *Formula
+	Override   bool // has `override` modifier
+	Span       Span
+}
+
+// PredicateDecl is a top-level predicate definition.
+type PredicateDecl struct {
+	Name       string
+	ReturnType *TypeRef // nil for predicates
+	Params     []ParamDecl
+	Body       *Formula
+	Span       Span
+}
+
+// ParamDecl is a parameter in a predicate or method.
+type ParamDecl struct {
+	Type TypeRef
+	Name string
+	Span Span
+}
+
+// TypeRef is a reference to a type (possibly qualified).
+type TypeRef struct {
+	Path []string // e.g. ["DataFlow", "Node"] for DataFlow::Node
+	Span Span
+}
+
+// String returns the qualified name.
+func (t TypeRef) String() string {
+	s := ""
+	for i, p := range t.Path {
+		if i > 0 {
+			s += "::"
+		}
+		s += p
+	}
+	return s
+}
+
+// SelectClause is the select statement in a .ql query.
+type SelectClause struct {
+	Decls  []VarDecl // `from` declarations
+	Where  *Formula  // `where` clause (may be nil)
+	Select []Expr    // `select` expressions
+	Labels []string  // optional string labels after select expressions
+	Span   Span
+}
+
+// VarDecl is a typed variable declaration (used in `from` and `exists`).
+type VarDecl struct {
+	Type TypeRef
+	Name string
+	Span Span
+}
+
+// --- Formulas ---
+
+// Formula is the interface for all QL formula nodes.
+type Formula interface {
+	formulaNode()
+	GetSpan() Span
+}
+
+// BaseFormula provides a shared Span field for formula nodes.
+type BaseFormula struct{ Span Span }
+
+// GetSpan returns the source span of the formula.
+func (b BaseFormula) GetSpan() Span { return b.Span }
+
+// Conjunction: f1 and f2
+type Conjunction struct {
+	BaseFormula
+	Left, Right Formula
+}
+
+func (Conjunction) formulaNode() {}
+
+// Disjunction: f1 or f2
+type Disjunction struct {
+	BaseFormula
+	Left, Right Formula
+}
+
+func (Disjunction) formulaNode() {}
+
+// Negation: not f
+type Negation struct {
+	BaseFormula
+	Formula Formula
+}
+
+func (Negation) formulaNode() {}
+
+// Comparison: expr op expr
+type Comparison struct {
+	BaseFormula
+	Left, Right Expr
+	Op          string // "=", "!=", "<", "<=", ">", ">="
+}
+
+func (Comparison) formulaNode() {}
+
+// PredicateCall: pred(args...) or this.method(args...)
+type PredicateCall struct {
+	BaseFormula
+	Recv Expr   // nil for non-method calls
+	Name string
+	Args []Expr
+}
+
+func (PredicateCall) formulaNode() {}
+
+// InstanceOf: expr instanceof Type
+type InstanceOf struct {
+	BaseFormula
+	Expr Expr
+	Type TypeRef
+}
+
+func (InstanceOf) formulaNode() {}
+
+// Exists: exists(decls | formula) or exists(decls | guard | formula)
+type Exists struct {
+	BaseFormula
+	Decls []VarDecl
+	Guard Formula // optional; nil if not present
+	Body  Formula
+}
+
+func (Exists) formulaNode() {}
+
+// Forall: forall(decls | guard | body)
+type Forall struct {
+	BaseFormula
+	Decls []VarDecl
+	Guard Formula
+	Body  Formula
+}
+
+func (Forall) formulaNode() {}
+
+// None: none() — always false
+type None struct{ BaseFormula }
+
+func (None) formulaNode() {}
+
+// Any: any() — always true
+type Any struct{ BaseFormula }
+
+func (Any) formulaNode() {}
+
+// --- Expressions ---
+
+// Expr is the interface for all QL expression nodes.
+type Expr interface {
+	exprNode()
+	GetSpan() Span
+}
+
+// BaseExpr provides a shared Span field for expression nodes.
+type BaseExpr struct{ Span Span }
+
+// GetSpan returns the source span of the expression.
+func (b BaseExpr) GetSpan() Span { return b.Span }
+
+// Variable: a named variable reference (including `this` and `result`)
+type Variable struct {
+	BaseExpr
+	Name string
+}
+
+func (Variable) exprNode() {}
+
+// IntLiteral: 42
+type IntLiteral struct {
+	BaseExpr
+	Value int64
+}
+
+func (IntLiteral) exprNode() {}
+
+// StringLiteral: "foo"
+type StringLiteral struct {
+	BaseExpr
+	Value string
+}
+
+func (StringLiteral) exprNode() {}
+
+// BoolLiteral: true, false
+type BoolLiteral struct {
+	BaseExpr
+	Value bool
+}
+
+func (BoolLiteral) exprNode() {}
+
+// FieldAccess: expr.field
+type FieldAccess struct {
+	BaseExpr
+	Recv  Expr
+	Field string
+}
+
+func (FieldAccess) exprNode() {}
+
+// MethodCall: expr.method(args...) — also used for chained method calls
+type MethodCall struct {
+	BaseExpr
+	Recv   Expr
+	Method string
+	Args   []Expr
+}
+
+func (MethodCall) exprNode() {}
+
+// Cast: expr.(Type)
+type Cast struct {
+	BaseExpr
+	Expr Expr
+	Type TypeRef
+}
+
+func (Cast) exprNode() {}
+
+// Aggregate: count(Type v | formula) etc.
+type Aggregate struct {
+	BaseExpr
+	Op    string // "count", "min", "max", "sum", "avg"
+	Decls []VarDecl
+	Guard Formula // optional
+	Body  Formula
+	Expr  Expr    // the expression to aggregate over (for min/max/sum/avg)
+}
+
+func (Aggregate) exprNode() {}
+
+// BinaryExpr: arithmetic
+type BinaryExpr struct {
+	BaseExpr
+	Left, Right Expr
+	Op          string // "+", "-", "*", "/", "%"
+}
+
+func (BinaryExpr) exprNode() {}

--- a/ql/ast/ast.go
+++ b/ql/ast/ast.go
@@ -29,8 +29,8 @@ type ImportDecl struct {
 // ClassDecl represents a QL class declaration.
 type ClassDecl struct {
 	Name       string
-	SuperTypes []TypeRef    // types listed in `extends` clause
-	CharPred   *Formula     // characteristic predicate body (the Foo() { ... } block)
+	SuperTypes []TypeRef // types listed in `extends` clause
+	CharPred   *Formula  // characteristic predicate body (the Foo() { ... } block)
 	Members    []MemberDecl
 	Span       Span
 }
@@ -38,7 +38,7 @@ type ClassDecl struct {
 // MemberDecl is a method or field declaration inside a class.
 type MemberDecl struct {
 	Name       string
-	ReturnType *TypeRef  // nil for predicates (no return type)
+	ReturnType *TypeRef // nil for predicates (no return type)
 	Params     []ParamDecl
 	Body       *Formula
 	Override   bool // has `override` modifier
@@ -145,7 +145,7 @@ func (Comparison) formulaNode() {}
 // PredicateCall: pred(args...) or this.method(args...)
 type PredicateCall struct {
 	BaseFormula
-	Recv Expr   // nil for non-method calls
+	Recv Expr // nil for non-method calls
 	Name string
 	Args []Expr
 }
@@ -272,7 +272,7 @@ type Aggregate struct {
 	Decls []VarDecl
 	Guard Formula // optional
 	Body  Formula
-	Expr  Expr    // the expression to aggregate over (for min/max/sum/avg)
+	Expr  Expr // the expression to aggregate over (for min/max/sum/avg)
 }
 
 func (Aggregate) exprNode() {}

--- a/ql/parse/lexer.go
+++ b/ql/parse/lexer.go
@@ -10,7 +10,7 @@ type TokenType int
 
 const (
 	// Literals
-	TokIdent  TokenType = iota
+	TokIdent TokenType = iota
 	TokInt
 	TokString
 
@@ -117,18 +117,12 @@ type Lexer struct {
 	line int
 	col  int
 	file string
+	err  *Token // pending error token (e.g. unterminated block comment)
 }
 
 // NewLexer creates a Lexer for the given source.
 func NewLexer(src, file string) *Lexer {
 	return &Lexer{src: []rune(src), pos: 0, line: 1, col: 1, file: file}
-}
-
-func (l *Lexer) peek() rune {
-	if l.pos >= len(l.src) {
-		return 0
-	}
-	return l.src[l.pos]
 }
 
 func (l *Lexer) advance() rune {
@@ -185,9 +179,15 @@ func (l *Lexer) skipWhitespaceAndComments() {
 				continue
 			}
 			if l.src[l.pos+1] == '*' {
+				errLine := l.line
+				errCol := l.col
 				l.advance()
 				l.advance()
-				l.skipBlockComment()
+				if !l.skipBlockComment() {
+					tok := Token{Type: TokError, Lit: "unterminated block comment", Line: errLine, Col: errCol}
+					l.err = &tok
+					return
+				}
 				continue
 			}
 		}
@@ -198,6 +198,12 @@ func (l *Lexer) skipWhitespaceAndComments() {
 // Next returns the next token.
 func (l *Lexer) Next() Token {
 	l.skipWhitespaceAndComments()
+
+	if l.err != nil {
+		tok := *l.err
+		l.err = nil
+		return tok
+	}
 
 	if l.pos >= len(l.src) {
 		return Token{Type: TokEOF, Lit: "", Line: l.line, Col: l.col}

--- a/ql/parse/lexer.go
+++ b/ql/parse/lexer.go
@@ -1,2 +1,325 @@
 // Package parse implements the QL lexer and recursive descent parser.
 package parse
+
+import (
+	"unicode"
+)
+
+// TokenType identifies a QL token.
+type TokenType int
+
+const (
+	// Literals
+	TokIdent  TokenType = iota
+	TokInt
+	TokString
+
+	// Punctuation
+	TokLParen // (
+	TokRParen // )
+	TokLBrace // {
+	TokRBrace // }
+	TokComma  // ,
+	TokSemi   // ;
+	TokDot    // .
+	TokPipe   // |
+	TokAt     // @
+	TokColCol // ::
+
+	// Operators
+	TokEq    // =
+	TokNeq   // !=
+	TokLt    // <
+	TokLte   // <=
+	TokGt    // >
+	TokGte   // >=
+	TokPlus  // +
+	TokMinus // -
+	TokStar  // *
+	TokSlash // /
+	TokPct   // %
+
+	// Keywords
+	TokKwImport
+	TokKwAs
+	TokKwClass
+	TokKwExtends
+	TokKwPredicate
+	TokKwFrom
+	TokKwWhere
+	TokKwSelect
+	TokKwExists
+	TokKwForall
+	TokKwNot
+	TokKwAnd
+	TokKwOr
+	TokKwInstanceof
+	TokKwResult
+	TokKwThis
+	TokKwNone
+	TokKwAny
+	TokKwTrue
+	TokKwFalse
+	TokKwOverride
+	TokKwAbstract
+	TokKwCount
+	TokKwMin
+	TokKwMax
+	TokKwSum
+	TokKwAvg
+
+	TokEOF
+	TokError // malformed input
+)
+
+var keywords = map[string]TokenType{
+	"import":     TokKwImport,
+	"as":         TokKwAs,
+	"class":      TokKwClass,
+	"extends":    TokKwExtends,
+	"predicate":  TokKwPredicate,
+	"from":       TokKwFrom,
+	"where":      TokKwWhere,
+	"select":     TokKwSelect,
+	"exists":     TokKwExists,
+	"forall":     TokKwForall,
+	"not":        TokKwNot,
+	"and":        TokKwAnd,
+	"or":         TokKwOr,
+	"instanceof": TokKwInstanceof,
+	"result":     TokKwResult,
+	"this":       TokKwThis,
+	"none":       TokKwNone,
+	"any":        TokKwAny,
+	"true":       TokKwTrue,
+	"false":      TokKwFalse,
+	"override":   TokKwOverride,
+	"abstract":   TokKwAbstract,
+	"count":      TokKwCount,
+	"min":        TokKwMin,
+	"max":        TokKwMax,
+	"sum":        TokKwSum,
+	"avg":        TokKwAvg,
+}
+
+// Token is a single QL token.
+type Token struct {
+	Type TokenType
+	Lit  string // the literal text
+	Line int
+	Col  int
+}
+
+// Lexer tokenises QL source.
+type Lexer struct {
+	src  []rune
+	pos  int
+	line int
+	col  int
+	file string
+}
+
+// NewLexer creates a Lexer for the given source.
+func NewLexer(src, file string) *Lexer {
+	return &Lexer{src: []rune(src), pos: 0, line: 1, col: 1, file: file}
+}
+
+func (l *Lexer) peek() rune {
+	if l.pos >= len(l.src) {
+		return 0
+	}
+	return l.src[l.pos]
+}
+
+func (l *Lexer) advance() rune {
+	if l.pos >= len(l.src) {
+		return 0
+	}
+	ch := l.src[l.pos]
+	l.pos++
+	if ch == '\n' {
+		l.line++
+		l.col = 1
+	} else {
+		l.col++
+	}
+	return ch
+}
+
+func (l *Lexer) skipWhitespace() {
+	for l.pos < len(l.src) && unicode.IsSpace(l.src[l.pos]) {
+		l.advance()
+	}
+}
+
+func (l *Lexer) skipLineComment() {
+	for l.pos < len(l.src) && l.src[l.pos] != '\n' {
+		l.advance()
+	}
+}
+
+func (l *Lexer) skipBlockComment() bool {
+	// already consumed /*
+	for l.pos < len(l.src) {
+		if l.src[l.pos] == '*' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '/' {
+			l.advance() // *
+			l.advance() // /
+			return true
+		}
+		l.advance()
+	}
+	return false // unterminated
+}
+
+func (l *Lexer) skipWhitespaceAndComments() {
+	for {
+		l.skipWhitespace()
+		if l.pos >= len(l.src) {
+			return
+		}
+		if l.src[l.pos] == '/' && l.pos+1 < len(l.src) {
+			if l.src[l.pos+1] == '/' {
+				l.advance()
+				l.advance()
+				l.skipLineComment()
+				continue
+			}
+			if l.src[l.pos+1] == '*' {
+				l.advance()
+				l.advance()
+				l.skipBlockComment()
+				continue
+			}
+		}
+		return
+	}
+}
+
+// Next returns the next token.
+func (l *Lexer) Next() Token {
+	l.skipWhitespaceAndComments()
+
+	if l.pos >= len(l.src) {
+		return Token{Type: TokEOF, Lit: "", Line: l.line, Col: l.col}
+	}
+
+	startLine := l.line
+	startCol := l.col
+	ch := l.src[l.pos]
+
+	// Identifier or keyword
+	if ch == '_' || unicode.IsLetter(ch) {
+		start := l.pos
+		for l.pos < len(l.src) && (l.src[l.pos] == '_' || unicode.IsLetter(l.src[l.pos]) || unicode.IsDigit(l.src[l.pos])) {
+			l.advance()
+		}
+		lit := string(l.src[start:l.pos])
+		typ := TokIdent
+		if kw, ok := keywords[lit]; ok {
+			typ = kw
+		}
+		return Token{Type: typ, Lit: lit, Line: startLine, Col: startCol}
+	}
+
+	// Integer literal
+	if unicode.IsDigit(ch) {
+		start := l.pos
+		for l.pos < len(l.src) && unicode.IsDigit(l.src[l.pos]) {
+			l.advance()
+		}
+		return Token{Type: TokInt, Lit: string(l.src[start:l.pos]), Line: startLine, Col: startCol}
+	}
+
+	// String literal
+	if ch == '"' {
+		l.advance() // opening "
+		var buf []rune
+		for l.pos < len(l.src) && l.src[l.pos] != '"' {
+			if l.src[l.pos] == '\\' && l.pos+1 < len(l.src) {
+				l.advance() // backslash
+				esc := l.advance()
+				switch esc {
+				case 'n':
+					buf = append(buf, '\n')
+				case 't':
+					buf = append(buf, '\t')
+				case '\\':
+					buf = append(buf, '\\')
+				case '"':
+					buf = append(buf, '"')
+				default:
+					buf = append(buf, '\\', esc)
+				}
+			} else {
+				buf = append(buf, l.advance())
+			}
+		}
+		if l.pos >= len(l.src) {
+			return Token{Type: TokError, Lit: "unterminated string", Line: startLine, Col: startCol}
+		}
+		l.advance() // closing "
+		return Token{Type: TokString, Lit: string(buf), Line: startLine, Col: startCol}
+	}
+
+	// Single/multi-character operators and punctuation
+	l.advance()
+
+	switch ch {
+	case '(':
+		return Token{Type: TokLParen, Lit: "(", Line: startLine, Col: startCol}
+	case ')':
+		return Token{Type: TokRParen, Lit: ")", Line: startLine, Col: startCol}
+	case '{':
+		return Token{Type: TokLBrace, Lit: "{", Line: startLine, Col: startCol}
+	case '}':
+		return Token{Type: TokRBrace, Lit: "}", Line: startLine, Col: startCol}
+	case ',':
+		return Token{Type: TokComma, Lit: ",", Line: startLine, Col: startCol}
+	case ';':
+		return Token{Type: TokSemi, Lit: ";", Line: startLine, Col: startCol}
+	case '.':
+		return Token{Type: TokDot, Lit: ".", Line: startLine, Col: startCol}
+	case '|':
+		return Token{Type: TokPipe, Lit: "|", Line: startLine, Col: startCol}
+	case '@':
+		return Token{Type: TokAt, Lit: "@", Line: startLine, Col: startCol}
+	case '+':
+		return Token{Type: TokPlus, Lit: "+", Line: startLine, Col: startCol}
+	case '-':
+		return Token{Type: TokMinus, Lit: "-", Line: startLine, Col: startCol}
+	case '*':
+		return Token{Type: TokStar, Lit: "*", Line: startLine, Col: startCol}
+	case '%':
+		return Token{Type: TokPct, Lit: "%", Line: startLine, Col: startCol}
+	case '/':
+		return Token{Type: TokSlash, Lit: "/", Line: startLine, Col: startCol}
+	case ':':
+		if l.pos < len(l.src) && l.src[l.pos] == ':' {
+			l.advance()
+			return Token{Type: TokColCol, Lit: "::", Line: startLine, Col: startCol}
+		}
+		return Token{Type: TokError, Lit: "unexpected ':'", Line: startLine, Col: startCol}
+	case '=':
+		return Token{Type: TokEq, Lit: "=", Line: startLine, Col: startCol}
+	case '!':
+		if l.pos < len(l.src) && l.src[l.pos] == '=' {
+			l.advance()
+			return Token{Type: TokNeq, Lit: "!=", Line: startLine, Col: startCol}
+		}
+		return Token{Type: TokError, Lit: "unexpected '!'", Line: startLine, Col: startCol}
+	case '<':
+		if l.pos < len(l.src) && l.src[l.pos] == '=' {
+			l.advance()
+			return Token{Type: TokLte, Lit: "<=", Line: startLine, Col: startCol}
+		}
+		return Token{Type: TokLt, Lit: "<", Line: startLine, Col: startCol}
+	case '>':
+		if l.pos < len(l.src) && l.src[l.pos] == '=' {
+			l.advance()
+			return Token{Type: TokGte, Lit: ">=", Line: startLine, Col: startCol}
+		}
+		return Token{Type: TokGt, Lit: ">", Line: startLine, Col: startCol}
+	}
+
+	return Token{Type: TokError, Lit: "unexpected character: " + string(ch), Line: startLine, Col: startCol}
+}

--- a/ql/parse/parse_test.go
+++ b/ql/parse/parse_test.go
@@ -134,6 +134,20 @@ func TestLexerUnterminatedString(t *testing.T) {
 	}
 }
 
+func TestLex_UnterminatedBlockComment(t *testing.T) {
+	l := parse.NewLexer("foo /* unterminated", "test.ql")
+	// First token should be the identifier "foo"
+	tok := l.Next()
+	if tok.Type != parse.TokIdent || tok.Lit != "foo" {
+		t.Errorf("expected ident 'foo', got type=%d lit=%q", tok.Type, tok.Lit)
+	}
+	// Second token must be TokError, not TokEOF
+	tok = l.Next()
+	if tok.Type != parse.TokError {
+		t.Errorf("expected TokError for unterminated block comment, got type=%d lit=%q", tok.Type, tok.Lit)
+	}
+}
+
 // --- Parser tests ---
 
 func TestEmptyModule(t *testing.T) {
@@ -736,9 +750,9 @@ func TestErrorParseErrorLocation(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	pe, ok := err.(*parse.ParseError)
+	pe, ok := err.(*parse.Error)
 	if !ok {
-		t.Fatalf("expected *ParseError, got %T", err)
+		t.Fatalf("expected *parse.Error, got %T", err)
 	}
 	if pe.File != "test.ql" {
 		t.Errorf("expected file 'test.ql', got %q", pe.File)

--- a/ql/parse/parse_test.go
+++ b/ql/parse/parse_test.go
@@ -1,6 +1,785 @@
 package parse_test
 
-import "testing"
+import (
+	"testing"
 
-// TestPlaceholder is a placeholder until Phase 1b implements the parser.
-func TestPlaceholder(t *testing.T) {}
+	"github.com/Gjdoalfnrxu/tsq/ql/ast"
+	"github.com/Gjdoalfnrxu/tsq/ql/parse"
+)
+
+func mustParse(t *testing.T, src string) *ast.Module {
+	t.Helper()
+	p := parse.NewParser(src, "test.ql")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	return mod
+}
+
+func mustFail(t *testing.T, src string) {
+	t.Helper()
+	p := parse.NewParser(src, "test.ql")
+	_, err := p.Parse()
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+}
+
+// --- Lexer tests ---
+
+func TestLexerBasicTokens(t *testing.T) {
+	l := parse.NewLexer("( ) { } , ; . | @ :: = != < <= > >= + - * / %", "test.ql")
+	expected := []parse.TokenType{
+		parse.TokLParen, parse.TokRParen, parse.TokLBrace, parse.TokRBrace,
+		parse.TokComma, parse.TokSemi, parse.TokDot, parse.TokPipe, parse.TokAt,
+		parse.TokColCol, parse.TokEq, parse.TokNeq, parse.TokLt, parse.TokLte,
+		parse.TokGt, parse.TokGte, parse.TokPlus, parse.TokMinus, parse.TokStar,
+		parse.TokSlash, parse.TokPct, parse.TokEOF,
+	}
+	for i, exp := range expected {
+		tok := l.Next()
+		if tok.Type != exp {
+			t.Errorf("token %d: expected type %d, got %d (lit=%q)", i, exp, tok.Type, tok.Lit)
+		}
+	}
+}
+
+func TestLexerKeywords(t *testing.T) {
+	l := parse.NewLexer("import as class extends predicate from where select exists forall not and or instanceof result this none any true false override abstract count min max sum avg", "test.ql")
+	expected := []parse.TokenType{
+		parse.TokKwImport, parse.TokKwAs, parse.TokKwClass, parse.TokKwExtends,
+		parse.TokKwPredicate, parse.TokKwFrom, parse.TokKwWhere, parse.TokKwSelect,
+		parse.TokKwExists, parse.TokKwForall, parse.TokKwNot, parse.TokKwAnd,
+		parse.TokKwOr, parse.TokKwInstanceof, parse.TokKwResult, parse.TokKwThis,
+		parse.TokKwNone, parse.TokKwAny, parse.TokKwTrue, parse.TokKwFalse,
+		parse.TokKwOverride, parse.TokKwAbstract, parse.TokKwCount, parse.TokKwMin,
+		parse.TokKwMax, parse.TokKwSum, parse.TokKwAvg, parse.TokEOF,
+	}
+	for i, exp := range expected {
+		tok := l.Next()
+		if tok.Type != exp {
+			t.Errorf("token %d: expected type %d, got %d (lit=%q)", i, exp, tok.Type, tok.Lit)
+		}
+	}
+}
+
+func TestLexerIdentifiers(t *testing.T) {
+	l := parse.NewLexer("foo _bar baz123", "test.ql")
+	for _, exp := range []string{"foo", "_bar", "baz123"} {
+		tok := l.Next()
+		if tok.Type != parse.TokIdent || tok.Lit != exp {
+			t.Errorf("expected ident %q, got type=%d lit=%q", exp, tok.Type, tok.Lit)
+		}
+	}
+}
+
+func TestLexerIntegers(t *testing.T) {
+	l := parse.NewLexer("0 42 9999", "test.ql")
+	for _, exp := range []string{"0", "42", "9999"} {
+		tok := l.Next()
+		if tok.Type != parse.TokInt || tok.Lit != exp {
+			t.Errorf("expected int %q, got type=%d lit=%q", exp, tok.Type, tok.Lit)
+		}
+	}
+}
+
+func TestLexerStrings(t *testing.T) {
+	l := parse.NewLexer(`"hello" "with \"escape\"" "tab\there" "newline\n"`, "test.ql")
+	expected := []string{"hello", `with "escape"`, "tab\there", "newline\n"}
+	for _, exp := range expected {
+		tok := l.Next()
+		if tok.Type != parse.TokString || tok.Lit != exp {
+			t.Errorf("expected string %q, got type=%d lit=%q", exp, tok.Type, tok.Lit)
+		}
+	}
+}
+
+func TestLexerComments(t *testing.T) {
+	src := `foo // line comment
+bar /* block comment */ baz
+/* multi
+   line */ qux`
+	l := parse.NewLexer(src, "test.ql")
+	expected := []string{"foo", "bar", "baz", "qux"}
+	for _, exp := range expected {
+		tok := l.Next()
+		if tok.Type != parse.TokIdent || tok.Lit != exp {
+			t.Errorf("expected ident %q, got type=%d lit=%q", exp, tok.Type, tok.Lit)
+		}
+	}
+}
+
+func TestLexerLineTracking(t *testing.T) {
+	l := parse.NewLexer("a\nb\nc", "test.ql")
+	tok := l.Next()
+	if tok.Line != 1 {
+		t.Errorf("expected line 1, got %d", tok.Line)
+	}
+	tok = l.Next()
+	if tok.Line != 2 {
+		t.Errorf("expected line 2, got %d", tok.Line)
+	}
+	tok = l.Next()
+	if tok.Line != 3 {
+		t.Errorf("expected line 3, got %d", tok.Line)
+	}
+}
+
+func TestLexerUnterminatedString(t *testing.T) {
+	l := parse.NewLexer(`"unterminated`, "test.ql")
+	tok := l.Next()
+	if tok.Type != parse.TokError {
+		t.Errorf("expected TokError for unterminated string, got type=%d", tok.Type)
+	}
+}
+
+// --- Parser tests ---
+
+func TestEmptyModule(t *testing.T) {
+	mod := mustParse(t, "")
+	if len(mod.Imports) != 0 || len(mod.Classes) != 0 || len(mod.Predicates) != 0 || mod.Select != nil {
+		t.Error("expected empty module")
+	}
+}
+
+func TestImportSimple(t *testing.T) {
+	mod := mustParse(t, "import javascript")
+	if len(mod.Imports) != 1 {
+		t.Fatalf("expected 1 import, got %d", len(mod.Imports))
+	}
+	if mod.Imports[0].Path != "javascript" {
+		t.Errorf("expected path 'javascript', got %q", mod.Imports[0].Path)
+	}
+	if mod.Imports[0].Alias != "" {
+		t.Errorf("expected no alias, got %q", mod.Imports[0].Alias)
+	}
+}
+
+func TestImportQualified(t *testing.T) {
+	mod := mustParse(t, "import DataFlow::PathGraph")
+	if len(mod.Imports) != 1 {
+		t.Fatalf("expected 1 import, got %d", len(mod.Imports))
+	}
+	if mod.Imports[0].Path != "DataFlow::PathGraph" {
+		t.Errorf("expected path 'DataFlow::PathGraph', got %q", mod.Imports[0].Path)
+	}
+}
+
+func TestImportWithAlias(t *testing.T) {
+	mod := mustParse(t, "import javascript as JS")
+	if len(mod.Imports) != 1 {
+		t.Fatalf("expected 1 import, got %d", len(mod.Imports))
+	}
+	if mod.Imports[0].Alias != "JS" {
+		t.Errorf("expected alias 'JS', got %q", mod.Imports[0].Alias)
+	}
+}
+
+func TestSimplePredicate(t *testing.T) {
+	mod := mustParse(t, `predicate foo(int x) { x > 0 }`)
+	if len(mod.Predicates) != 1 {
+		t.Fatalf("expected 1 predicate, got %d", len(mod.Predicates))
+	}
+	pred := mod.Predicates[0]
+	if pred.Name != "foo" {
+		t.Errorf("expected name 'foo', got %q", pred.Name)
+	}
+	if len(pred.Params) != 1 {
+		t.Fatalf("expected 1 param, got %d", len(pred.Params))
+	}
+	if pred.Params[0].Name != "x" {
+		t.Errorf("expected param name 'x', got %q", pred.Params[0].Name)
+	}
+	if pred.Params[0].Type.String() != "int" {
+		t.Errorf("expected param type 'int', got %q", pred.Params[0].Type.String())
+	}
+	if pred.Body == nil {
+		t.Fatal("expected body, got nil")
+	}
+	comp, ok := (*pred.Body).(*ast.Comparison)
+	if !ok {
+		t.Fatalf("expected Comparison, got %T", *pred.Body)
+	}
+	if comp.Op != ">" {
+		t.Errorf("expected op '>', got %q", comp.Op)
+	}
+}
+
+func TestTypedPredicate(t *testing.T) {
+	mod := mustParse(t, `string getName() { result = "hi" }`)
+	if len(mod.Predicates) != 1 {
+		t.Fatalf("expected 1 predicate, got %d", len(mod.Predicates))
+	}
+	pred := mod.Predicates[0]
+	if pred.Name != "getName" {
+		t.Errorf("expected name 'getName', got %q", pred.Name)
+	}
+	if pred.ReturnType == nil {
+		t.Fatal("expected return type, got nil")
+	}
+	if pred.ReturnType.String() != "string" {
+		t.Errorf("expected return type 'string', got %q", pred.ReturnType.String())
+	}
+}
+
+func TestClassWithMethod(t *testing.T) {
+	src := `class Foo extends Bar {
+		Foo() { this.x() }
+		string getX() { result = "hi" }
+	}`
+	mod := mustParse(t, src)
+	if len(mod.Classes) != 1 {
+		t.Fatalf("expected 1 class, got %d", len(mod.Classes))
+	}
+	cls := mod.Classes[0]
+	if cls.Name != "Foo" {
+		t.Errorf("expected name 'Foo', got %q", cls.Name)
+	}
+	if len(cls.SuperTypes) != 1 || cls.SuperTypes[0].String() != "Bar" {
+		t.Errorf("expected extends Bar, got %v", cls.SuperTypes)
+	}
+	if cls.CharPred == nil {
+		t.Error("expected characteristic predicate, got nil")
+	}
+	if len(cls.Members) != 1 {
+		t.Fatalf("expected 1 member, got %d", len(cls.Members))
+	}
+	mem := cls.Members[0]
+	if mem.Name != "getX" {
+		t.Errorf("expected member name 'getX', got %q", mem.Name)
+	}
+	if mem.ReturnType == nil || mem.ReturnType.String() != "string" {
+		t.Errorf("expected return type 'string'")
+	}
+}
+
+func TestClassOverrideMethod(t *testing.T) {
+	src := `class Foo extends Bar {
+		Foo() { this.x() }
+		override string getX() { result = "hi" }
+	}`
+	mod := mustParse(t, src)
+	cls := mod.Classes[0]
+	if len(cls.Members) != 1 {
+		t.Fatalf("expected 1 member, got %d", len(cls.Members))
+	}
+	if !cls.Members[0].Override {
+		t.Error("expected override=true")
+	}
+}
+
+func TestSelectClause(t *testing.T) {
+	mod := mustParse(t, `from int x where x > 0 select x`)
+	if mod.Select == nil {
+		t.Fatal("expected select clause, got nil")
+	}
+	sel := mod.Select
+	if len(sel.Decls) != 1 {
+		t.Fatalf("expected 1 decl, got %d", len(sel.Decls))
+	}
+	if sel.Decls[0].Name != "x" {
+		t.Errorf("expected decl name 'x', got %q", sel.Decls[0].Name)
+	}
+	if sel.Where == nil {
+		t.Error("expected where clause, got nil")
+	}
+	if len(sel.Select) != 1 {
+		t.Fatalf("expected 1 select expr, got %d", len(sel.Select))
+	}
+}
+
+func TestSelectWithLabels(t *testing.T) {
+	mod := mustParse(t, `from int x where x > 0 select x as "value"`)
+	if mod.Select == nil {
+		t.Fatal("expected select clause")
+	}
+	if len(mod.Select.Labels) != 1 || mod.Select.Labels[0] != "value" {
+		t.Errorf("expected label 'value', got %v", mod.Select.Labels)
+	}
+}
+
+func TestSelectOnly(t *testing.T) {
+	mod := mustParse(t, `select 42`)
+	if mod.Select == nil {
+		t.Fatal("expected select clause")
+	}
+	if len(mod.Select.Select) != 1 {
+		t.Fatalf("expected 1 select expr, got %d", len(mod.Select.Select))
+	}
+}
+
+func TestExists(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { exists(int y | y > 0 and y < 10) }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	pc, ok := body.(*ast.Exists)
+	if !ok {
+		t.Fatalf("expected Exists, got %T", body)
+	}
+	if len(pc.Decls) != 1 || pc.Decls[0].Name != "y" {
+		t.Error("expected decl y")
+	}
+	conj, ok := pc.Body.(*ast.Conjunction)
+	if !ok {
+		t.Fatalf("expected Conjunction in body, got %T", pc.Body)
+	}
+	_ = conj
+}
+
+func TestForall(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { forall(int y | y > 0 | y < 100) }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	fa, ok := body.(*ast.Forall)
+	if !ok {
+		t.Fatalf("expected Forall, got %T", body)
+	}
+	if len(fa.Decls) != 1 || fa.Decls[0].Name != "y" {
+		t.Error("expected decl y")
+	}
+	if fa.Guard == nil {
+		t.Error("expected guard, got nil")
+	}
+	if fa.Body == nil {
+		t.Error("expected body, got nil")
+	}
+}
+
+func TestQualifiedType(t *testing.T) {
+	mod := mustParse(t, `predicate foo(DataFlow::Node n) { n.toString() }`)
+	if mod.Predicates[0].Params[0].Type.String() != "DataFlow::Node" {
+		t.Errorf("expected DataFlow::Node, got %q", mod.Predicates[0].Params[0].Type.String())
+	}
+}
+
+func TestMethodChain(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { this.getCallee().getTarget() }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	// The body should be a PredicateCall (converted from MethodCall)
+	pc, ok := body.(*ast.PredicateCall)
+	if !ok {
+		t.Fatalf("expected PredicateCall, got %T", body)
+	}
+	if pc.Name != "getTarget" {
+		t.Errorf("expected method name 'getTarget', got %q", pc.Name)
+	}
+	// The receiver should be a MethodCall for getCallee
+	mc, ok := pc.Recv.(*ast.MethodCall)
+	if !ok {
+		t.Fatalf("expected MethodCall receiver, got %T", pc.Recv)
+	}
+	if mc.Method != "getCallee" {
+		t.Errorf("expected method name 'getCallee', got %q", mc.Method)
+	}
+	// The receiver of getCallee should be "this"
+	v, ok := mc.Recv.(*ast.Variable)
+	if !ok {
+		t.Fatalf("expected Variable, got %T", mc.Recv)
+	}
+	if v.Name != "this" {
+		t.Errorf("expected 'this', got %q", v.Name)
+	}
+}
+
+func TestCast(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { this.(SubType).bar() }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	pc, ok := body.(*ast.PredicateCall)
+	if !ok {
+		t.Fatalf("expected PredicateCall, got %T", body)
+	}
+	if pc.Name != "bar" {
+		t.Errorf("expected method name 'bar', got %q", pc.Name)
+	}
+	cast, ok := pc.Recv.(*ast.Cast)
+	if !ok {
+		t.Fatalf("expected Cast receiver, got %T", pc.Recv)
+	}
+	if cast.Type.String() != "SubType" {
+		t.Errorf("expected cast type 'SubType', got %q", cast.Type.String())
+	}
+}
+
+func TestAggregate(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { count(int x | x > 0) > 5 }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	comp, ok := body.(*ast.Comparison)
+	if !ok {
+		t.Fatalf("expected Comparison, got %T", body)
+	}
+	agg, ok := comp.Left.(*ast.Aggregate)
+	if !ok {
+		t.Fatalf("expected Aggregate, got %T", comp.Left)
+	}
+	if agg.Op != "count" {
+		t.Errorf("expected op 'count', got %q", agg.Op)
+	}
+	if len(agg.Decls) != 1 {
+		t.Fatalf("expected 1 decl, got %d", len(agg.Decls))
+	}
+}
+
+func TestNegation(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { not this.bar() }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	neg, ok := body.(*ast.Negation)
+	if !ok {
+		t.Fatalf("expected Negation, got %T", body)
+	}
+	pc, ok := neg.Formula.(*ast.PredicateCall)
+	if !ok {
+		t.Fatalf("expected PredicateCall inside negation, got %T", neg.Formula)
+	}
+	if pc.Name != "bar" {
+		t.Errorf("expected method name 'bar', got %q", pc.Name)
+	}
+}
+
+func TestConjunctionDisjunctionPrecedence(t *testing.T) {
+	// "a or b and c" should parse as "a or (b and c)"
+	mod := mustParse(t, `predicate foo() { a() or b() and c() }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	disj, ok := body.(*ast.Disjunction)
+	if !ok {
+		t.Fatalf("expected Disjunction at top, got %T", body)
+	}
+	_, ok = disj.Left.(*ast.PredicateCall)
+	if !ok {
+		t.Fatalf("expected PredicateCall on left of or, got %T", disj.Left)
+	}
+	conj, ok := disj.Right.(*ast.Conjunction)
+	if !ok {
+		t.Fatalf("expected Conjunction on right of or, got %T", disj.Right)
+	}
+	_ = conj
+}
+
+func TestNoneFormula(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { none() }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	_, ok := body.(*ast.None)
+	if !ok {
+		t.Fatalf("expected None, got %T", body)
+	}
+}
+
+func TestAnyFormula(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { any() }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	_, ok := body.(*ast.Any)
+	if !ok {
+		t.Fatalf("expected Any, got %T", body)
+	}
+}
+
+func TestInstanceOf(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { x instanceof Foo }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	io, ok := body.(*ast.InstanceOf)
+	if !ok {
+		t.Fatalf("expected InstanceOf, got %T", body)
+	}
+	if io.Type.String() != "Foo" {
+		t.Errorf("expected type Foo, got %q", io.Type.String())
+	}
+}
+
+func TestBoolLiterals(t *testing.T) {
+	mod := mustParse(t, `select true, false`)
+	if mod.Select == nil {
+		t.Fatal("expected select")
+	}
+	if len(mod.Select.Select) != 2 {
+		t.Fatalf("expected 2 select exprs, got %d", len(mod.Select.Select))
+	}
+	b1, ok := mod.Select.Select[0].(*ast.BoolLiteral)
+	if !ok || !b1.Value {
+		t.Error("expected true")
+	}
+	b2, ok := mod.Select.Select[1].(*ast.BoolLiteral)
+	if !ok || b2.Value {
+		t.Error("expected false")
+	}
+}
+
+func TestArithmeticPrecedence(t *testing.T) {
+	// "1 + 2 * 3" should parse as "1 + (2 * 3)"
+	mod := mustParse(t, `select 1 + 2 * 3`)
+	expr := mod.Select.Select[0]
+	add, ok := expr.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected BinaryExpr, got %T", expr)
+	}
+	if add.Op != "+" {
+		t.Errorf("expected op '+', got %q", add.Op)
+	}
+	mul, ok := add.Right.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected BinaryExpr on right, got %T", add.Right)
+	}
+	if mul.Op != "*" {
+		t.Errorf("expected op '*', got %q", mul.Op)
+	}
+}
+
+func TestStringLiteralExpr(t *testing.T) {
+	mod := mustParse(t, `select "hello world"`)
+	expr := mod.Select.Select[0]
+	s, ok := expr.(*ast.StringLiteral)
+	if !ok {
+		t.Fatalf("expected StringLiteral, got %T", expr)
+	}
+	if s.Value != "hello world" {
+		t.Errorf("expected 'hello world', got %q", s.Value)
+	}
+}
+
+func TestParenthesisedFormula(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { (a() or b()) and c() }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	conj, ok := body.(*ast.Conjunction)
+	if !ok {
+		t.Fatalf("expected Conjunction at top, got %T", body)
+	}
+	_, ok = conj.Left.(*ast.Disjunction)
+	if !ok {
+		t.Fatalf("expected Disjunction on left of and, got %T", conj.Left)
+	}
+}
+
+func TestMultipleImports(t *testing.T) {
+	mod := mustParse(t, `import javascript
+import DataFlow::PathGraph as DFP`)
+	if len(mod.Imports) != 2 {
+		t.Fatalf("expected 2 imports, got %d", len(mod.Imports))
+	}
+	if mod.Imports[1].Path != "DataFlow::PathGraph" {
+		t.Errorf("expected DataFlow::PathGraph, got %q", mod.Imports[1].Path)
+	}
+	if mod.Imports[1].Alias != "DFP" {
+		t.Errorf("expected alias DFP, got %q", mod.Imports[1].Alias)
+	}
+}
+
+func TestPredicateEmptyBody(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { }`)
+	if len(mod.Predicates) != 1 {
+		t.Fatalf("expected 1 predicate, got %d", len(mod.Predicates))
+	}
+	if mod.Predicates[0].Body != nil {
+		t.Error("expected nil body for empty predicate")
+	}
+}
+
+func TestPredicateMultipleParams(t *testing.T) {
+	mod := mustParse(t, `predicate foo(int x, string y, DataFlow::Node z) { x > 0 }`)
+	params := mod.Predicates[0].Params
+	if len(params) != 3 {
+		t.Fatalf("expected 3 params, got %d", len(params))
+	}
+	if params[0].Type.String() != "int" {
+		t.Errorf("param 0: expected int, got %q", params[0].Type.String())
+	}
+	if params[1].Type.String() != "string" {
+		t.Errorf("param 1: expected string, got %q", params[1].Type.String())
+	}
+	if params[2].Type.String() != "DataFlow::Node" {
+		t.Errorf("param 2: expected DataFlow::Node, got %q", params[2].Type.String())
+	}
+}
+
+func TestFieldAccess(t *testing.T) {
+	mod := mustParse(t, `select this.name`)
+	expr := mod.Select.Select[0]
+	fa, ok := expr.(*ast.FieldAccess)
+	if !ok {
+		t.Fatalf("expected FieldAccess, got %T", expr)
+	}
+	if fa.Field != "name" {
+		t.Errorf("expected field 'name', got %q", fa.Field)
+	}
+}
+
+func TestFunctionCallAsFormula(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { bar(1, 2) }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	pc, ok := body.(*ast.PredicateCall)
+	if !ok {
+		t.Fatalf("expected PredicateCall, got %T", body)
+	}
+	if pc.Name != "bar" {
+		t.Errorf("expected name 'bar', got %q", pc.Name)
+	}
+	if len(pc.Args) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(pc.Args))
+	}
+}
+
+func TestResultAssignment(t *testing.T) {
+	mod := mustParse(t, `string foo() { result = "hello" }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	comp, ok := body.(*ast.Comparison)
+	if !ok {
+		t.Fatalf("expected Comparison, got %T", body)
+	}
+	if comp.Op != "=" {
+		t.Errorf("expected op '=', got %q", comp.Op)
+	}
+	v, ok := comp.Left.(*ast.Variable)
+	if !ok {
+		t.Fatalf("expected Variable, got %T", comp.Left)
+	}
+	if v.Name != "result" {
+		t.Errorf("expected 'result', got %q", v.Name)
+	}
+}
+
+func TestMultipleSelectExprs(t *testing.T) {
+	mod := mustParse(t, `from int x, int y where x > 0 select x, y`)
+	if len(mod.Select.Decls) != 2 {
+		t.Fatalf("expected 2 decls, got %d", len(mod.Select.Decls))
+	}
+	if len(mod.Select.Select) != 2 {
+		t.Fatalf("expected 2 select exprs, got %d", len(mod.Select.Select))
+	}
+}
+
+func TestClassMultipleSuperTypes(t *testing.T) {
+	src := `class Foo extends Bar, Baz { Foo() { } }`
+	mod := mustParse(t, src)
+	cls := mod.Classes[0]
+	if len(cls.SuperTypes) != 2 {
+		t.Fatalf("expected 2 supertypes, got %d", len(cls.SuperTypes))
+	}
+	if cls.SuperTypes[0].String() != "Bar" {
+		t.Errorf("expected Bar, got %q", cls.SuperTypes[0].String())
+	}
+	if cls.SuperTypes[1].String() != "Baz" {
+		t.Errorf("expected Baz, got %q", cls.SuperTypes[1].String())
+	}
+}
+
+func TestExistsWithGuard(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { exists(int y | y > 0 | y < 10) }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	ex, ok := body.(*ast.Exists)
+	if !ok {
+		t.Fatalf("expected Exists, got %T", body)
+	}
+	if ex.Guard == nil {
+		t.Error("expected guard, got nil")
+	}
+	if ex.Body == nil {
+		t.Error("expected body, got nil")
+	}
+}
+
+func TestComparisonOperators(t *testing.T) {
+	ops := []struct {
+		src string
+		op  string
+	}{
+		{`predicate foo() { x = 0 }`, "="},
+		{`predicate foo() { x != 0 }`, "!="},
+		{`predicate foo() { x < 0 }`, "<"},
+		{`predicate foo() { x <= 0 }`, "<="},
+		{`predicate foo() { x > 0 }`, ">"},
+		{`predicate foo() { x >= 0 }`, ">="},
+	}
+	for _, tc := range ops {
+		mod := mustParse(t, tc.src)
+		body := *mod.Predicates[0].Body
+		comp, ok := body.(*ast.Comparison)
+		if !ok {
+			t.Fatalf("op %q: expected Comparison, got %T", tc.op, body)
+		}
+		if comp.Op != tc.op {
+			t.Errorf("expected op %q, got %q", tc.op, comp.Op)
+		}
+	}
+}
+
+// --- Error cases ---
+
+func TestErrorUnexpectedToken(t *testing.T) {
+	mustFail(t, `predicate { }`)
+}
+
+func TestErrorUnclosedBrace(t *testing.T) {
+	mustFail(t, `predicate foo() {`)
+}
+
+func TestErrorUnclosedParen(t *testing.T) {
+	mustFail(t, `predicate foo( { }`)
+}
+
+func TestErrorBadTopLevel(t *testing.T) {
+	mustFail(t, `+ +`)
+}
+
+func TestErrorParseErrorLocation(t *testing.T) {
+	p := parse.NewParser("predicate { }", "test.ql")
+	_, err := p.Parse()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	pe, ok := err.(*parse.ParseError)
+	if !ok {
+		t.Fatalf("expected *ParseError, got %T", err)
+	}
+	if pe.File != "test.ql" {
+		t.Errorf("expected file 'test.ql', got %q", pe.File)
+	}
+	if pe.Line != 1 {
+		t.Errorf("expected line 1, got %d", pe.Line)
+	}
+}
+
+func TestFullModule(t *testing.T) {
+	src := `
+import javascript
+import DataFlow::PathGraph as DFP
+
+class MyClass extends DataFlow::Node {
+	MyClass() { this.toString() != "" }
+	override predicate hasFlow() {
+		exists(DataFlow::Node src | src instanceof MyClass)
+	}
+}
+
+predicate isInteresting(DataFlow::Node n) {
+	not n.toString() = ""
+	and n instanceof MyClass
+}
+
+from DataFlow::Node n
+where isInteresting(n)
+select n as "node"
+`
+	mod := mustParse(t, src)
+	if len(mod.Imports) != 2 {
+		t.Errorf("expected 2 imports, got %d", len(mod.Imports))
+	}
+	if len(mod.Classes) != 1 {
+		t.Errorf("expected 1 class, got %d", len(mod.Classes))
+	}
+	if len(mod.Predicates) != 1 {
+		t.Errorf("expected 1 predicate, got %d", len(mod.Predicates))
+	}
+	if mod.Select == nil {
+		t.Error("expected select clause, got nil")
+	}
+}

--- a/ql/parse/parser.go
+++ b/ql/parse/parser.go
@@ -7,15 +7,15 @@ import (
 	"github.com/Gjdoalfnrxu/tsq/ql/ast"
 )
 
-// ParseError is returned for malformed QL input.
-type ParseError struct {
+// Error is returned for malformed QL input.
+type Error struct {
 	File    string
 	Line    int
 	Col     int
 	Message string
 }
 
-func (e *ParseError) Error() string {
+func (e *Error) Error() string {
 	return fmt.Sprintf("%s:%d:%d: %s", e.File, e.Line, e.Col, e.Message)
 }
 
@@ -23,8 +23,6 @@ func (e *ParseError) Error() string {
 type Parser struct {
 	lexer   *Lexer
 	current Token
-	peeked  Token
-	hasPeek bool
 	file    string
 }
 
@@ -37,21 +35,8 @@ func NewParser(src, file string) *Parser {
 
 func (p *Parser) advance() Token {
 	prev := p.current
-	if p.hasPeek {
-		p.current = p.peeked
-		p.hasPeek = false
-	} else {
-		p.current = p.lexer.Next()
-	}
+	p.current = p.lexer.Next()
 	return prev
-}
-
-func (p *Parser) peek() Token {
-	if !p.hasPeek {
-		p.peeked = p.lexer.Next()
-		p.hasPeek = true
-	}
-	return p.peeked
 }
 
 func (p *Parser) at(t TokenType) bool {
@@ -66,7 +51,7 @@ func (p *Parser) expect(t TokenType) (Token, error) {
 }
 
 func (p *Parser) errorf(format string, args ...interface{}) error {
-	return &ParseError{
+	return &Error{
 		File:    p.file,
 		Line:    p.current.Line,
 		Col:     p.current.Col,
@@ -956,7 +941,7 @@ func (p *Parser) parsePrimary() (ast.Expr, error) {
 		tok := p.advance()
 		val, err := strconv.ParseInt(tok.Lit, 10, 64)
 		if err != nil {
-			return nil, &ParseError{File: p.file, Line: tok.Line, Col: tok.Col, Message: "invalid integer: " + tok.Lit}
+			return nil, &Error{File: p.file, Line: tok.Line, Col: tok.Col, Message: "invalid integer: " + tok.Lit}
 		}
 		return &ast.IntLiteral{
 			BaseExpr: ast.BaseExpr{Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col}},

--- a/ql/parse/parser.go
+++ b/ql/parse/parser.go
@@ -1,1 +1,1212 @@
 package parse
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/ast"
+)
+
+// ParseError is returned for malformed QL input.
+type ParseError struct {
+	File    string
+	Line    int
+	Col     int
+	Message string
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("%s:%d:%d: %s", e.File, e.Line, e.Col, e.Message)
+}
+
+// Parser is a recursive descent QL parser.
+type Parser struct {
+	lexer   *Lexer
+	current Token
+	peeked  Token
+	hasPeek bool
+	file    string
+}
+
+// NewParser creates a Parser for the given source.
+func NewParser(src, file string) *Parser {
+	p := &Parser{lexer: NewLexer(src, file), file: file}
+	p.advance()
+	return p
+}
+
+func (p *Parser) advance() Token {
+	prev := p.current
+	if p.hasPeek {
+		p.current = p.peeked
+		p.hasPeek = false
+	} else {
+		p.current = p.lexer.Next()
+	}
+	return prev
+}
+
+func (p *Parser) peek() Token {
+	if !p.hasPeek {
+		p.peeked = p.lexer.Next()
+		p.hasPeek = true
+	}
+	return p.peeked
+}
+
+func (p *Parser) at(t TokenType) bool {
+	return p.current.Type == t
+}
+
+func (p *Parser) expect(t TokenType) (Token, error) {
+	if p.current.Type != t {
+		return p.current, p.errorf("expected %s, got %q", tokenName(t), p.current.Lit)
+	}
+	return p.advance(), nil
+}
+
+func (p *Parser) errorf(format string, args ...interface{}) error {
+	return &ParseError{
+		File:    p.file,
+		Line:    p.current.Line,
+		Col:     p.current.Col,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+func tokenName(t TokenType) string {
+	switch t {
+	case TokIdent:
+		return "identifier"
+	case TokInt:
+		return "integer"
+	case TokString:
+		return "string"
+	case TokLParen:
+		return "'('"
+	case TokRParen:
+		return "')'"
+	case TokLBrace:
+		return "'{'"
+	case TokRBrace:
+		return "'}'"
+	case TokComma:
+		return "','"
+	case TokSemi:
+		return "';'"
+	case TokDot:
+		return "'.'"
+	case TokPipe:
+		return "'|'"
+	case TokColCol:
+		return "'::'"
+	case TokEq:
+		return "'='"
+	case TokEOF:
+		return "EOF"
+	default:
+		return fmt.Sprintf("token(%d)", t)
+	}
+}
+
+// Parse parses the full module and returns an ast.Module or error.
+func (p *Parser) Parse() (*ast.Module, error) {
+	mod := &ast.Module{
+		Span: ast.Span{File: p.file, StartLine: p.current.Line, StartCol: p.current.Col},
+	}
+
+	for !p.at(TokEOF) && !p.at(TokError) {
+		switch p.current.Type {
+		case TokKwImport:
+			imp, err := p.parseImport()
+			if err != nil {
+				return nil, err
+			}
+			mod.Imports = append(mod.Imports, *imp)
+		case TokKwClass:
+			cls, err := p.parseClass()
+			if err != nil {
+				return nil, err
+			}
+			mod.Classes = append(mod.Classes, *cls)
+		case TokKwPredicate:
+			pred, err := p.parsePredicate()
+			if err != nil {
+				return nil, err
+			}
+			mod.Predicates = append(mod.Predicates, *pred)
+		case TokKwFrom:
+			sel, err := p.parseSelectClause()
+			if err != nil {
+				return nil, err
+			}
+			mod.Select = sel
+		case TokKwSelect:
+			// select without from/where
+			sel, err := p.parseSelectOnly()
+			if err != nil {
+				return nil, err
+			}
+			mod.Select = sel
+		case TokIdent:
+			// Could be a predicate with a return type like: string foo() { ... }
+			pred, err := p.parseTypedPredicate()
+			if err != nil {
+				return nil, err
+			}
+			mod.Predicates = append(mod.Predicates, *pred)
+		default:
+			return nil, p.errorf("unexpected token %q at top level", p.current.Lit)
+		}
+	}
+
+	if p.at(TokError) {
+		return nil, p.errorf("lexer error: %s", p.current.Lit)
+	}
+
+	mod.Span.EndLine = p.current.Line
+	mod.Span.EndCol = p.current.Col
+	return mod, nil
+}
+
+func (p *Parser) parseImport() (*ast.ImportDecl, error) {
+	tok, _ := p.expect(TokKwImport)
+	imp := &ast.ImportDecl{
+		Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col},
+	}
+
+	// Parse the import path: ident (:: ident)*
+	name, err := p.expect(TokIdent)
+	if err != nil {
+		return nil, err
+	}
+	path := name.Lit
+	for p.at(TokColCol) {
+		p.advance()
+		next, err := p.expect(TokIdent)
+		if err != nil {
+			return nil, err
+		}
+		path += "::" + next.Lit
+	}
+	imp.Path = path
+
+	// Optional alias
+	if p.at(TokKwAs) {
+		p.advance()
+		alias, err := p.expect(TokIdent)
+		if err != nil {
+			return nil, err
+		}
+		imp.Alias = alias.Lit
+	}
+
+	imp.Span.EndLine = p.current.Line
+	imp.Span.EndCol = p.current.Col
+	return imp, nil
+}
+
+func (p *Parser) parseClass() (*ast.ClassDecl, error) {
+	tok, _ := p.expect(TokKwClass)
+	cls := &ast.ClassDecl{
+		Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col},
+	}
+
+	name, err := p.expect(TokIdent)
+	if err != nil {
+		return nil, err
+	}
+	cls.Name = name.Lit
+
+	if p.at(TokKwExtends) {
+		p.advance()
+		for {
+			tr, err := p.parseTypeRef()
+			if err != nil {
+				return nil, err
+			}
+			cls.SuperTypes = append(cls.SuperTypes, *tr)
+			if !p.at(TokComma) {
+				break
+			}
+			p.advance()
+		}
+	}
+
+	if _, err := p.expect(TokLBrace); err != nil {
+		return nil, err
+	}
+
+	for !p.at(TokRBrace) && !p.at(TokEOF) {
+		member, isCharPred, err := p.parseClassMember(cls.Name)
+		if err != nil {
+			return nil, err
+		}
+		if isCharPred {
+			body := member.Body
+			cls.CharPred = body
+		} else {
+			cls.Members = append(cls.Members, *member)
+		}
+	}
+
+	end, err := p.expect(TokRBrace)
+	if err != nil {
+		return nil, err
+	}
+	cls.Span.EndLine = end.Line
+	cls.Span.EndCol = end.Col
+	return cls, nil
+}
+
+func (p *Parser) parseClassMember(className string) (*ast.MemberDecl, bool, error) {
+	startLine := p.current.Line
+	startCol := p.current.Col
+	member := &ast.MemberDecl{
+		Span: ast.Span{File: p.file, StartLine: startLine, StartCol: startCol},
+	}
+
+	// Check for override modifier
+	if p.at(TokKwOverride) {
+		member.Override = true
+		p.advance()
+	}
+
+	// Check for predicate keyword
+	if p.at(TokKwPredicate) {
+		p.advance()
+		name, err := p.expect(TokIdent)
+		if err != nil {
+			return nil, false, err
+		}
+		member.Name = name.Lit
+		params, err := p.parseParamList()
+		if err != nil {
+			return nil, false, err
+		}
+		member.Params = params
+		body, err := p.parseBody()
+		if err != nil {
+			return nil, false, err
+		}
+		member.Body = body
+		member.Span.EndLine = p.current.Line
+		member.Span.EndCol = p.current.Col
+		return member, false, nil
+	}
+
+	// Could be: ClassName() { ... } (characteristic predicate)
+	// or: ReturnType name(...) { ... } (method)
+	// or: name(...) { ... } (predicate member without return type)
+	// We need to look ahead to distinguish.
+
+	// Parse what looks like a type or name
+	if !p.at(TokIdent) {
+		return nil, false, p.errorf("expected member declaration, got %q", p.current.Lit)
+	}
+
+	firstName := p.current
+	p.advance()
+
+	// Collect qualified name parts
+	qualParts := []string{firstName.Lit}
+	for p.at(TokColCol) {
+		p.advance()
+		next, err := p.expect(TokIdent)
+		if err != nil {
+			return nil, false, err
+		}
+		qualParts = append(qualParts, next.Lit)
+	}
+
+	// Check if this is the characteristic predicate: ClassName()
+	if len(qualParts) == 1 && qualParts[0] == className && p.at(TokLParen) {
+		// Characteristic predicate
+		p.advance() // (
+		if _, err := p.expect(TokRParen); err != nil {
+			return nil, false, err
+		}
+		body, err := p.parseBody()
+		if err != nil {
+			return nil, false, err
+		}
+		member.Name = className
+		member.Body = body
+		member.Span.EndLine = p.current.Line
+		member.Span.EndCol = p.current.Col
+		return member, true, nil
+	}
+
+	// If next is '(' then this is a predicate member with no return type
+	if len(qualParts) == 1 && p.at(TokLParen) {
+		member.Name = qualParts[0]
+		params, err := p.parseParamList()
+		if err != nil {
+			return nil, false, err
+		}
+		member.Params = params
+		body, err := p.parseBody()
+		if err != nil {
+			return nil, false, err
+		}
+		member.Body = body
+		member.Span.EndLine = p.current.Line
+		member.Span.EndCol = p.current.Col
+		return member, false, nil
+	}
+
+	// Otherwise it's a typed member: Type name(...)
+	retType := &ast.TypeRef{
+		Path: qualParts,
+		Span: ast.Span{File: p.file, StartLine: firstName.Line, StartCol: firstName.Col},
+	}
+	member.ReturnType = retType
+
+	name, err := p.expect(TokIdent)
+	if err != nil {
+		return nil, false, err
+	}
+	member.Name = name.Lit
+
+	params, err := p.parseParamList()
+	if err != nil {
+		return nil, false, err
+	}
+	member.Params = params
+
+	body, err := p.parseBody()
+	if err != nil {
+		return nil, false, err
+	}
+	member.Body = body
+	member.Span.EndLine = p.current.Line
+	member.Span.EndCol = p.current.Col
+	return member, false, nil
+}
+
+func (p *Parser) parsePredicate() (*ast.PredicateDecl, error) {
+	tok, _ := p.expect(TokKwPredicate)
+	pred := &ast.PredicateDecl{
+		Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col},
+	}
+
+	name, err := p.expect(TokIdent)
+	if err != nil {
+		return nil, err
+	}
+	pred.Name = name.Lit
+
+	params, err := p.parseParamList()
+	if err != nil {
+		return nil, err
+	}
+	pred.Params = params
+
+	body, err := p.parseBody()
+	if err != nil {
+		return nil, err
+	}
+	pred.Body = body
+	pred.Span.EndLine = p.current.Line
+	pred.Span.EndCol = p.current.Col
+	return pred, nil
+}
+
+// parseTypedPredicate parses: Type name(...) { ... } at top level
+func (p *Parser) parseTypedPredicate() (*ast.PredicateDecl, error) {
+	startLine := p.current.Line
+	startCol := p.current.Col
+	pred := &ast.PredicateDecl{
+		Span: ast.Span{File: p.file, StartLine: startLine, StartCol: startCol},
+	}
+
+	retType, err := p.parseTypeRef()
+	if err != nil {
+		return nil, err
+	}
+	pred.ReturnType = retType
+
+	name, err := p.expect(TokIdent)
+	if err != nil {
+		return nil, err
+	}
+	pred.Name = name.Lit
+
+	params, err := p.parseParamList()
+	if err != nil {
+		return nil, err
+	}
+	pred.Params = params
+
+	body, err := p.parseBody()
+	if err != nil {
+		return nil, err
+	}
+	pred.Body = body
+	pred.Span.EndLine = p.current.Line
+	pred.Span.EndCol = p.current.Col
+	return pred, nil
+}
+
+func (p *Parser) parseParamList() ([]ast.ParamDecl, error) {
+	if _, err := p.expect(TokLParen); err != nil {
+		return nil, err
+	}
+
+	var params []ast.ParamDecl
+	if !p.at(TokRParen) {
+		for {
+			param, err := p.parseParamDecl()
+			if err != nil {
+				return nil, err
+			}
+			params = append(params, *param)
+			if !p.at(TokComma) {
+				break
+			}
+			p.advance()
+		}
+	}
+
+	if _, err := p.expect(TokRParen); err != nil {
+		return nil, err
+	}
+	return params, nil
+}
+
+func (p *Parser) parseParamDecl() (*ast.ParamDecl, error) {
+	startLine := p.current.Line
+	startCol := p.current.Col
+
+	tr, err := p.parseTypeRef()
+	if err != nil {
+		return nil, err
+	}
+
+	name, err := p.expect(TokIdent)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.ParamDecl{
+		Type: *tr,
+		Name: name.Lit,
+		Span: ast.Span{File: p.file, StartLine: startLine, StartCol: startCol, EndLine: name.Line, EndCol: name.Col},
+	}, nil
+}
+
+func (p *Parser) parseTypeRef() (*ast.TypeRef, error) {
+	startLine := p.current.Line
+	startCol := p.current.Col
+
+	name, err := p.expect(TokIdent)
+	if err != nil {
+		return nil, err
+	}
+	parts := []string{name.Lit}
+
+	for p.at(TokColCol) {
+		p.advance()
+		next, err := p.expect(TokIdent)
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, next.Lit)
+	}
+
+	return &ast.TypeRef{
+		Path: parts,
+		Span: ast.Span{File: p.file, StartLine: startLine, StartCol: startCol},
+	}, nil
+}
+
+func (p *Parser) parseBody() (*ast.Formula, error) {
+	if _, err := p.expect(TokLBrace); err != nil {
+		return nil, err
+	}
+
+	if p.at(TokRBrace) {
+		p.advance()
+		return nil, nil
+	}
+
+	f, err := p.parseFormula()
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expect(TokRBrace); err != nil {
+		return nil, err
+	}
+
+	return &f, nil
+}
+
+// --- Formula parsing ---
+
+func (p *Parser) parseFormula() (ast.Formula, error) {
+	return p.parseOr()
+}
+
+func (p *Parser) parseOr() (ast.Formula, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	for p.at(TokKwOr) {
+		p.advance()
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = &ast.Disjunction{
+			BaseFormula: ast.BaseFormula{Span: left.GetSpan()},
+			Left:        left,
+			Right:       right,
+		}
+	}
+	return left, nil
+}
+
+func (p *Parser) parseAnd() (ast.Formula, error) {
+	left, err := p.parseNot()
+	if err != nil {
+		return nil, err
+	}
+	for p.at(TokKwAnd) {
+		p.advance()
+		right, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+		left = &ast.Conjunction{
+			BaseFormula: ast.BaseFormula{Span: left.GetSpan()},
+			Left:        left,
+			Right:       right,
+		}
+	}
+	return left, nil
+}
+
+func (p *Parser) parseNot() (ast.Formula, error) {
+	if p.at(TokKwNot) {
+		tok := p.advance()
+		f, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.Negation{
+			BaseFormula: ast.BaseFormula{Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col}},
+			Formula:     f,
+		}, nil
+	}
+	return p.parseComparisonOrAtom()
+}
+
+func (p *Parser) parseComparisonOrAtom() (ast.Formula, error) {
+	// Try to parse an expression, and if followed by comparison op or instanceof, make it a comparison/instanceof.
+	// Otherwise, it must be a formula atom (predicate call, exists, forall, etc.)
+
+	// Check for formula atoms first
+	switch p.current.Type {
+	case TokKwExists:
+		return p.parseExists()
+	case TokKwForall:
+		return p.parseForall()
+	case TokKwNone:
+		return p.parseNone()
+	case TokKwAny:
+		return p.parseAnyFormula()
+	case TokLParen:
+		// Parenthesised formula
+		p.advance()
+		f, err := p.parseFormula()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(TokRParen); err != nil {
+			return nil, err
+		}
+		return f, nil
+	}
+
+	// Parse expression-based formula: comparison, instanceof, or predicate call
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for comparison operators
+	if isComparisonOp(p.current.Type) {
+		op := p.advance()
+		right, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.Comparison{
+			BaseFormula: ast.BaseFormula{Span: expr.GetSpan()},
+			Left:        expr,
+			Right:       right,
+			Op:          op.Lit,
+		}, nil
+	}
+
+	// Check for instanceof
+	if p.at(TokKwInstanceof) {
+		p.advance()
+		tr, err := p.parseTypeRef()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.InstanceOf{
+			BaseFormula: ast.BaseFormula{Span: expr.GetSpan()},
+			Expr:        expr,
+			Type:        *tr,
+		}, nil
+	}
+
+	// Must be a predicate call expression used as a formula
+	// Convert MethodCall or function call expression to PredicateCall formula
+	return exprToFormula(expr)
+}
+
+func exprToFormula(e ast.Expr) (ast.Formula, error) {
+	switch v := e.(type) {
+	case *ast.MethodCall:
+		return &ast.PredicateCall{
+			BaseFormula: ast.BaseFormula{Span: v.GetSpan()},
+			Recv:        v.Recv,
+			Name:        v.Method,
+			Args:        v.Args,
+		}, nil
+	case *ast.Variable:
+		// Bare name used as formula — treat as zero-arg predicate call
+		return &ast.PredicateCall{
+			BaseFormula: ast.BaseFormula{Span: v.GetSpan()},
+			Name:        v.Name,
+		}, nil
+	default:
+		return nil, fmt.Errorf("expression cannot be used as formula")
+	}
+}
+
+func isComparisonOp(t TokenType) bool {
+	return t == TokEq || t == TokNeq || t == TokLt || t == TokLte || t == TokGt || t == TokGte
+}
+
+func (p *Parser) parseExists() (ast.Formula, error) {
+	tok := p.advance() // exists
+	if _, err := p.expect(TokLParen); err != nil {
+		return nil, err
+	}
+
+	decls, err := p.parseVarDeclList()
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expect(TokPipe); err != nil {
+		return nil, err
+	}
+
+	body, err := p.parseFormula()
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for second pipe (guard | body form)
+	var guard ast.Formula
+	if p.at(TokPipe) {
+		p.advance()
+		guard = body
+		body, err = p.parseFormula()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if _, err := p.expect(TokRParen); err != nil {
+		return nil, err
+	}
+
+	return &ast.Exists{
+		BaseFormula: ast.BaseFormula{Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col}},
+		Decls:       decls,
+		Guard:       guard,
+		Body:        body,
+	}, nil
+}
+
+func (p *Parser) parseForall() (ast.Formula, error) {
+	tok := p.advance() // forall
+	if _, err := p.expect(TokLParen); err != nil {
+		return nil, err
+	}
+
+	decls, err := p.parseVarDeclList()
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expect(TokPipe); err != nil {
+		return nil, err
+	}
+
+	guard, err := p.parseFormula()
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expect(TokPipe); err != nil {
+		return nil, err
+	}
+
+	body, err := p.parseFormula()
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expect(TokRParen); err != nil {
+		return nil, err
+	}
+
+	return &ast.Forall{
+		BaseFormula: ast.BaseFormula{Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col}},
+		Decls:       decls,
+		Guard:       guard,
+		Body:        body,
+	}, nil
+}
+
+func (p *Parser) parseNone() (ast.Formula, error) {
+	tok := p.advance() // none
+	if _, err := p.expect(TokLParen); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(TokRParen); err != nil {
+		return nil, err
+	}
+	return &ast.None{
+		BaseFormula: ast.BaseFormula{Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col}},
+	}, nil
+}
+
+func (p *Parser) parseAnyFormula() (ast.Formula, error) {
+	tok := p.advance() // any
+	if _, err := p.expect(TokLParen); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(TokRParen); err != nil {
+		return nil, err
+	}
+	return &ast.Any{
+		BaseFormula: ast.BaseFormula{Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col}},
+	}, nil
+}
+
+func (p *Parser) parseVarDeclList() ([]ast.VarDecl, error) {
+	var decls []ast.VarDecl
+	for {
+		tr, err := p.parseTypeRef()
+		if err != nil {
+			return nil, err
+		}
+		name, err := p.expect(TokIdent)
+		if err != nil {
+			return nil, err
+		}
+		decls = append(decls, ast.VarDecl{
+			Type: *tr,
+			Name: name.Lit,
+			Span: ast.Span{File: p.file, StartLine: tr.Span.StartLine, StartCol: tr.Span.StartCol},
+		})
+		if !p.at(TokComma) {
+			break
+		}
+		p.advance()
+	}
+	return decls, nil
+}
+
+// --- Expression parsing ---
+
+func (p *Parser) parseExpr() (ast.Expr, error) {
+	return p.parseAddSub()
+}
+
+func (p *Parser) parseAddSub() (ast.Expr, error) {
+	left, err := p.parseMulDiv()
+	if err != nil {
+		return nil, err
+	}
+	for p.at(TokPlus) || p.at(TokMinus) {
+		op := p.advance()
+		right, err := p.parseMulDiv()
+		if err != nil {
+			return nil, err
+		}
+		left = &ast.BinaryExpr{
+			BaseExpr: ast.BaseExpr{Span: left.GetSpan()},
+			Left:     left,
+			Right:    right,
+			Op:       op.Lit,
+		}
+	}
+	return left, nil
+}
+
+func (p *Parser) parseMulDiv() (ast.Expr, error) {
+	left, err := p.parseUnary()
+	if err != nil {
+		return nil, err
+	}
+	for p.at(TokStar) || p.at(TokSlash) || p.at(TokPct) {
+		op := p.advance()
+		right, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		left = &ast.BinaryExpr{
+			BaseExpr: ast.BaseExpr{Span: left.GetSpan()},
+			Left:     left,
+			Right:    right,
+			Op:       op.Lit,
+		}
+	}
+	return left, nil
+}
+
+func (p *Parser) parseUnary() (ast.Expr, error) {
+	if p.at(TokMinus) {
+		op := p.advance()
+		expr, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.BinaryExpr{
+			BaseExpr: ast.BaseExpr{Span: ast.Span{File: p.file, StartLine: op.Line, StartCol: op.Col}},
+			Left:     &ast.IntLiteral{BaseExpr: ast.BaseExpr{Span: ast.Span{File: p.file, StartLine: op.Line, StartCol: op.Col}}, Value: 0},
+			Right:    expr,
+			Op:       "-",
+		}, nil
+	}
+	return p.parsePostfix()
+}
+
+func (p *Parser) parsePostfix() (ast.Expr, error) {
+	expr, err := p.parsePrimary()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.at(TokDot) {
+		p.advance() // .
+
+		// Cast: .(Type)
+		if p.at(TokLParen) {
+			p.advance()
+			tr, err := p.parseTypeRef()
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(TokRParen); err != nil {
+				return nil, err
+			}
+			expr = &ast.Cast{
+				BaseExpr: ast.BaseExpr{Span: expr.GetSpan()},
+				Expr:     expr,
+				Type:     *tr,
+			}
+			continue
+		}
+
+		name, err := p.expect(TokIdent)
+		if err != nil {
+			return nil, err
+		}
+
+		// Method call: .name(args...)
+		if p.at(TokLParen) {
+			args, err := p.parseArgList()
+			if err != nil {
+				return nil, err
+			}
+			expr = &ast.MethodCall{
+				BaseExpr: ast.BaseExpr{Span: expr.GetSpan()},
+				Recv:     expr,
+				Method:   name.Lit,
+				Args:     args,
+			}
+		} else {
+			// Field access: .name
+			expr = &ast.FieldAccess{
+				BaseExpr: ast.BaseExpr{Span: expr.GetSpan()},
+				Recv:     expr,
+				Field:    name.Lit,
+			}
+		}
+	}
+
+	return expr, nil
+}
+
+func (p *Parser) parsePrimary() (ast.Expr, error) {
+	switch p.current.Type {
+	case TokInt:
+		tok := p.advance()
+		val, err := strconv.ParseInt(tok.Lit, 10, 64)
+		if err != nil {
+			return nil, &ParseError{File: p.file, Line: tok.Line, Col: tok.Col, Message: "invalid integer: " + tok.Lit}
+		}
+		return &ast.IntLiteral{
+			BaseExpr: ast.BaseExpr{Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col}},
+			Value:    val,
+		}, nil
+
+	case TokString:
+		tok := p.advance()
+		return &ast.StringLiteral{
+			BaseExpr: ast.BaseExpr{Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col}},
+			Value:    tok.Lit,
+		}, nil
+
+	case TokKwTrue:
+		tok := p.advance()
+		return &ast.BoolLiteral{
+			BaseExpr: ast.BaseExpr{Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col}},
+			Value:    true,
+		}, nil
+
+	case TokKwFalse:
+		tok := p.advance()
+		return &ast.BoolLiteral{
+			BaseExpr: ast.BaseExpr{Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col}},
+			Value:    false,
+		}, nil
+
+	case TokKwThis:
+		tok := p.advance()
+		return &ast.Variable{
+			BaseExpr: ast.BaseExpr{Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col}},
+			Name:     "this",
+		}, nil
+
+	case TokKwResult:
+		tok := p.advance()
+		return &ast.Variable{
+			BaseExpr: ast.BaseExpr{Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col}},
+			Name:     "result",
+		}, nil
+
+	case TokKwCount, TokKwMin, TokKwMax, TokKwSum, TokKwAvg:
+		return p.parseAggregate()
+
+	case TokIdent:
+		tok := p.advance()
+		// Check for function call: ident(args...)
+		if p.at(TokLParen) {
+			// But first check if this might be a qualified name function call
+			// For now, simple ident(args...) — treat as method call with nil recv
+			args, err := p.parseArgList()
+			if err != nil {
+				return nil, err
+			}
+			return &ast.MethodCall{
+				BaseExpr: ast.BaseExpr{Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col}},
+				Recv:     nil,
+				Method:   tok.Lit,
+				Args:     args,
+			}, nil
+		}
+		return &ast.Variable{
+			BaseExpr: ast.BaseExpr{Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col}},
+			Name:     tok.Lit,
+		}, nil
+
+	case TokLParen:
+		p.advance()
+		expr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(TokRParen); err != nil {
+			return nil, err
+		}
+		return expr, nil
+
+	default:
+		return nil, p.errorf("unexpected token %q in expression", p.current.Lit)
+	}
+}
+
+func (p *Parser) parseAggregate() (ast.Expr, error) {
+	tok := p.advance() // count/min/max/sum/avg
+	opName := tok.Lit
+
+	if _, err := p.expect(TokLParen); err != nil {
+		return nil, err
+	}
+
+	decls, err := p.parseVarDeclList()
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expect(TokPipe); err != nil {
+		return nil, err
+	}
+
+	body, err := p.parseFormula()
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for optional expr after another pipe (for min/max/sum/avg: | expr)
+	var aggExpr ast.Expr
+	var guard ast.Formula
+	if p.at(TokPipe) {
+		p.advance()
+		// Could be guard | body pattern OR body | expr pattern
+		// For aggregates, the pattern is: decls | guard | expr
+		// So body was actually the guard, and now we parse the expression
+		guard = body
+		aggExpr, err = p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		// The "body" for aggregate in this case is the guard
+		body = nil
+	}
+
+	if _, err := p.expect(TokRParen); err != nil {
+		return nil, err
+	}
+
+	return &ast.Aggregate{
+		BaseExpr: ast.BaseExpr{Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col}},
+		Op:       opName,
+		Decls:    decls,
+		Guard:    guard,
+		Body:     body,
+		Expr:     aggExpr,
+	}, nil
+}
+
+func (p *Parser) parseArgList() ([]ast.Expr, error) {
+	if _, err := p.expect(TokLParen); err != nil {
+		return nil, err
+	}
+
+	var args []ast.Expr
+	if !p.at(TokRParen) {
+		for {
+			arg, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, arg)
+			if !p.at(TokComma) {
+				break
+			}
+			p.advance()
+		}
+	}
+
+	if _, err := p.expect(TokRParen); err != nil {
+		return nil, err
+	}
+	return args, nil
+}
+
+// --- Select clause parsing ---
+
+func (p *Parser) parseSelectClause() (*ast.SelectClause, error) {
+	tok, _ := p.expect(TokKwFrom)
+	sel := &ast.SelectClause{
+		Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col},
+	}
+
+	// Parse from declarations
+	if !p.at(TokKwWhere) && !p.at(TokKwSelect) {
+		decls, err := p.parseVarDeclList()
+		if err != nil {
+			return nil, err
+		}
+		sel.Decls = decls
+	}
+
+	// Optional where
+	if p.at(TokKwWhere) {
+		p.advance()
+		f, err := p.parseFormula()
+		if err != nil {
+			return nil, err
+		}
+		sel.Where = &f
+	}
+
+	// select
+	if _, err := p.expect(TokKwSelect); err != nil {
+		return nil, err
+	}
+
+	exprs, labels, err := p.parseSelectExprs()
+	if err != nil {
+		return nil, err
+	}
+	sel.Select = exprs
+	sel.Labels = labels
+
+	sel.Span.EndLine = p.current.Line
+	sel.Span.EndCol = p.current.Col
+	return sel, nil
+}
+
+// parseSelectOnly parses `select expr, ...` without from/where.
+func (p *Parser) parseSelectOnly() (*ast.SelectClause, error) {
+	tok, _ := p.expect(TokKwSelect)
+	sel := &ast.SelectClause{
+		Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col},
+	}
+
+	exprs, labels, err := p.parseSelectExprs()
+	if err != nil {
+		return nil, err
+	}
+	sel.Select = exprs
+	sel.Labels = labels
+
+	sel.Span.EndLine = p.current.Line
+	sel.Span.EndCol = p.current.Col
+	return sel, nil
+}
+
+func (p *Parser) parseSelectExprs() ([]ast.Expr, []string, error) {
+	var exprs []ast.Expr
+	var labels []string
+	for {
+		expr, err := p.parseExpr()
+		if err != nil {
+			return nil, nil, err
+		}
+		exprs = append(exprs, expr)
+
+		// Optional label
+		label := ""
+		if p.at(TokKwAs) {
+			p.advance()
+			lt, err := p.expect(TokString)
+			if err != nil {
+				return nil, nil, err
+			}
+			label = lt.Lit
+		}
+		labels = append(labels, label)
+
+		if !p.at(TokComma) {
+			break
+		}
+		p.advance()
+	}
+	return exprs, labels, nil
+}


### PR DESCRIPTION
## Summary
Implements the QL lexer and recursive descent parser producing ast.Module.

- ql/ast: complete AST type hierarchy (Module, ClassDecl, PredicateDecl, SelectClause, Formula, Expr subtypes)
- ql/parse: Lexer (all token types, comment skipping, string escapes)
- ql/parse: Parser (recursive descent for v1 QL subset)
- Comprehensive tests for all syntax forms, precedence, error cases

## Test plan
- [x] go test ./ql/... passes (49 tests, all passing)
- [x] All grammar forms parse correctly
- [x] Operator precedence correct for formulas and expressions
- [x] Method chains, casts, aggregates parse
- [x] Import, class, predicate declarations parse
- [x] Error cases produce ParseError with location info
- [x] go vet ./... clean
- [x] go build ./... clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)