### PR TITLE
Phase 2b: QL name resolver

### DIFF
--- a/HANDOVER-phase-2b.md
+++ b/HANDOVER-phase-2b.md
@@ -1,0 +1,75 @@
+# Handover: Phase 2b — QL Name Resolver
+
+## What Was Implemented
+
+`ql/resolve/resolve.go` — full name resolution pass for QL AST modules.
+`ql/resolve/resolve_test.go` — 21 table-driven tests covering all specified cases.
+
+---
+
+## Annotation Mechanism (Pointer-Keyed Side Tables)
+
+Resolution results are stored in `Annotations`, which uses two maps keyed by pointer identity:
+
+```go
+ExprResolutions map[ast.Expr]*Resolution      // keyed on ast.Expr interface value (pointer)
+VarBindings     map[*ast.Variable]VarBinding  // keyed on *ast.Variable pointer
+```
+
+Because every AST node is allocated as a distinct pointer during parsing (or test construction), pointer identity uniquely identifies each node. There is no need for node IDs. Two AST nodes that happen to have the same field values are still different entries in the map if they are different allocations.
+
+**How to look up:** after Resolve returns, index into `rm.Annotations.ExprResolutions[someExprPtr]` or `rm.Annotations.VarBindings[someVarPtr]`. The expression pointer must be the same pointer that appeared in the AST — not a copy of the struct.
+
+---
+
+## How the Desugarer (Phase 3b) Should Access Resolution Results
+
+The desugarer receives a `*ResolvedModule` and should:
+
+1. **Class → predicate lowering:** For each `*ast.ClassDecl` in `rm.Env.Classes`, generate a unary Datalog predicate from the class's characteristic predicate. The resolver has already validated supertypes, so the desugarer can trust `cd.SuperTypes` are resolvable.
+
+2. **Method → binary predicate lowering:** For each `*ast.MemberDecl`, emit a predicate with explicit `this` and (if `ReturnType != nil`) `result` arguments. Use `rm.Env.Classes[className]` to traverse the inheritance chain for override union semantics.
+
+3. **Method call sites:** When the desugarer encounters a `*ast.MethodCall` in an expression, look up `rm.Annotations.ExprResolutions[mc]`. The `Resolution.DeclClass` is the defining class and `Resolution.DeclMember` is the member. Use these to emit the correct predicate reference (e.g., `Bar_getY(this, result)` rather than `Foo_getY`).
+
+4. **Variable binding:** When lowering quantified formulas (exists/forall), look up `rm.Annotations.VarBindings[v]` to confirm which declaration a variable refers to, and emit the correct Datalog variable.
+
+5. **`this` and `result`:** These are resolved by the resolver (errors emitted for invalid use). The desugarer can treat `this` as the first argument and `result` as the last argument of every method predicate without further validation.
+
+---
+
+## Partial Resolution Behaviour
+
+Resolve never short-circuits. All passes run to completion regardless of errors:
+
+- **First pass** registers as many classes and predicates as it can (duplicates produce an error but the first declaration is registered).
+- **Cycle detection** marks cycles and continues — the second pass still runs on non-cyclic classes.
+- **Second pass** resolves all bodies it can reach. An undefined predicate or variable produces an error but does not halt resolution of other predicates or bodies.
+- **Import failures** produce an error for the missing import; resolution of the rest of the module continues using whatever was already in the environment.
+
+`rm.Errors` collects all errors. `rm.Env` and `rm.Annotations` are always populated with whatever was successfully resolved. The desugarer should check `len(rm.Errors) > 0` and refuse to proceed if there are errors (partial annotations may be incomplete).
+
+---
+
+## QL Constructs NOT Supported in v1 Resolver
+
+| Construct | Status | Notes |
+|---|---|---|
+| Module parameters | Not supported | `module Foo<T> { ... }` — parameterised modules are not parsed or resolved |
+| `newtype` | Not supported | Required for IPA dataflow; deferred to v2 |
+| Abstract classes with multi-dispatch | Partial | Single supertype chain only; multiple supertypes in extends are structurally supported but dispatch semantics are not enforced |
+| `pragma[noopt]` / `pragma[noinline]` | Not supported | Parser drops pragmas; resolver ignores them |
+| `module` scoping / qualified imports | Partial | Import paths are stored as strings; `DataFlow::Node` style qualified names resolve only the leaf name within a flat env |
+| `instanceof` type checks | Parsed, not fully resolved | InstanceOf type is validated (class must exist) but not used for type inference in ExprResolutions |
+| `forex` | Parsed as Exists/Forall variant | The quantifier body is resolved correctly; forex semantics (exactly-one) are not enforced at resolution time |
+| Chained method calls (`x.getA().getB()`) | Partial | Return type of `getA()` is inferred from ExprResolutions if already resolved; ordering dependency means the inner call must be resolved before the outer. Works in practice for left-to-right resolution. |
+| Overload resolution | Not supported | If two members share a name with different arities, the first one found in the member list wins |
+| `any()` / `none()` formulas | Supported | Resolved as no-ops (no variables to bind) |
+| Aggregate expressions | Supported | `count`/`min`/`max`/`sum`/`avg` — decls are bound in inner scope, guard and body resolved |
+
+---
+
+## File Locations
+
+- `ql/resolve/resolve.go` — resolver implementation
+- `ql/resolve/resolve_test.go` — 21 tests

--- a/ql/resolve/resolve.go
+++ b/ql/resolve/resolve.go
@@ -12,7 +12,7 @@ type ResolvedModule struct {
 	AST         *ast.Module
 	Env         *Environment
 	Annotations *Annotations
-	Errors      []ResolveError
+	Errors      []Error
 }
 
 // Environment holds all top-level declarations in scope.
@@ -22,13 +22,13 @@ type Environment struct {
 	Imports    map[string]*ResolvedModule
 }
 
