### PR TITLE
chore: add pre-commit hook for auto-formatting

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Auto-fix formatting and linting before commit.
+# This hook never blocks — it fixes what it can and re-stages modified files.
+
+echo "pre-commit: running gofmt..."
+gofmt -w ./...
+
+echo "pre-commit: running golangci-lint --fix..."
+golangci-lint run --fix ./... || true
+
+# Re-stage any files modified by the above so fixes are included in the commit.
+git diff --name-only | xargs -r git add
+
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 ## Development Workflow
 
+After cloning, run `make setup` to configure the git hooks path. This installs a pre-commit hook that auto-formats and auto-fixes lint issues before each commit.
+
 All changes to tsq must go through a pull request. Direct pushes to `main` are not permitted.
 
 ### Branch Naming

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint extract query
+.PHONY: build test lint extract query setup
 
 build:
 	go build -o bin/tsq ./cmd/tsq
@@ -14,3 +14,7 @@ extract:
 
 query:
 	go run ./cmd/tsq query $(ARGS)
+
+setup:
+	git config core.hooksPath .githooks
+	chmod +x .githooks/pre-commit


### PR DESCRIPTION
## What this does

Adds a `.githooks/pre-commit` script that runs on every commit:

1. `gofmt -w ./...` — auto-formats all Go files
2. `golangci-lint run --fix ./...` — auto-fixes lint issues (`|| true` so it's a no-op if golangci-lint isn't installed)
3. Re-stages any files modified by the above, so fixes land in the commit rather than being left as dirty working tree changes

The hook always exits 0. It is an auto-fix hook, not a blocking lint gate.

## Setup

The hook lives in `.githooks/` rather than `.git/hooks/` so it's checked into the repo. Contributors need to wire it once after cloning:

```
make setup
```

This runs `git config core.hooksPath .githooks` and `chmod +x .githooks/pre-commit`.

`CONTRIBUTING.md` has been updated with this instruction.