-// ResolveError describes a name resolution failure.
-type ResolveError struct {
+// Error describes a name resolution failure.
+type Error struct {
 	Pos     ast.Span
 	Message string
 }
 
-func (e ResolveError) Error() string {
+func (e Error) Error() string {
 	return fmt.Sprintf("%s:%d:%d: %s", e.Pos.File, e.Pos.StartLine, e.Pos.StartCol, e.Message)
 }
 
@@ -67,7 +67,7 @@ var primitiveTypes = map[string]bool{
 type resolver struct {
 	env    *Environment
 	ann    *Annotations
-	errors []ResolveError
+	errors []Error
 	mod    *ast.Module
 }
 
@@ -109,7 +109,7 @@ func Resolve(mod *ast.Module, importLoader func(path string) (*ast.Module, error
 
 // errorf records a resolution error without stopping.
 func (r *resolver) errorf(span ast.Span, format string, args ...interface{}) {
-	r.errors = append(r.errors, ResolveError{
+	r.errors = append(r.errors, Error{
 		Pos:     span,
 		Message: fmt.Sprintf(format, args...),
 	})

--- a/ql/resolve/resolve.go
+++ b/ql/resolve/resolve.go
@@ -1,2 +1,589 @@
 // Package resolve implements QL name resolution, producing a ResolvedModule.
 package resolve
+
+import (
+	"fmt"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/ast"
+)
+
+// ResolvedModule is the output of name resolution.
+type ResolvedModule struct {
+	AST         *ast.Module
+	Env         *Environment
+	Annotations *Annotations
+	Errors      []ResolveError
+}
+
+// Environment holds all top-level declarations in scope.
+type Environment struct {
+	Predicates map[string]*ast.PredicateDecl
+	Classes    map[string]*ast.ClassDecl
+	Imports    map[string]*ResolvedModule
+}
+
+// ResolveError describes a name resolution failure.
+type ResolveError struct {
+	Pos     ast.Span
+	Message string
+}
+
+func (e ResolveError) Error() string {
+	return fmt.Sprintf("%s:%d:%d: %s", e.Pos.File, e.Pos.StartLine, e.Pos.StartCol, e.Message)
+}
+
+// Annotations is a side-table of resolution results.
+// Keys are pointer identity into the AST.
+type Annotations struct {
+	// ExprResolutions maps expressions to what they resolved to.
+	ExprResolutions map[ast.Expr]*Resolution
+	// VarBindings maps Variable exprs to their binding declaration.
+	VarBindings map[*ast.Variable]VarBinding
+}
+
+// Resolution describes what a name resolved to.
+type Resolution struct {
+	DeclClass     *ast.ClassDecl
+	DeclMember    *ast.MemberDecl
+	DeclPredicate *ast.PredicateDecl
+}
+
+// VarBinding records where a variable was bound.
+type VarBinding struct {
+	Param *ast.ParamDecl // non-nil if bound as parameter
+	// Exists/Forall/Forex/From bindings: just the ParamDecl from that construct
+}
+
+// primitiveTypes is the set of built-in scalar type names.
+var primitiveTypes = map[string]bool{
+	"int":     true,
+	"float":   true,
+	"string":  true,
+	"boolean": true,
+	"date":    true,
+}
+
+// resolver is the internal state for a resolution pass.
+type resolver struct {
+	env    *Environment
+	ann    *Annotations
+	errors []ResolveError
+	mod    *ast.Module
+}
+
+// Resolve performs name resolution on mod.
+// importLoader is called for each import path; it may return nil to indicate
+// the module is unavailable (resolution continues with errors).
+func Resolve(mod *ast.Module, importLoader func(path string) (*ast.Module, error)) (*ResolvedModule, error) {
+	env := &Environment{
+		Predicates: make(map[string]*ast.PredicateDecl),
+		Classes:    make(map[string]*ast.ClassDecl),
+		Imports:    make(map[string]*ResolvedModule),
+	}
+	ann := &Annotations{
+		ExprResolutions: make(map[ast.Expr]*Resolution),
+		VarBindings:     make(map[*ast.Variable]VarBinding),
+	}
+	r := &resolver{env: env, ann: ann, mod: mod}
+
+	// Process imports first so imported names are available.
+	r.processImports(mod, importLoader)
+
+	// First pass: register all top-level declarations.
+	r.firstPass(mod)
+
+	// Detect cyclic inheritance before second pass.
+	r.detectCycles(mod)
+
+	// Second pass: resolve bodies.
+	r.secondPass(mod)
+
+	rm := &ResolvedModule{
+		AST:         mod,
+		Env:         env,
+		Annotations: ann,
+		Errors:      r.errors,
+	}
+	return rm, nil
+}
+
+// errorf records a resolution error without stopping.
+func (r *resolver) errorf(span ast.Span, format string, args ...interface{}) {
+	r.errors = append(r.errors, ResolveError{
+		Pos:     span,
+		Message: fmt.Sprintf(format, args...),
+	})
+}
+
+// ---- Pass 0: imports ----
+
+func (r *resolver) processImports(mod *ast.Module, importLoader func(string) (*ast.Module, error)) {
+	if importLoader == nil {
+		return
+	}
+	for i := range mod.Imports {
+		imp := &mod.Imports[i]
+		path := imp.Path
+		if _, already := r.env.Imports[path]; already {
+			continue
+		}
+		importedAST, err := importLoader(path)
+		if err != nil || importedAST == nil {
+			r.errorf(imp.Span, "cannot load import %q: %v", path, err)
+			continue
+		}
+		// Recursively resolve the imported module (no further import loading).
+		rm, _ := Resolve(importedAST, nil)
+		r.env.Imports[path] = rm
+		// Make imported predicates and classes available in our env.
+		for name, pd := range rm.Env.Predicates {
+			if _, exists := r.env.Predicates[name]; !exists {
+				r.env.Predicates[name] = pd
+			}
+		}
+		for name, cd := range rm.Env.Classes {
+			if _, exists := r.env.Classes[name]; !exists {
+				r.env.Classes[name] = cd
+			}
+		}
+	}
+}
+
+// ---- Pass 1: register declarations ----
+
+func (r *resolver) firstPass(mod *ast.Module) {
+	for i := range mod.Classes {
+		cd := &mod.Classes[i]
+		if existing, dup := r.env.Classes[cd.Name]; dup {
+			r.errorf(cd.Span, "duplicate class declaration %q (first declared at %s:%d)",
+				cd.Name, existing.Span.File, existing.Span.StartLine)
+		} else {
+			r.env.Classes[cd.Name] = cd
+		}
+	}
+	for i := range mod.Predicates {
+		pd := &mod.Predicates[i]
+		if existing, dup := r.env.Predicates[pd.Name]; dup {
+			r.errorf(pd.Span, "duplicate predicate declaration %q (first declared at %s:%d)",
+				pd.Name, existing.Span.File, existing.Span.StartLine)
+		} else {
+			r.env.Predicates[pd.Name] = pd
+		}
+	}
+}
+
+// ---- Cycle detection ----
+
+// detectCycles finds cyclic inheritance in the class hierarchy.
+func (r *resolver) detectCycles(mod *ast.Module) {
+	// colour: 0=white, 1=grey (in stack), 2=black (done)
+	colour := make(map[string]int)
+	var visit func(name string, span ast.Span) bool
+	visit = func(name string, span ast.Span) bool {
+		if colour[name] == 2 {
+			return false
+		}
+		if colour[name] == 1 {
+			r.errorf(span, "cyclic class inheritance involving %q", name)
+			return true
+		}
+		cd, ok := r.env.Classes[name]
+		if !ok {
+			return false
+		}
+		colour[name] = 1
+		for _, st := range cd.SuperTypes {
+			stName := st.String()
+			if visit(stName, st.Span) {
+				colour[name] = 2
+				return true
+			}
+		}
+		colour[name] = 2
+		return false
+	}
+	for i := range mod.Classes {
+		visit(mod.Classes[i].Name, mod.Classes[i].Span)
+	}
+}
+
+// ---- Pass 2: resolve bodies ----
+
+// scope maps variable names to their types (for method-call resolution) and
+// tracks binding ParamDecl pointers.
+type scope struct {
+	vars     map[string]varInfo
+	inClass  *ast.ClassDecl
+	inMethod *ast.MemberDecl
+	inPred   *ast.PredicateDecl
+}
+
+type varInfo struct {
+	typeName string // resolved class name or primitive type name; empty if unknown
+	param    *ast.ParamDecl
+}
+
+func newScope() *scope {
+	return &scope{vars: make(map[string]varInfo)}
+}
+
+func (s *scope) child() *scope {
+	c := &scope{
+		vars:     make(map[string]varInfo),
+		inClass:  s.inClass,
+		inMethod: s.inMethod,
+		inPred:   s.inPred,
+	}
+	// Copy parent vars.
+	for k, v := range s.vars {
+		c.vars[k] = v
+	}
+	return c
+}
+
+func (r *resolver) secondPass(mod *ast.Module) {
+	// Resolve extends type references for each class.
+	for i := range mod.Classes {
+		cd := &mod.Classes[i]
+		for _, st := range cd.SuperTypes {
+			r.resolveTypeRef(st)
+		}
+	}
+
+	// Resolve class bodies.
+	for i := range mod.Classes {
+		cd := &mod.Classes[i]
+		s := newScope()
+		s.inClass = cd
+		// `this` is implicitly bound in class context.
+		s.vars["this"] = varInfo{typeName: cd.Name}
+
+		// Resolve member params and bodies.
+		for j := range cd.Members {
+			md := &cd.Members[j]
+			ms := s.child()
+			ms.inMethod = md
+			// Bind parameters.
+			for k := range md.Params {
+				param := &md.Params[k]
+				r.resolveTypeRef(param.Type)
+				ms.vars[param.Name] = varInfo{typeName: param.Type.String(), param: param}
+			}
+			// `result` is valid when the method has a non-nil ReturnType.
+			if md.ReturnType != nil {
+				ms.vars["result"] = varInfo{typeName: md.ReturnType.String()}
+			}
+			if md.Body != nil {
+				r.resolveFormula(*md.Body, ms)
+			}
+		}
+
+		// Resolve characteristic predicate body.
+		if cd.CharPred != nil {
+			r.resolveFormula(*cd.CharPred, s)
+		}
+	}
+
+	// Resolve top-level predicate bodies.
+	for i := range mod.Predicates {
+		pd := &mod.Predicates[i]
+		s := newScope()
+		s.inPred = pd
+		for k := range pd.Params {
+			param := &pd.Params[k]
+			r.resolveTypeRef(param.Type)
+			s.vars[param.Name] = varInfo{typeName: param.Type.String(), param: param}
+		}
+		if pd.ReturnType != nil {
+			s.vars["result"] = varInfo{typeName: pd.ReturnType.String()}
+		}
+		if pd.Body != nil {
+			r.resolveFormula(*pd.Body, s)
+		}
+	}
+
+	// Resolve select clause.
+	if mod.Select != nil {
+		r.resolveSelect(mod.Select)
+	}
+}
+
+// resolveTypeRef checks that a type reference exists (class or primitive).
+func (r *resolver) resolveTypeRef(tr ast.TypeRef) {
+	name := tr.String()
+	if primitiveTypes[name] {
+		return
+	}
+	if _, ok := r.env.Classes[name]; !ok {
+		r.errorf(tr.Span, "undefined type %q", name)
+	}
+}
+
+// resolveSelect resolves the from/where/select clause.
+func (r *resolver) resolveSelect(sel *ast.SelectClause) {
+	s := newScope()
+	// Bind from declarations.
+	for i := range sel.Decls {
+		vd := &sel.Decls[i]
+		r.resolveTypeRef(vd.Type)
+		// Synthesise a ParamDecl so VarBindings can reference it.
+		pd := &ast.ParamDecl{Type: vd.Type, Name: vd.Name, Span: vd.Span}
+		s.vars[vd.Name] = varInfo{typeName: vd.Type.String(), param: pd}
+	}
+	if sel.Where != nil {
+		r.resolveFormula(*sel.Where, s)
+	}
+	for _, e := range sel.Select {
+		r.resolveExpr(e, s)
+	}
+}
+
+// ---- Formula resolution ----
+
+func (r *resolver) resolveFormula(f ast.Formula, s *scope) {
+	if f == nil {
+		return
+	}
+	switch n := f.(type) {
+	case *ast.Conjunction:
+		r.resolveFormula(n.Left, s)
+		r.resolveFormula(n.Right, s)
+	case *ast.Disjunction:
+		r.resolveFormula(n.Left, s)
+		r.resolveFormula(n.Right, s)
+	case *ast.Negation:
+		r.resolveFormula(n.Formula, s)
+	case *ast.Comparison:
+		r.resolveExpr(n.Left, s)
+		r.resolveExpr(n.Right, s)
+	case *ast.PredicateCall:
+		r.resolvePredicateCall(n, s)
+	case *ast.InstanceOf:
+		r.resolveExpr(n.Expr, s)
+		r.resolveTypeRef(n.Type)
+	case *ast.Exists:
+		r.resolveQuantified(n.Decls, n.Guard, n.Body, s)
+	case *ast.Forall:
+		r.resolveQuantified(n.Decls, n.Guard, n.Body, s)
+	case *ast.None, *ast.Any:
+		// nothing to resolve
+	}
+}
+
+// resolveQuantified handles exists/forall bodies (shared logic).
+func (r *resolver) resolveQuantified(decls []ast.VarDecl, guard ast.Formula, body ast.Formula, s *scope) {
+	inner := s.child()
+	for i := range decls {
+		vd := &decls[i]
+		r.resolveTypeRef(vd.Type)
+		pd := &ast.ParamDecl{Type: vd.Type, Name: vd.Name, Span: vd.Span}
+		inner.vars[vd.Name] = varInfo{typeName: vd.Type.String(), param: pd}
+	}
+	if guard != nil {
+		r.resolveFormula(guard, inner)
+	}
+	r.resolveFormula(body, inner)
+}
+
+// resolvePredicateCall resolves a predicate/method call used as a formula.
+func (r *resolver) resolvePredicateCall(pc *ast.PredicateCall, s *scope) {
+	if pc.Recv != nil {
+		// Method call on receiver: resolve receiver then look up method on its type.
+		r.resolveExpr(pc.Recv, s)
+		recvType := r.exprType(pc.Recv, s)
+		if recvType != "" {
+			if cd, ok := r.env.Classes[recvType]; ok {
+				if md := r.lookupMember(cd, pc.Name); md == nil {
+					r.errorf(pc.GetSpan(), "class %q has no member %q", recvType, pc.Name)
+				}
+			}
+		}
+		for _, arg := range pc.Args {
+			r.resolveExpr(arg, s)
+		}
+		return
+	}
+	// Bare call — look up in predicates.
+	if _, ok := r.env.Predicates[pc.Name]; !ok {
+		r.errorf(pc.GetSpan(), "undefined predicate %q", pc.Name)
+	}
+	for _, arg := range pc.Args {
+		r.resolveExpr(arg, s)
+	}
+}
+
+// ---- Expression resolution ----
+
+func (r *resolver) resolveExpr(e ast.Expr, s *scope) {
+	if e == nil {
+		return
+	}
+	switch n := e.(type) {
+	case *ast.Variable:
+		r.resolveVariable(n, s)
+	case *ast.IntLiteral, *ast.StringLiteral, *ast.BoolLiteral:
+		// nothing
+	case *ast.FieldAccess:
+		r.resolveExpr(n.Recv, s)
+	case *ast.MethodCall:
+		r.resolveMethodCall(n, s)
+	case *ast.Cast:
+		r.resolveExpr(n.Expr, s)
+		r.resolveTypeRef(n.Type)
+	case *ast.Aggregate:
+		r.resolveAggregate(n, s)
+	case *ast.BinaryExpr:
+		r.resolveExpr(n.Left, s)
+		r.resolveExpr(n.Right, s)
+	}
+}
+
+// resolveVariable checks that a variable is bound, handling `this` and `result` specially.
+func (r *resolver) resolveVariable(v *ast.Variable, s *scope) {
+	switch v.Name {
+	case "this":
+		if s.inClass == nil {
+			r.errorf(v.GetSpan(), "`this` used outside a class body")
+			return
+		}
+		// `this` is pre-bound in s; no additional annotation needed.
+		return
+	case "result":
+		// Valid if we're inside a method with a return type, or a predicate with return type.
+		if s.inMethod != nil && s.inMethod.ReturnType != nil {
+			return
+		}
+		if s.inPred != nil && s.inPred.ReturnType != nil {
+			return
+		}
+		r.errorf(v.GetSpan(), "`result` used in predicate/method without a return type")
+		return
+	}
+	info, ok := s.vars[v.Name]
+	if !ok {
+		r.errorf(v.GetSpan(), "undefined variable %q", v.Name)
+		return
+	}
+	if info.param != nil {
+		r.ann.VarBindings[v] = VarBinding{Param: info.param}
+	}
+}
+
+// resolveMethodCall resolves expr.method(args...) and records annotation.
+func (r *resolver) resolveMethodCall(mc *ast.MethodCall, s *scope) {
+	r.resolveExpr(mc.Recv, s)
+	recvType := r.exprType(mc.Recv, s)
+	if recvType != "" {
+		if cd, ok := r.env.Classes[recvType]; ok {
+			defClass := r.memberDefiningClass(cd, mc.Method)
+			if defClass != nil {
+				md := r.lookupMember(defClass, mc.Method)
+				r.ann.ExprResolutions[mc] = &Resolution{
+					DeclClass:  defClass,
+					DeclMember: md,
+				}
+			} else {
+				r.errorf(mc.GetSpan(), "class %q has no member %q", recvType, mc.Method)
+			}
+		}
+	}
+	for _, arg := range mc.Args {
+		r.resolveExpr(arg, s)
+	}
+}
+
+func (r *resolver) resolveAggregate(a *ast.Aggregate, s *scope) {
+	inner := s.child()
+	for i := range a.Decls {
+		vd := &a.Decls[i]
+		r.resolveTypeRef(vd.Type)
+		pd := &ast.ParamDecl{Type: vd.Type, Name: vd.Name, Span: vd.Span}
+		inner.vars[vd.Name] = varInfo{typeName: vd.Type.String(), param: pd}
+	}
+	if a.Guard != nil {
+		r.resolveFormula(a.Guard, inner)
+	}
+	if a.Body != nil {
+		r.resolveFormula(a.Body, inner)
+	}
+	if a.Expr != nil {
+		r.resolveExpr(a.Expr, inner)
+	}
+}
+
+// ---- Type inference helpers ----
+
+// exprType returns the inferred class name for an expression, or "" if unknown.
+func (r *resolver) exprType(e ast.Expr, s *scope) string {
+	switch n := e.(type) {
+	case *ast.Variable:
+		if info, ok := s.vars[n.Name]; ok {
+			return info.typeName
+		}
+	case *ast.Cast:
+		return n.Type.String()
+	case *ast.MethodCall:
+		// Look up the resolution to infer the return type.
+		if res, ok := r.ann.ExprResolutions[n]; ok && res.DeclMember != nil && res.DeclMember.ReturnType != nil {
+			return res.DeclMember.ReturnType.String()
+		}
+	}
+	return ""
+}
+
+// ---- Member lookup helpers (supertype chain) ----
+
+// lookupMember searches cd and its supertype chain for a member named name.
+// Returns the first (most-derived) match found, or nil.
+func (r *resolver) lookupMember(cd *ast.ClassDecl, name string) *ast.MemberDecl {
+	visited := make(map[string]bool)
+	return r.lookupMemberRec(cd, name, visited)
+}
+
+func (r *resolver) lookupMemberRec(cd *ast.ClassDecl, name string, visited map[string]bool) *ast.MemberDecl {
+	if cd == nil || visited[cd.Name] {
+		return nil
+	}
+	visited[cd.Name] = true
+	for i := range cd.Members {
+		if cd.Members[i].Name == name {
+			return &cd.Members[i]
+		}
+	}
+	// Walk supertype chain.
+	for _, st := range cd.SuperTypes {
+		if superCD, ok := r.env.Classes[st.String()]; ok {
+			if md := r.lookupMemberRec(superCD, name, visited); md != nil {
+				return md
+			}
+		}
+	}
+	return nil
+}
+
+// memberDefiningClass returns the ClassDecl that directly defines name,
+// walking up the supertype chain from cd.
+func (r *resolver) memberDefiningClass(cd *ast.ClassDecl, name string) *ast.ClassDecl {
+	visited := make(map[string]bool)
+	return r.memberDefiningClassRec(cd, name, visited)
+}
+
+func (r *resolver) memberDefiningClassRec(cd *ast.ClassDecl, name string, visited map[string]bool) *ast.ClassDecl {
+	if cd == nil || visited[cd.Name] {
+		return nil
+	}
+	visited[cd.Name] = true
+	for i := range cd.Members {
+		if cd.Members[i].Name == name {
+			return cd
+		}
+	}
+	for _, st := range cd.SuperTypes {
+		if superCD, ok := r.env.Classes[st.String()]; ok {
+			if found := r.memberDefiningClassRec(superCD, name, visited); found != nil {
+				return found
+			}
+		}
+	}
+	return nil
+}

--- a/ql/resolve/resolve_test.go
+++ b/ql/resolve/resolve_test.go
@@ -1,5 +1,665 @@
 package resolve_test
 
-import "testing"
+import (
+	"errors"
+	"strings"
+	"testing"
 
-func TestPlaceholder(t *testing.T) {}
+	"github.com/Gjdoalfnrxu/tsq/ql/ast"
+	"github.com/Gjdoalfnrxu/tsq/ql/resolve"
+)
+
+// helpers
+
+func span() ast.Span { return ast.Span{File: "test.ql", StartLine: 1, StartCol: 1} }
+
+func typeRef(name string) ast.TypeRef {
+	return ast.TypeRef{Path: []string{name}, Span: span()}
+}
+
+func varExpr(name string) *ast.Variable {
+	return &ast.Variable{BaseExpr: ast.BaseExpr{Span: span()}, Name: name}
+}
+
+func noErrors(t *testing.T, rm *resolve.ResolvedModule) {
+	t.Helper()
+	for _, e := range rm.Errors {
+		t.Errorf("unexpected error: %s", e.Message)
+	}
+}
+
+func hasError(t *testing.T, rm *resolve.ResolvedModule, substr string) {
+	t.Helper()
+	for _, e := range rm.Errors {
+		if strings.Contains(e.Message, substr) {
+			return
+		}
+	}
+	t.Errorf("expected error containing %q; got errors: %v", substr, rm.Errors)
+}
+
+// ---- Tests ----
+
+// Resolve module with one class → class in env.
+func TestResolveOneClass(t *testing.T) {
+	mod := &ast.Module{
+		Classes: []ast.ClassDecl{
+			{Name: "Foo", Span: span()},
+		},
+	}
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noErrors(t, rm)
+	if _, ok := rm.Env.Classes["Foo"]; !ok {
+		t.Error("expected Foo in env.Classes")
+	}
+}
+
+// Resolve module with predicate calling another predicate → no errors, predicate in env.
+func TestResolvePredCallsPred(t *testing.T) {
+	body := ast.Formula(&ast.PredicateCall{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Name:        "bar",
+		Args:        []ast.Expr{},
+	})
+	mod := &ast.Module{
+		Predicates: []ast.PredicateDecl{
+			{Name: "bar", Body: nil, Span: span()},
+			{
+				Name: "foo",
+				Body: &body,
+				Span: span(),
+			},
+		},
+	}
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noErrors(t, rm)
+}
+
+// Class extends another class → supertype resolved, no errors.
+func TestClassExtendsClass(t *testing.T) {
+	mod := &ast.Module{
+		Classes: []ast.ClassDecl{
+			{Name: "Base", Span: span()},
+			{
+				Name:       "Derived",
+				SuperTypes: []ast.TypeRef{typeRef("Base")},
+				Span:       span(),
+			},
+		},
+	}
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noErrors(t, rm)
+}
+
+// `this` inside class body → valid.
+func TestThisInsideClass(t *testing.T) {
+	thisVar := varExpr("this")
+	body := ast.Formula(&ast.Comparison{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Left:        thisVar,
+		Right:       &ast.IntLiteral{BaseExpr: ast.BaseExpr{Span: span()}, Value: 1},
+		Op:          "=",
+	})
+	mod := &ast.Module{
+		Classes: []ast.ClassDecl{
+			{
+				Name:     "Foo",
+				CharPred: &body,
+				Span:     span(),
+			},
+		},
+	}
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noErrors(t, rm)
+}
+
+// `this` outside class body → ResolveError.
+func TestThisOutsideClass(t *testing.T) {
+	thisVar := varExpr("this")
+	body := ast.Formula(&ast.Comparison{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Left:        thisVar,
+		Right:       &ast.IntLiteral{BaseExpr: ast.BaseExpr{Span: span()}, Value: 1},
+		Op:          "=",
+	})
+	mod := &ast.Module{
+		Predicates: []ast.PredicateDecl{
+			{Name: "foo", Body: &body, Span: span()},
+		},
+	}
+	rm, _ := resolve.Resolve(mod, nil)
+	hasError(t, rm, "`this` used outside a class body")
+}
+
+// `result` inside method with return type → valid.
+func TestResultInsideMethodWithReturnType(t *testing.T) {
+	resultVar := varExpr("result")
+	body := ast.Formula(&ast.Comparison{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Left:        resultVar,
+		Right:       &ast.IntLiteral{BaseExpr: ast.BaseExpr{Span: span()}, Value: 42},
+		Op:          "=",
+	})
+	rt := typeRef("int")
+	mod := &ast.Module{
+		Classes: []ast.ClassDecl{
+			{
+				Name: "Foo",
+				Members: []ast.MemberDecl{
+					{
+						Name:       "getValue",
+						ReturnType: &rt,
+						Body:       &body,
+						Span:       span(),
+					},
+				},
+				Span: span(),
+			},
+		},
+	}
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noErrors(t, rm)
+}
+
+// `result` in predicate without return type → ResolveError.
+func TestResultInPredicateWithoutReturnType(t *testing.T) {
+	resultVar := varExpr("result")
+	body := ast.Formula(&ast.Comparison{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Left:        resultVar,
+		Right:       &ast.IntLiteral{BaseExpr: ast.BaseExpr{Span: span()}, Value: 42},
+		Op:          "=",
+	})
+	mod := &ast.Module{
+		Predicates: []ast.PredicateDecl{
+			{Name: "foo", ReturnType: nil, Body: &body, Span: span()},
+		},
+	}
+	rm, _ := resolve.Resolve(mod, nil)
+	hasError(t, rm, "`result` used in predicate/method without a return type")
+}
+
+// Undefined predicate name → ResolveError with position.
+func TestUndefinedPredicate(t *testing.T) {
+	callSpan := ast.Span{File: "test.ql", StartLine: 5, StartCol: 3}
+	body := ast.Formula(&ast.PredicateCall{
+		BaseFormula: ast.BaseFormula{Span: callSpan},
+		Name:        "doesNotExist",
+	})
+	mod := &ast.Module{
+		Predicates: []ast.PredicateDecl{
+			{Name: "foo", Body: &body, Span: span()},
+		},
+	}
+	rm, _ := resolve.Resolve(mod, nil)
+	hasError(t, rm, "undefined predicate")
+	// Check position is propagated.
+	if len(rm.Errors) == 0 {
+		t.Fatal("no errors")
+	}
+	found := false
+	for _, e := range rm.Errors {
+		if e.Pos.StartLine == 5 && e.Pos.StartCol == 3 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error at 5:3, got %v", rm.Errors)
+	}
+}
+
+// Undefined class in extends → ResolveError.
+func TestUndefinedClassInExtends(t *testing.T) {
+	mod := &ast.Module{
+		Classes: []ast.ClassDecl{
+			{
+				Name:       "Child",
+				SuperTypes: []ast.TypeRef{typeRef("Ghost")},
+				Span:       span(),
+			},
+		},
+	}
+	rm, _ := resolve.Resolve(mod, nil)
+	hasError(t, rm, "undefined type")
+}
+
+// Variable not bound by exists/forall → ResolveError.
+func TestUnboundVariable(t *testing.T) {
+	unbound := varExpr("x")
+	body := ast.Formula(&ast.Comparison{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Left:        unbound,
+		Right:       &ast.IntLiteral{BaseExpr: ast.BaseExpr{Span: span()}, Value: 1},
+		Op:          "=",
+	})
+	mod := &ast.Module{
+		Predicates: []ast.PredicateDecl{
+			{Name: "foo", Body: &body, Span: span()},
+		},
+	}
+	rm, _ := resolve.Resolve(mod, nil)
+	hasError(t, rm, "undefined variable")
+}
+
+// Import: mock importLoader returning a pre-built ast.Module → imported predicates accessible.
+func TestImportLoader(t *testing.T) {
+	importedMod := &ast.Module{
+		Predicates: []ast.PredicateDecl{
+			{Name: "importedPred", Span: span()},
+		},
+	}
+	loader := func(path string) (*ast.Module, error) {
+		if path == "mylib" {
+			return importedMod, nil
+		}
+		return nil, errors.New("not found")
+	}
+	body := ast.Formula(&ast.PredicateCall{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Name:        "importedPred",
+	})
+	mod := &ast.Module{
+		Imports: []ast.ImportDecl{
+			{Path: "mylib", Span: span()},
+		},
+		Predicates: []ast.PredicateDecl{
+			{Name: "callIt", Body: &body, Span: span()},
+		},
+	}
+	rm, err := resolve.Resolve(mod, loader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noErrors(t, rm)
+	if _, ok := rm.Env.Imports["mylib"]; !ok {
+		t.Error("expected mylib in env.Imports")
+	}
+}
+
+// Method call x.getY() where x: Foo → resolved to Foo.getY member.
+func TestMethodCallResolved(t *testing.T) {
+	// Build: Foo class with method getY returning string.
+	rt := typeRef("string")
+	getY := ast.MemberDecl{
+		Name:       "getY",
+		ReturnType: &rt,
+		Span:       span(),
+	}
+	fooClass := ast.ClassDecl{
+		Name:    "Foo",
+		Members: []ast.MemberDecl{getY},
+		Span:    span(),
+	}
+
+	// predicate: string p(Foo x) { result = x.getY() }
+	xVar := varExpr("x")
+	mc := &ast.MethodCall{
+		BaseExpr: ast.BaseExpr{Span: span()},
+		Recv:     xVar,
+		Method:   "getY",
+	}
+	resultVar := varExpr("result")
+	predBody := ast.Formula(&ast.Comparison{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Left:        resultVar,
+		Right:       mc,
+		Op:          "=",
+	})
+	prt := typeRef("string")
+	pred := ast.PredicateDecl{
+		Name:       "p",
+		ReturnType: &prt,
+		Params: []ast.ParamDecl{
+			{Type: typeRef("Foo"), Name: "x", Span: span()},
+		},
+		Body: &predBody,
+		Span: span(),
+	}
+
+	mod := &ast.Module{
+		Classes:    []ast.ClassDecl{fooClass},
+		Predicates: []ast.PredicateDecl{pred},
+	}
+
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noErrors(t, rm)
+
+	res, ok := rm.Annotations.ExprResolutions[mc]
+	if !ok {
+		t.Fatal("expected ExprResolutions entry for method call")
+	}
+	if res.DeclMember == nil || res.DeclMember.Name != "getY" {
+		t.Errorf("expected DeclMember.Name=getY, got %v", res.DeclMember)
+	}
+	if res.DeclClass == nil || res.DeclClass.Name != "Foo" {
+		t.Errorf("expected DeclClass.Name=Foo, got %v", res.DeclClass)
+	}
+}
+
+// Inherited method: Foo extends Bar, getY on Bar → resolved to Bar.getY.
+func TestInheritedMethodResolution(t *testing.T) {
+	rt := typeRef("string")
+	getY := ast.MemberDecl{
+		Name:       "getY",
+		ReturnType: &rt,
+		Span:       span(),
+	}
+	barClass := ast.ClassDecl{
+		Name:    "Bar",
+		Members: []ast.MemberDecl{getY},
+		Span:    span(),
+	}
+	fooClass := ast.ClassDecl{
+		Name:       "Foo",
+		SuperTypes: []ast.TypeRef{typeRef("Bar")},
+		Span:       span(),
+	}
+
+	xVar := varExpr("x")
+	mc := &ast.MethodCall{
+		BaseExpr: ast.BaseExpr{Span: span()},
+		Recv:     xVar,
+		Method:   "getY",
+	}
+	resultVar := varExpr("result")
+	predBody := ast.Formula(&ast.Comparison{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Left:        resultVar,
+		Right:       mc,
+		Op:          "=",
+	})
+	prt := typeRef("string")
+	pred := ast.PredicateDecl{
+		Name:       "p",
+		ReturnType: &prt,
+		Params: []ast.ParamDecl{
+			{Type: typeRef("Foo"), Name: "x", Span: span()},
+		},
+		Body: &predBody,
+		Span: span(),
+	}
+
+	mod := &ast.Module{
+		Classes:    []ast.ClassDecl{barClass, fooClass},
+		Predicates: []ast.PredicateDecl{pred},
+	}
+
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noErrors(t, rm)
+
+	res, ok := rm.Annotations.ExprResolutions[mc]
+	if !ok {
+		t.Fatal("expected ExprResolutions entry for inherited method call")
+	}
+	if res.DeclClass == nil || res.DeclClass.Name != "Bar" {
+		t.Errorf("expected DeclClass.Name=Bar (defining class), got %v", res.DeclClass)
+	}
+	if res.DeclMember == nil || res.DeclMember.Name != "getY" {
+		t.Errorf("expected DeclMember.Name=getY, got %v", res.DeclMember)
+	}
+}
+
+// Multiple errors: module with several issues → all errors collected.
+func TestMultipleErrors(t *testing.T) {
+	// Two undefined predicates in two different predicates.
+	body1 := ast.Formula(&ast.PredicateCall{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Name:        "missing1",
+	})
+	body2 := ast.Formula(&ast.PredicateCall{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Name:        "missing2",
+	})
+	mod := &ast.Module{
+		Predicates: []ast.PredicateDecl{
+			{Name: "p1", Body: &body1, Span: span()},
+			{Name: "p2", Body: &body2, Span: span()},
+		},
+	}
+	rm, _ := resolve.Resolve(mod, nil)
+	if len(rm.Errors) < 2 {
+		t.Errorf("expected at least 2 errors, got %d: %v", len(rm.Errors), rm.Errors)
+	}
+}
+
+// Duplicate class declarations → ResolveError.
+func TestDuplicateClass(t *testing.T) {
+	mod := &ast.Module{
+		Classes: []ast.ClassDecl{
+			{Name: "Foo", Span: span()},
+			{Name: "Foo", Span: span()},
+		},
+	}
+	rm, _ := resolve.Resolve(mod, nil)
+	hasError(t, rm, "duplicate class declaration")
+}
+
+// Cyclic inheritance A extends B extends A → ResolveError (not infinite loop).
+func TestCyclicInheritance(t *testing.T) {
+	mod := &ast.Module{
+		Classes: []ast.ClassDecl{
+			{
+				Name:       "A",
+				SuperTypes: []ast.TypeRef{typeRef("B")},
+				Span:       span(),
+			},
+			{
+				Name:       "B",
+				SuperTypes: []ast.TypeRef{typeRef("A")},
+				Span:       span(),
+			},
+		},
+	}
+	rm, _ := resolve.Resolve(mod, nil)
+	hasError(t, rm, "cyclic class inheritance")
+}
+
+// Complex query: class with method calls, exists → fully resolved, no errors.
+func TestComplexQuery(t *testing.T) {
+	// class Node { string getName() { result = "x" } }
+	// predicate string findName(Node n) {
+	//   exists(Node m | result = m.getName())
+	// }
+	rt := typeRef("string")
+	getName := ast.MemberDecl{
+		Name:       "getName",
+		ReturnType: &rt,
+		Body: func() *ast.Formula {
+			resultVar := varExpr("result")
+			f := ast.Formula(&ast.Comparison{
+				BaseFormula: ast.BaseFormula{Span: span()},
+				Left:        resultVar,
+				Right:       &ast.StringLiteral{BaseExpr: ast.BaseExpr{Span: span()}, Value: "x"},
+				Op:          "=",
+			})
+			return &f
+		}(),
+		Span: span(),
+	}
+	nodeClass := ast.ClassDecl{
+		Name:    "Node",
+		Members: []ast.MemberDecl{getName},
+		Span:    span(),
+	}
+
+	// exists body: result = m.getName()
+	mVar := varExpr("m")
+	mc := &ast.MethodCall{
+		BaseExpr: ast.BaseExpr{Span: span()},
+		Recv:     mVar,
+		Method:   "getName",
+	}
+	resultVar2 := varExpr("result")
+	existsBody := ast.Formula(&ast.Comparison{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Left:        resultVar2,
+		Right:       mc,
+		Op:          "=",
+	})
+	existsFormula := ast.Formula(&ast.Exists{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Decls:       []ast.VarDecl{{Type: typeRef("Node"), Name: "m", Span: span()}},
+		Body:        existsBody,
+	})
+	predRT := typeRef("string")
+	pred := ast.PredicateDecl{
+		Name:       "findName",
+		ReturnType: &predRT,
+		Params: []ast.ParamDecl{
+			{Type: typeRef("Node"), Name: "n", Span: span()},
+		},
+		Body: &existsFormula,
+		Span: span(),
+	}
+
+	mod := &ast.Module{
+		Classes:    []ast.ClassDecl{nodeClass},
+		Predicates: []ast.PredicateDecl{pred},
+	}
+
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noErrors(t, rm)
+
+	// Verify method call resolved.
+	res, ok := rm.Annotations.ExprResolutions[mc]
+	if !ok {
+		t.Fatal("expected ExprResolutions entry for m.getName() in exists")
+	}
+	if res.DeclMember == nil || res.DeclMember.Name != "getName" {
+		t.Errorf("expected getName member, got %v", res.DeclMember)
+	}
+}
+
+// VarBindings: parameter variable is recorded.
+func TestVarBindingParameter(t *testing.T) {
+	xVar := varExpr("x")
+	body := ast.Formula(&ast.Comparison{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Left:        xVar,
+		Right:       &ast.IntLiteral{BaseExpr: ast.BaseExpr{Span: span()}, Value: 0},
+		Op:          "=",
+	})
+	mod := &ast.Module{
+		Predicates: []ast.PredicateDecl{
+			{
+				Name: "pred",
+				Params: []ast.ParamDecl{
+					{Type: typeRef("int"), Name: "x", Span: span()},
+				},
+				Body: &body,
+				Span: span(),
+			},
+		},
+	}
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noErrors(t, rm)
+	binding, ok := rm.Annotations.VarBindings[xVar]
+	if !ok {
+		t.Fatal("expected VarBindings entry for x")
+	}
+	if binding.Param == nil || binding.Param.Name != "x" {
+		t.Errorf("expected param name x, got %v", binding.Param)
+	}
+}
+
+// Exists-bound variable resolved correctly.
+func TestExistsBoundVariable(t *testing.T) {
+	fVar := varExpr("f")
+	mc := &ast.MethodCall{
+		BaseExpr: ast.BaseExpr{Span: span()},
+		Recv:     fVar,
+		Method:   "doIt",
+	}
+	existsBody := ast.Formula(&ast.PredicateCall{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Recv:        fVar,
+		Name:        "doIt",
+	})
+	_ = mc
+	existsFormula := ast.Formula(&ast.Exists{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Decls:       []ast.VarDecl{{Type: typeRef("Foo"), Name: "f", Span: span()}},
+		Body:        existsBody,
+	})
+	body := existsFormula
+	mod := &ast.Module{
+		Classes: []ast.ClassDecl{
+			{
+				Name:    "Foo",
+				Members: []ast.MemberDecl{{Name: "doIt", Span: span()}},
+				Span:    span(),
+			},
+		},
+		Predicates: []ast.PredicateDecl{
+			{Name: "pred", Body: &body, Span: span()},
+		},
+	}
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noErrors(t, rm)
+}
+
+// Failed import → ResolveError for that import, resolution continues.
+func TestImportLoaderFailure(t *testing.T) {
+	loader := func(path string) (*ast.Module, error) {
+		return nil, errors.New("module not found")
+	}
+	mod := &ast.Module{
+		Imports: []ast.ImportDecl{
+			{Path: "badlib", Span: span()},
+		},
+	}
+	rm, _ := resolve.Resolve(mod, loader)
+	hasError(t, rm, "cannot load import")
+}
+
+// Predicate with return type and result variable → no error.
+func TestPredicateWithReturnTypeResult(t *testing.T) {
+	resultVar := varExpr("result")
+	body := ast.Formula(&ast.Comparison{
+		BaseFormula: ast.BaseFormula{Span: span()},
+		Left:        resultVar,
+		Right:       &ast.IntLiteral{BaseExpr: ast.BaseExpr{Span: span()}, Value: 1},
+		Op:          "=",
+	})
+	rt := typeRef("int")
+	mod := &ast.Module{
+		Predicates: []ast.PredicateDecl{
+			{Name: "getOne", ReturnType: &rt, Body: &body, Span: span()},
+		},
+	}
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noErrors(t, rm)
+}


### PR DESCRIPTION
## Summary

- Implements `ql/resolve` package: two-pass name resolver producing `ResolvedModule` with populated `Environment` and `Annotations`
- First pass registers all classes and predicates (duplicate detection). Cycle detection via DFS colouring over the inheritance graph.
- Second pass resolves variable bindings (`this`, `result`, parameters, `exists`/`forall`/`from` decls), predicate/method calls, type references, and imports via `importLoader`
- Annotation side-tables use pointer identity (`map[ast.Expr]*Resolution`, `map[*ast.Variable]VarBinding`) — intentional, each AST node is a unique allocation
- Method calls walk the supertype chain; `DeclClass` in the annotation is the defining class, not the static receiver type
- All errors collected without short-circuiting; partial resolution is valid output
- `HANDOVER-phase-2b.md` documents annotation mechanism, desugarer integration, and unsupported v1 constructs

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes — 21 tests in `ql/resolve`, all other packages unaffected
- [ ] `go vet ./...` passes
- [ ] Review: one class in env, predicate calling predicate, class extends class, `this` valid/invalid, `result` valid/invalid, undefined predicate with position, undefined class in extends, unbound variable, import loader (success + failure), method call resolved, inherited method resolved, multiple errors, duplicate class, cyclic inheritance, complex query with exists