### PR TITLE
Phase 4: Planner — stratification and join ordering

### DIFF
--- a/HANDOVER-phase-4.md
+++ b/HANDOVER-phase-4.md
@@ -1,0 +1,219 @@
+# Phase 4 Handover: Planner — Stratification and Join Ordering
+
+## What was implemented
+
+Four files in `ql/plan/`:
+
+- `plan.go` — IR types (`ExecutionPlan`, `Stratum`, `PlannedRule`, `JoinStep`, `PlannedAggregate`, `PlannedQuery`) and the top-level `Plan()` entry point
+- `stratify.go` — Tarjan's SCC + stratum assignment
+- `join.go` — Greedy join ordering with eligibility rules
+- `validate.go` — Safety validation for individual rules
+
+Three test files:
+- `stratify_test.go` — 8 stratification tests
+- `join_test.go` — 6 join ordering tests
+- `validate_test.go` — 5 validation tests
+
+All 20 tests pass (`go test ./ql/plan/...`).
+
+---
+
+## Stratification Algorithm
+
+### Overview
+
+Stratification ensures that negation and aggregation are evaluated safely: a predicate that another rule negates or aggregates over must be fully computed before the negating/aggregating rule fires.
+
+### Step 1: Build the dependency graph
+
+For each rule `Head :- Body`:
+- For each positive body literal with predicate Q: add edge `Head → Q` (positive)
+- For each negative body literal (`not Q(...)`) : add edge `Head → Q` (negative)
+- For each aggregate literal `count(T v | Q(v) | ...)`: add edge `Head → Q` (negative, treated like negation)
+- Comparison literals (`Cmp != nil`) produce no predicate edges
+
+Predicates that appear only as rule heads never appear as dependency targets — they are derived. Predicates that appear only in rule bodies (never as rule heads) are base fact relations; they have no rules and implicitly occupy stratum 0.
+
+### Step 2: Tarjan's SCC
+
+Standard lowlink algorithm (~60 lines). Finds all strongly connected components. Tarjan's output is in reverse topological order.
+
+Each SCC is either:
+- A single predicate (possibly with a self-loop)
+- Multiple predicates in mutual positive recursion
+
+### Step 3: Unstratifiability check
+
+Any negative edge within an SCC means the predicate recursively depends on its own negation — this is undefined semantics. The planner returns an error: `"unstratifiable: predicate X has recursive negation"`.
+
+Self-loops are checked separately: a predicate with a negative self-loop is caught even if the SCC has only one node.
+
+### Step 4: Stratum assignment
+
+After reversing Tarjan's output to get topological order (dependencies first), we assign stratum numbers via iterative propagation:
+
+- For a positive dependency `Head → Dep` (different SCCs): `stratum[Head] >= stratum[Dep]`
+- For a negative/aggregate dependency `Head → Dep` (different SCCs): `stratum[Head] > stratum[Dep]` (strictly greater)
+
+The propagation loop runs until no stratum number changes (fixed point). This correctly handles chains.
+
+### Worked example: 5-predicate chain with negation
+
+```
+base(x) — fact relation, no rules
+A(x) :- base(x).
+B(x) :- A(x).
+C(x) :- base(x), not B(x).
+D(x) :- C(x), not A(x).
+E(x) :- D(x), A(x).
+```
+
+Dependency graph:
+- A → base (positive)
+- B → A (positive)
+- C → base (positive), C → B (negative)
+- D → C (positive), D → A (negative)
+- E → D (positive), E → A (positive)
+
+SCCs: {base}, {A}, {B}, {C}, {D}, {E} — all singleton (no mutual recursion).
+
+Topological order (dependencies first): base, A, B, C, D, E.
+
+Stratum assignment:
+- base: 0 (fact, no rules)
+- A: 0 (positive dep on base)
+- B: 0 (positive dep on A)
+- C: 1 (negative dep on B, so stratum[C] > stratum[B]=0 → 1)
+- D: 2 (negative dep on A stratum=0, positive dep on C stratum=1 → max is 2 from negative A? No: D→A is negative, stratum[D] > stratum[A]=0 → 1; D→C is positive, stratum[D] >= stratum[C]=1 → 1; combined → stratum[D]=2 because D→A negative forces >0 and D→C positive forces >=1, so D=2? Let's trace: initially all 0. Pass 1: D→C positive: 0>=1 fails → D=1. D→A negative: 1>0 ok. Pass 2: D→C positive: 1>=1 ok. Stable. D=1.)
+
+Wait — let me retrace more carefully:
+- Pass 1: C→B negative: C=0, B=0, 0>0 fails → C=1. D→C positive: D=0, C=1, 0>=1 fails → D=1. D→A negative: D=1, A=0, 1>0 ok.
+- Pass 2: C→B negative: C=1, B=0, 1>0 ok. D→C positive: D=1, C=1, 1>=1 ok. D→A negative: D=1, A=0, 1>0 ok. E→D positive: E=0, D=1, 0>=1 fails → E=1.
+- Pass 3: E→D positive: E=1, D=1, ok. E→A positive: E=1, A=0, ok. Stable.
+
+Final strata: {base=fact, A=0, B=0, C=1, D=1, E=1}.
+
+Evaluation order: stratum 0 (A, B rules), stratum 1 (C, D, E rules). base is a fact, always available.
+
+---
+
+## Join Ordering Heuristic
+
+### Overview
+
+For each rule body (a conjunction of literals), the planner determines the order in which to evaluate them. Good ordering minimises intermediate relation sizes.
+
+### Algorithm: Greedy most-bound-first, smallest-size tie-break
+
+At each step:
+
+1. **Eligibility check** — a literal is eligible to be placed if:
+   - It is a positive atom: always eligible (scans the relation)
+   - It is a negative atom (`not Q(...)`): eligible only when all its variables are already bound
+   - It is a comparison (`x < y`): eligible only when both operand variables are bound
+   - It is an aggregate: always eligible (self-contained sub-computation)
+
+2. **Score eligible literals** — score = `(-boundCount, size)` where:
+   - `boundCount` = number of the literal's variables already bound (more is better)
+   - `size` = relation size from `sizeHints`, default 1000 if unknown
+   - Lower score = placed earlier (`-boundCount` so more-bound = lower score)
+
+3. **Place the best-scored literal**, mark its variables as bound, add it to `JoinOrder`.
+
+4. Repeat until all literals are placed.
+
+### Worked example
+
+Rule: `P(x, y, z) :- A(x), B(x, y), C(y, z).`  
+Size hints: A=10, B=100, C=50.
+
+Step 1: All eligible. Scores: A=(-0, 10), B=(-0, 100), C=(-0, 50). Best: A (smallest size). Place A. Bound: {x}.
+
+Step 2: B eligible (x bound, 1 bound var). C eligible (0 bound vars). Scores: B=(-1, 100), C=(-0, 50). Best: B (more bound vars wins). Place B. Bound: {x, y}.
+
+Step 3: C eligible (y bound, 1 bound var). Scores: C=(-1, 50). Place C.
+
+Result: A → B → C.
+
+### Why negatives and comparisons are deferred
+
+Negation in Datalog requires the negative relation to be fully computed before the check. At the join level, we enforce this by requiring all variables in a negative literal to be bound before it is placed — which means a positive literal binding those variables must appear earlier. The same logic applies to comparisons, which are filter predicates that require both operands to be ground.
+
+---
+
+## What the Evaluator (Phase 5) Needs
+
+### Iterating strata
+
+```go
+for _, stratum := range ep.Strata {
+    // Run fixpoint for this stratum's rules.
+    for _, plannedRule := range stratum.Rules {
+        evaluateRule(plannedRule, db)
+    }
+    // After fixpoint: evaluate aggregates.
+    for _, agg := range stratum.Aggregates {
+        evaluateAggregate(agg, db)
+    }
+}
+```
+
+Strata are already in evaluation order — no sorting needed.
+
+### Executing JoinSteps
+
+Each `JoinStep` has:
+- `Literal` — the literal to evaluate at this step
+- `IsFilter` — if true, all variables were already bound when this step was placed; it is a filter, not a scan
+- `JoinCols` — currently empty (v1 placeholder); the evaluator uses variable names to correlate across steps
+
+For v1, the evaluator can maintain a binding map `varName → value` and for each step:
+
+```
+for each binding-set in current partial results:
+    if step.Literal is positive atom:
+        scan step.Literal.Atom.Predicate, filter rows matching already-bound vars, extend binding
+    if step.Literal is negative atom:
+        check that no row in step.Literal.Atom.Predicate matches current bindings
+    if step.Literal.Cmp != nil:
+        evaluate comparison with current bindings, keep or discard
+    if step.Literal.Agg != nil:
+        compute aggregate over its Body with current outer bindings, bind ResultVar
+```
+
+### PlannedAggregate
+
+```go
+type PlannedAggregate struct {
+    ResultRelation string        // variable name that holds result (from Agg.ResultVar.Name)
+    Agg            datalog.Aggregate
+    GroupByVars    []datalog.Var // head variables excluding the result variable
+}
+```
+
+The evaluator computes `Agg.Func` (count/min/max/sum/avg) over `Agg.Body` literals, grouped by `GroupByVars`, and stores results in the named relation/variable.
+
+### PlannedQuery
+
+After all strata are evaluated:
+
+```go
+if ep.Query != nil {
+    for each binding in evaluateJoinOrder(ep.Query.JoinOrder, db):
+        emit tuple [evaluate term t with binding for t in ep.Query.Select]
+}
+```
+
+---
+
+## Performance
+
+- **Stratification:** O(V+E) for Tarjan's SCC, plus O(R×L) for stratum propagation where R = number of rules and L = average body size. In practice, the propagation converges in 1-2 passes for typical programs.
+- **Join ordering:** O(n²) per rule where n = number of body literals. For typical rules (2-8 literals) this is negligible.
+- **Space:** O(V+E) for the dependency graph.
+
+## Known limitations
+
+- `JoinCols` in `JoinStep` is always empty in v1. For index-accelerated evaluation, the evaluator should compute this from variable positions at eval time.
+- Forall helper predicates (full double-negation encoding) are not generated by the desugarer — this is a known Phase 3b limitation.
+- Disjunction in rule bodies is approximated by the desugarer; the planner handles whatever rules it receives.

--- a/ql/plan/join.go
+++ b/ql/plan/join.go
@@ -1,0 +1,163 @@
+package plan
+
+import (
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+const defaultSizeHint = 1000
+
+// varsInTerm returns variable names referenced by a term.
+func varsInTerm(t datalog.Term) []string {
+	if v, ok := t.(datalog.Var); ok {
+		return []string{v.Name}
+	}
+	return nil
+}
+
+// varsInLiteral returns all variable names referenced in a literal.
+func varsInLiteral(lit datalog.Literal) []string {
+	var vs []string
+	if lit.Cmp != nil {
+		vs = append(vs, varsInTerm(lit.Cmp.Left)...)
+		vs = append(vs, varsInTerm(lit.Cmp.Right)...)
+		return vs
+	}
+	if lit.Agg != nil {
+		// Aggregate result variable is bound after placement.
+		if lit.Agg.ResultVar.Name != "" {
+			vs = append(vs, lit.Agg.ResultVar.Name)
+		}
+		return vs
+	}
+	for _, arg := range lit.Atom.Args {
+		vs = append(vs, varsInTerm(arg)...)
+	}
+	return vs
+}
+
+// isEligible returns true if lit can be placed given the currently bound variables.
+func isEligible(lit datalog.Literal, bound map[string]bool) bool {
+	if lit.Cmp != nil {
+		// Comparison is eligible when both operands are bound (or are constants).
+		leftVars := varsInTerm(lit.Cmp.Left)
+		rightVars := varsInTerm(lit.Cmp.Right)
+		for _, v := range leftVars {
+			if !bound[v] {
+				return false
+			}
+		}
+		for _, v := range rightVars {
+			if !bound[v] {
+				return false
+			}
+		}
+		return true
+	}
+	if lit.Agg != nil {
+		// Aggregate: eligible when all body literal vars used in the outer rule are bound.
+		// For now, aggregates are always eligible (their body is self-contained).
+		return true
+	}
+	if !lit.Positive {
+		// Negative literal: eligible only when all its variables are already bound.
+		for _, v := range varsInLiteral(lit) {
+			if !bound[v] {
+				return false
+			}
+		}
+		return true
+	}
+	return true // positive atoms are always eligible
+}
+
+// scoreLiteral returns a score for ordering: lower score = placed earlier.
+// We want most-bound-first and smallest relation first.
+func scoreLiteral(lit datalog.Literal, bound map[string]bool, sizeHints map[string]int) (boundCount int, size int) {
+	vars := varsInLiteral(lit)
+	for _, v := range vars {
+		if bound[v] {
+			boundCount++
+		}
+	}
+	// Higher bound count = better (placed earlier), so negate for "lower = earlier" convention.
+	// We return (negBound, size) and pick minimum.
+	relName := ""
+	if lit.Atom.Predicate != "" {
+		relName = lit.Atom.Predicate
+	}
+	sz, ok := sizeHints[relName]
+	if !ok || sz <= 0 {
+		sz = defaultSizeHint
+	}
+	return -boundCount, sz
+}
+
+// orderJoins implements greedy join ordering for a rule body.
+func orderJoins(body []datalog.Literal, sizeHints map[string]int) []JoinStep {
+	if len(body) == 0 {
+		return nil
+	}
+
+	bound := map[string]bool{}
+	placed := make([]bool, len(body))
+	steps := make([]JoinStep, 0, len(body))
+
+	for len(steps) < len(body) {
+		bestIdx := -1
+		bestNegBound := 0
+		bestSize := 0
+
+		for i, lit := range body {
+			if placed[i] {
+				continue
+			}
+			if !isEligible(lit, bound) {
+				continue
+			}
+			negBound, size := scoreLiteral(lit, bound, sizeHints)
+			if bestIdx == -1 || negBound < bestNegBound || (negBound == bestNegBound && size < bestSize) {
+				bestIdx = i
+				bestNegBound = negBound
+				bestSize = size
+			}
+		}
+
+		if bestIdx == -1 {
+			// No eligible literal found — this shouldn't happen for safe rules,
+			// but handle gracefully by placing the first unplaced literal.
+			for i, p := range placed {
+				if !p {
+					bestIdx = i
+					break
+				}
+			}
+		}
+
+		lit := body[bestIdx]
+		placed[bestIdx] = true
+
+		// Determine if this is a filter step (all vars already bound).
+		vars := varsInLiteral(lit)
+		allBound := true
+		for _, v := range vars {
+			if !bound[v] {
+				allBound = false
+				break
+			}
+		}
+
+		step := JoinStep{
+			Literal:  lit,
+			IsFilter: allBound && lit.Cmp == nil, // filters are non-comparison steps where all vars are bound
+		}
+
+		// Mark newly bound variables.
+		for _, v := range vars {
+			bound[v] = true
+		}
+
+		steps = append(steps, step)
+	}
+
+	return steps
+}

--- a/ql/plan/join_test.go
+++ b/ql/plan/join_test.go
@@ -1,0 +1,198 @@
+package plan_test
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// cmpLit creates a comparison literal.
+func cmpLit(op string, left, right string) datalog.Literal {
+	return datalog.Literal{
+		Positive: true,
+		Cmp: &datalog.Comparison{
+			Op:    op,
+			Left:  datalog.Var{Name: left},
+			Right: datalog.Var{Name: right},
+		},
+	}
+}
+
+// aggLit creates an aggregate literal with a result variable.
+func aggLit(fn, bodyPred, bodyVar, resultVar string) datalog.Literal {
+	return datalog.Literal{
+		Positive: true,
+		Agg: &datalog.Aggregate{
+			Func:      fn,
+			Var:       bodyVar,
+			TypeName:  "T",
+			Body:      []datalog.Literal{posLit(bodyPred, bodyVar)},
+			ResultVar: datalog.Var{Name: resultVar},
+		},
+	}
+}
+
+// TestJoinSingleLiteral: one literal → one step.
+func TestJoinSingleLiteral(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("P", "x"), posLit("A", "x")),
+		},
+	}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(ep.Strata) == 0 || len(ep.Strata[0].Rules) == 0 {
+		t.Fatal("no strata or rules")
+	}
+	r := ep.Strata[0].Rules[0]
+	if len(r.JoinOrder) != 1 {
+		t.Errorf("expected 1 join step, got %d", len(r.JoinOrder))
+	}
+	if r.JoinOrder[0].Literal.Atom.Predicate != "A" {
+		t.Errorf("expected step for A, got %s", r.JoinOrder[0].Literal.Atom.Predicate)
+	}
+}
+
+// TestJoinTwoLiteralsSharedVar: shared variable guides join order.
+func TestJoinTwoLiteralsSharedVar(t *testing.T) {
+	// P(x, y) :- A(x), B(x, y).
+	// A and B both eligible first; no size hints → default 1000 each → A placed first (first eligible),
+	// then B (x is now bound, one var bound).
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: atom("P", "x", "y"),
+				Body: []datalog.Literal{posLit("A", "x"), posLit("B", "x", "y")},
+			},
+		},
+	}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	r := ep.Strata[0].Rules[0]
+	if len(r.JoinOrder) != 2 {
+		t.Errorf("expected 2 join steps, got %d", len(r.JoinOrder))
+	}
+}
+
+// TestJoinThreeLiteralsGreedy: most-bound-first selection.
+func TestJoinThreeLiteralsGreedy(t *testing.T) {
+	// P(x, y, z) :- A(x), B(x, y), C(y, z).
+	// Start: A eligible (0 bound vars), B eligible (0), C eligible (0).
+	// Ties broken by size. All same size → A placed first (stable index).
+	// After A: x bound. B has 1 bound var (x), C has 0.
+	// B placed. After B: x, y bound. C has 1 bound var (y). C placed.
+	hints := map[string]int{"A": 10, "B": 100, "C": 50}
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: atom("P", "x", "y", "z"),
+				Body: []datalog.Literal{posLit("A", "x"), posLit("B", "x", "y"), posLit("C", "y", "z")},
+			},
+		},
+	}
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	r := ep.Strata[0].Rules[0]
+	if len(r.JoinOrder) != 3 {
+		t.Fatalf("expected 3 join steps, got %d", len(r.JoinOrder))
+	}
+	// A should be first (smallest size among tie of 0-bound-var relations).
+	if r.JoinOrder[0].Literal.Atom.Predicate != "A" {
+		t.Errorf("expected A first (smallest size), got %s", r.JoinOrder[0].Literal.Atom.Predicate)
+	}
+	// B second.
+	if r.JoinOrder[1].Literal.Atom.Predicate != "B" {
+		t.Errorf("expected B second, got %s", r.JoinOrder[1].Literal.Atom.Predicate)
+	}
+	// C last.
+	if r.JoinOrder[2].Literal.Atom.Predicate != "C" {
+		t.Errorf("expected C last, got %s", r.JoinOrder[2].Literal.Atom.Predicate)
+	}
+}
+
+// TestJoinSizeHintsTieBreaking: smaller relation placed first when bound counts tie.
+func TestJoinSizeHintsTieBreaking(t *testing.T) {
+	// P(x) :- BigRel(x), SmallRel(x).
+	// Both have x unbound initially; SmallRel has smaller hint → placed first.
+	hints := map[string]int{"BigRel": 9000, "SmallRel": 5}
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: atom("P", "x"),
+				Body: []datalog.Literal{posLit("BigRel", "x"), posLit("SmallRel", "x")},
+			},
+		},
+	}
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	r := ep.Strata[0].Rules[0]
+	if len(r.JoinOrder) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(r.JoinOrder))
+	}
+	if r.JoinOrder[0].Literal.Atom.Predicate != "SmallRel" {
+		t.Errorf("expected SmallRel first (smaller size), got %s", r.JoinOrder[0].Literal.Atom.Predicate)
+	}
+}
+
+// TestJoinComparisonPlacedAfterOperandsBound.
+func TestJoinComparisonPlacedAfterOperandsBound(t *testing.T) {
+	// P(x, y) :- A(x), B(y), x < y.
+	// Comparison x < y only eligible after both x and y are bound.
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: atom("P", "x", "y"),
+				Body: []datalog.Literal{posLit("A", "x"), posLit("B", "y"), cmpLit("<", "x", "y")},
+			},
+		},
+	}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	r := ep.Strata[0].Rules[0]
+	if len(r.JoinOrder) != 3 {
+		t.Fatalf("expected 3 steps, got %d", len(r.JoinOrder))
+	}
+	last := r.JoinOrder[2]
+	if last.Literal.Cmp == nil {
+		t.Errorf("expected comparison as last step, got atom %s", last.Literal.Atom.Predicate)
+	}
+}
+
+// TestJoinNegativeLiteralPlacedAfterVarsBound.
+func TestJoinNegativeLiteralPlacedAfterVarsBound(t *testing.T) {
+	// P(x) :- A(x), not B(x).
+	// not B(x) only eligible after x is bound.
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: atom("P", "x"),
+				Body: []datalog.Literal{posLit("A", "x"), negLit("B", "x")},
+			},
+		},
+	}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	r := ep.Strata[0].Rules[0]
+	if len(r.JoinOrder) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(r.JoinOrder))
+	}
+	if r.JoinOrder[0].Literal.Atom.Predicate != "A" {
+		t.Errorf("expected A first, got %s", r.JoinOrder[0].Literal.Atom.Predicate)
+	}
+	if r.JoinOrder[1].Literal.Positive {
+		t.Errorf("expected last step to be negative literal")
+	}
+}

--- a/ql/plan/join_test.go
+++ b/ql/plan/join_test.go
@@ -169,6 +169,36 @@ func TestJoinComparisonPlacedAfterOperandsBound(t *testing.T) {
 	}
 }
 
+// TestJoinOrderAggregateAfterPositives: aggregate literal is placed after positive literals.
+func TestJoinOrderAggregateAfterPositives(t *testing.T) {
+	// P(x, total) :- A(x), count<y : T(y)>(total).
+	// The positive literal A(x) should come before the aggregate literal.
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: atom("P", "x", "total"),
+				Body: []datalog.Literal{posLit("A", "x"), aggLit("count", "T", "y", "total")},
+			},
+		},
+	}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	r := ep.Strata[0].Rules[0]
+	if len(r.JoinOrder) != 2 {
+		t.Fatalf("expected 2 join steps, got %d", len(r.JoinOrder))
+	}
+	// Positive literal A should come first.
+	if r.JoinOrder[0].Literal.Atom.Predicate != "A" {
+		t.Errorf("expected A first, got %s", r.JoinOrder[0].Literal.Atom.Predicate)
+	}
+	// Aggregate literal should come second.
+	if r.JoinOrder[1].Literal.Agg == nil {
+		t.Errorf("expected aggregate as second step")
+	}
+}
+
 // TestJoinNegativeLiteralPlacedAfterVarsBound.
 func TestJoinNegativeLiteralPlacedAfterVarsBound(t *testing.T) {
 	// P(x) :- A(x), not B(x).

--- a/ql/plan/plan.go
+++ b/ql/plan/plan.go
@@ -1,2 +1,120 @@
 // Package plan implements stratification and join ordering over Datalog programs.
 package plan
+
+import (
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// ExecutionPlan is the output of the planner.
+type ExecutionPlan struct {
+	Strata []Stratum
+	Query  *PlannedQuery // nil if no select clause
+}
+
+// Stratum is a set of rules that can be evaluated together (same SCC or dependent group).
+type Stratum struct {
+	Rules      []PlannedRule
+	Aggregates []PlannedAggregate
+}
+
+// PlannedRule is a rule with a determined join order.
+type PlannedRule struct {
+	Head      datalog.Atom
+	JoinOrder []JoinStep
+}
+
+// JoinStep is one step in the join plan.
+type JoinStep struct {
+	Literal  datalog.Literal // the literal being joined (may be negative)
+	JoinCols [][2]int        // pairs of (bodyVar, headVar) positions — for index building
+	IsFilter bool            // true if this step filters (not a new relation scan)
+}
+
+// PlannedAggregate is an aggregate to evaluate after the stratum fixpoint.
+type PlannedAggregate struct {
+	ResultRelation string        // name of the relation that holds aggregate results
+	Agg            datalog.Aggregate
+	GroupByVars    []datalog.Var // variables that form the group key
+}
+
+// PlannedQuery is the select clause plan.
+type PlannedQuery struct {
+	Select    []datalog.Term
+	JoinOrder []JoinStep
+}
+
+// Plan produces an ExecutionPlan from a Datalog program.
+// sizeHints maps relation names to estimated tuple counts (for join ordering).
+// Unknown relations default to 1000.
+func Plan(prog *datalog.Program, sizeHints map[string]int) (*ExecutionPlan, []error) {
+	// Validate all rules first.
+	var errs []error
+	for _, rule := range prog.Rules {
+		if ruleErrs := ValidateRule(rule); len(ruleErrs) > 0 {
+			errs = append(errs, ruleErrs...)
+		}
+	}
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	// Build dependency graph and stratify.
+	strata, stratErrs := stratify(prog.Rules)
+	if len(stratErrs) > 0 {
+		return nil, stratErrs
+	}
+
+	if sizeHints == nil {
+		sizeHints = map[string]int{}
+	}
+
+	ep := &ExecutionPlan{}
+	for _, stratum := range strata {
+		ps := Stratum{}
+		for _, rule := range stratum {
+			order := orderJoins(rule.Body, sizeHints)
+			ps.Rules = append(ps.Rules, PlannedRule{
+				Head:      rule.Head,
+				JoinOrder: order,
+			})
+			// Collect aggregates from rule body.
+			for _, lit := range rule.Body {
+				if lit.Agg != nil {
+					ps.Aggregates = append(ps.Aggregates, PlannedAggregate{
+						ResultRelation: lit.Agg.ResultVar.Name,
+						Agg:            *lit.Agg,
+						GroupByVars:    collectGroupByVars(rule, lit.Agg),
+					})
+				}
+			}
+		}
+		ep.Strata = append(ep.Strata, ps)
+	}
+
+	// Plan the query.
+	if prog.Query != nil {
+		order := orderJoins(prog.Query.Body, sizeHints)
+		ep.Query = &PlannedQuery{
+			Select:    prog.Query.Select,
+			JoinOrder: order,
+		}
+	}
+
+	return ep, nil
+}
+
+// collectGroupByVars returns the head variables that are not the aggregate result variable.
+func collectGroupByVars(rule datalog.Rule, agg *datalog.Aggregate) []datalog.Var {
+	aggResultName := agg.ResultVar.Name
+	var groupBy []datalog.Var
+	seen := map[string]bool{}
+	for _, arg := range rule.Head.Args {
+		if v, ok := arg.(datalog.Var); ok {
+			if v.Name != aggResultName && !seen[v.Name] {
+				groupBy = append(groupBy, v)
+				seen[v.Name] = true
+			}
+		}
+	}
+	return groupBy
+}

--- a/ql/plan/plan.go
+++ b/ql/plan/plan.go
@@ -27,12 +27,16 @@ type PlannedRule struct {
 type JoinStep struct {
 	Literal  datalog.Literal // the literal being joined (may be negative)
 	JoinCols [][2]int        // pairs of (bodyVar, headVar) positions — for index building
-	IsFilter bool            // true if this step filters (not a new relation scan)
+	// IsFilter is true if all variables in Literal are already bound, meaning this step
+	// acts as a filter rather than introducing new bindings.
+	// Note: IsFilter=true on a negative literal (Literal.Positive==false) means anti-join,
+	// not positive membership filter. Callers must check Literal.Positive to distinguish.
+	IsFilter bool
 }
 
 // PlannedAggregate is an aggregate to evaluate after the stratum fixpoint.
 type PlannedAggregate struct {
-	ResultRelation string        // name of the relation that holds aggregate results
+	ResultRelation string // name of the relation that holds aggregate results
 	Agg            datalog.Aggregate
 	GroupByVars    []datalog.Var // variables that form the group key
 }

--- a/ql/plan/stratify.go
+++ b/ql/plan/stratify.go
@@ -1,0 +1,277 @@
+package plan
+
+import (
+	"fmt"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// edgeKind distinguishes positive and negative (or aggregate) dependencies.
+type edgeKind int
+
+const (
+	edgePositive edgeKind = iota
+	edgeNegative // negative literal or aggregate dependency
+)
+
+type depEdge struct {
+	to   string
+	kind edgeKind
+}
+
+// buildDepGraph builds the predicate dependency graph.
+// Returns: adjacency list (from → []depEdge), and the set of all predicates.
+func buildDepGraph(rules []datalog.Rule) (map[string][]depEdge, map[string]bool) {
+	adj := map[string][]depEdge{}
+	preds := map[string]bool{}
+
+	for _, rule := range rules {
+		head := rule.Head.Predicate
+		preds[head] = true
+		if _, ok := adj[head]; !ok {
+			adj[head] = nil
+		}
+		for _, lit := range rule.Body {
+			if lit.Cmp != nil {
+				continue // comparison — no predicate dependency
+			}
+			if lit.Agg != nil {
+				// Aggregate body predicates are negative-style dependencies.
+				for _, bodyLit := range lit.Agg.Body {
+					if bodyLit.Cmp != nil || bodyLit.Agg != nil {
+						continue
+					}
+					dep := bodyLit.Atom.Predicate
+					preds[dep] = true
+					adj[head] = append(adj[head], depEdge{to: dep, kind: edgeNegative})
+				}
+				continue
+			}
+			dep := lit.Atom.Predicate
+			preds[dep] = true
+			kind := edgePositive
+			if !lit.Positive {
+				kind = edgeNegative
+			}
+			adj[head] = append(adj[head], depEdge{to: dep, kind: kind})
+		}
+	}
+	return adj, preds
+}
+
+// tarjan implements Tarjan's SCC algorithm.
+type tarjanState struct {
+	index   int
+	stack   []string
+	onStack map[string]bool
+	indices map[string]int
+	lowlink map[string]int
+	sccs    [][]string
+}
+
+func tarjanSCCs(adj map[string][]depEdge, preds map[string]bool) [][]string {
+	ts := &tarjanState{
+		onStack: map[string]bool{},
+		indices: map[string]int{},
+		lowlink: map[string]int{},
+	}
+	for p := range preds {
+		if _, visited := ts.indices[p]; !visited {
+			ts.strongConnect(p, adj)
+		}
+	}
+	return ts.sccs
+}
+
+func (ts *tarjanState) strongConnect(v string, adj map[string][]depEdge) {
+	ts.indices[v] = ts.index
+	ts.lowlink[v] = ts.index
+	ts.index++
+	ts.stack = append(ts.stack, v)
+	ts.onStack[v] = true
+
+	for _, e := range adj[v] {
+		w := e.to
+		if _, visited := ts.indices[w]; !visited {
+			ts.strongConnect(w, adj)
+			if ts.lowlink[w] < ts.lowlink[v] {
+				ts.lowlink[v] = ts.lowlink[w]
+			}
+		} else if ts.onStack[w] {
+			if ts.indices[w] < ts.lowlink[v] {
+				ts.lowlink[v] = ts.indices[w]
+			}
+		}
+	}
+
+	if ts.lowlink[v] == ts.indices[v] {
+		// Pop SCC
+		var scc []string
+		for {
+			w := ts.stack[len(ts.stack)-1]
+			ts.stack = ts.stack[:len(ts.stack)-1]
+			ts.onStack[w] = false
+			scc = append(scc, w)
+			if w == v {
+				break
+			}
+		}
+		ts.sccs = append(ts.sccs, scc)
+	}
+}
+
+// stratify assigns rules to strata in evaluation order (dependencies first).
+// Returns strata as slices of rules, ordered so that each stratum's dependencies
+// are in earlier strata.
+func stratify(rules []datalog.Rule) ([][]datalog.Rule, []error) {
+	adj, preds := buildDepGraph(rules)
+	sccs := tarjanSCCs(adj, preds)
+
+	// Check for negation within SCCs (unstratifiable).
+	// Build a set for each SCC.
+	sccOf := map[string]int{} // predicate → SCC index
+	for i, scc := range sccs {
+		for _, p := range scc {
+			sccOf[p] = i
+		}
+	}
+
+	var errs []error
+	for _, scc := range sccs {
+		sccSet := map[string]bool{}
+		for _, p := range scc {
+			sccSet[p] = true
+		}
+		if len(scc) <= 1 {
+			// Self-loop check for single-node SCC.
+			p := scc[0]
+			for _, e := range adj[p] {
+				if e.to == p && e.kind == edgeNegative {
+					errs = append(errs, fmt.Errorf("unstratifiable: predicate %s has recursive negation", p))
+				}
+			}
+			continue
+		}
+		// Multi-node SCC: any negative edge within it is an error.
+		for _, p := range scc {
+			for _, e := range adj[p] {
+				if e.kind == edgeNegative && sccSet[e.to] {
+					errs = append(errs, fmt.Errorf("unstratifiable: predicate %s has recursive negation", p))
+				}
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	// Topological sort of SCCs.
+	// Tarjan's output is reverse topological order — dependencies come later in sccs.
+	// We want evaluation order: dependencies first, so reverse.
+	n := len(sccs)
+	ordered := make([][]string, n)
+	for i, scc := range sccs {
+		ordered[n-1-i] = scc
+	}
+
+	// Assign stratum numbers per SCC.
+	// Start with the topological order. For negative edges crossing SCC boundaries,
+	// ensure the dependency SCC has a strictly lower stratum than the using SCC.
+	sccIdx := map[string]int{} // SCC identifier (first pred) → index in ordered
+	sccOfPred := map[string]int{}
+	for i, scc := range ordered {
+		for _, p := range scc {
+			sccOfPred[p] = i
+		}
+	}
+
+	stratum := make([]int, n) // stratum number per ordered SCC index
+
+	// Propagate stratum numbers: for each rule, if the using predicate's SCC
+	// has a negative edge to a dependency SCC, the dep must have a stratum
+	// strictly less than the using SCC.
+	// We do a simple iterative pass.
+	changed := true
+	for changed {
+		changed = false
+		for _, rule := range rules {
+			head := rule.Head.Predicate
+			headSCC := sccOfPred[head]
+			for _, lit := range rule.Body {
+				if lit.Cmp != nil {
+					continue
+				}
+				if lit.Agg != nil {
+					for _, bodyLit := range lit.Agg.Body {
+						if bodyLit.Cmp != nil || bodyLit.Agg != nil {
+							continue
+						}
+						depPred := bodyLit.Atom.Predicate
+						depSCC := sccOfPred[depPred]
+						if depSCC != headSCC && stratum[headSCC] <= stratum[depSCC] {
+							stratum[headSCC] = stratum[depSCC] + 1
+							changed = true
+						}
+					}
+					continue
+				}
+				depPred := lit.Atom.Predicate
+				depSCC := sccOfPred[depPred]
+				if depSCC == headSCC {
+					continue
+				}
+				if !lit.Positive {
+					// Negative dependency: dep must be strictly lower.
+					if stratum[headSCC] <= stratum[depSCC] {
+						stratum[headSCC] = stratum[depSCC] + 1
+						changed = true
+					}
+				} else {
+					// Positive dependency: dep must be <= (at most equal).
+					if stratum[headSCC] < stratum[depSCC] {
+						stratum[headSCC] = stratum[depSCC]
+						changed = true
+					}
+				}
+			}
+		}
+	}
+
+	// Group SCCs by stratum number, then sort by stratum.
+	maxStratum := 0
+	for _, s := range stratum {
+		if s > maxStratum {
+			maxStratum = s
+		}
+	}
+
+	// Build predicate → stratum map.
+	predStratum := map[string]int{}
+	for i, scc := range ordered {
+		for _, p := range scc {
+			predStratum[p] = stratum[i]
+		}
+	}
+
+	// Group rules by stratum.
+	stratumRules := make([][]datalog.Rule, maxStratum+1)
+	for _, rule := range rules {
+		s := predStratum[rule.Head.Predicate]
+		stratumRules[s] = append(stratumRules[s], rule)
+	}
+
+	// Remove empty strata.
+	var result [][]datalog.Rule
+	for _, sr := range stratumRules {
+		if len(sr) > 0 {
+			result = append(result, sr)
+		}
+	}
+
+	// Predicates that only appear in bodies (base facts) → stratum 0.
+	// They don't have rules, so they're implicitly at stratum 0. No action needed.
+
+	_ = sccIdx // silence unused warning
+
+	return result, nil
+}

--- a/ql/plan/stratify.go
+++ b/ql/plan/stratify.go
@@ -11,7 +11,7 @@ type edgeKind int
 
 const (
 	edgePositive edgeKind = iota
-	edgeNegative // negative literal or aggregate dependency
+	edgeNegative          // negative literal or aggregate dependency
 )
 
 type depEdge struct {
@@ -177,7 +177,6 @@ func stratify(rules []datalog.Rule) ([][]datalog.Rule, []error) {
 	// Assign stratum numbers per SCC.
 	// Start with the topological order. For negative edges crossing SCC boundaries,
 	// ensure the dependency SCC has a strictly lower stratum than the using SCC.
-	sccIdx := map[string]int{} // SCC identifier (first pred) → index in ordered
 	sccOfPred := map[string]int{}
 	for i, scc := range ordered {
 		for _, p := range scc {
@@ -270,8 +269,6 @@ func stratify(rules []datalog.Rule) ([][]datalog.Rule, []error) {
 
 	// Predicates that only appear in bodies (base facts) → stratum 0.
 	// They don't have rules, so they're implicitly at stratum 0. No action needed.
-
-	_ = sccIdx // silence unused warning
 
 	return result, nil
 }

--- a/ql/plan/stratify_test.go
+++ b/ql/plan/stratify_test.go
@@ -187,10 +187,10 @@ func TestStratifyAggregateTreatedLikeNegation(t *testing.T) {
 	aggLit := datalog.Literal{
 		Positive: true,
 		Agg: &datalog.Aggregate{
-			Func:     "count",
-			Var:      "x",
-			TypeName: "T",
-			Body:     []datalog.Literal{posLit("Q", "x")},
+			Func:      "count",
+			Var:       "x",
+			TypeName:  "T",
+			Body:      []datalog.Literal{posLit("Q", "x")},
 			ResultVar: datalog.Var{Name: "_v1"},
 		},
 	}

--- a/ql/plan/stratify_test.go
+++ b/ql/plan/stratify_test.go
@@ -1,0 +1,250 @@
+package plan_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+func atom(pred string, vars ...string) datalog.Atom {
+	args := make([]datalog.Term, len(vars))
+	for i, v := range vars {
+		args[i] = datalog.Var{Name: v}
+	}
+	return datalog.Atom{Predicate: pred, Args: args}
+}
+
+func posLit(pred string, vars ...string) datalog.Literal {
+	return datalog.Literal{Positive: true, Atom: atom(pred, vars...)}
+}
+
+func negLit(pred string, vars ...string) datalog.Literal {
+	return datalog.Literal{Positive: false, Atom: atom(pred, vars...)}
+}
+
+func rule(head datalog.Atom, body ...datalog.Literal) datalog.Rule {
+	return datalog.Rule{Head: head, Body: body}
+}
+
+// TestStratifySinglePredicate: one predicate with a single recursive rule → 1 stratum.
+func TestStratifySinglePredicate(t *testing.T) {
+	// R(x) :- R(x).  — positive self-recursion, fine for stratification.
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("R", "x"), posLit("R", "x")),
+		},
+	}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(ep.Strata) != 1 {
+		t.Errorf("expected 1 stratum, got %d", len(ep.Strata))
+	}
+}
+
+// TestStratifyTwoPredicates: P uses Q → Q in earlier stratum.
+func TestStratifyTwoPredicates(t *testing.T) {
+	// Q(x) :- base(x).
+	// P(x) :- Q(x).
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("Q", "x"), posLit("base", "x")),
+			rule(atom("P", "x"), posLit("Q", "x")),
+		},
+	}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	// P must come after Q — at least 2 strata, or same stratum but P's rule after Q's.
+	// Since P depends on Q (positive), they can be in same stratum or P later.
+	// We just check both rules appear.
+	total := 0
+	for _, s := range ep.Strata {
+		total += len(s.Rules)
+	}
+	if total != 2 {
+		t.Errorf("expected 2 rules total across strata, got %d", total)
+	}
+	// Q must not be in a later stratum than P.
+	qStratum := -1
+	pStratum := -1
+	for i, s := range ep.Strata {
+		for _, r := range s.Rules {
+			if r.Head.Predicate == "Q" {
+				qStratum = i
+			}
+			if r.Head.Predicate == "P" {
+				pStratum = i
+			}
+		}
+	}
+	if qStratum > pStratum {
+		t.Errorf("Q (stratum %d) should not be after P (stratum %d)", qStratum, pStratum)
+	}
+}
+
+// TestStratifyMutualRecursion: P↔Q positive → same stratum.
+func TestStratifyMutualRecursion(t *testing.T) {
+	// P(x) :- Q(x).
+	// Q(x) :- P(x).
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("P", "x"), posLit("Q", "x")),
+			rule(atom("Q", "x"), posLit("P", "x")),
+		},
+	}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	// Both in the same stratum.
+	if len(ep.Strata) != 1 {
+		t.Errorf("expected 1 stratum for mutual recursion, got %d", len(ep.Strata))
+	}
+}
+
+// TestStratifyNegation: P uses not Q → Q's stratum < P's stratum.
+func TestStratifyNegation(t *testing.T) {
+	// Q(x) :- base(x).
+	// P(x) :- base(x), not Q(x).
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("Q", "x"), posLit("base", "x")),
+			rule(atom("P", "x"), posLit("base", "x"), negLit("Q", "x")),
+		},
+	}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	qStratum := -1
+	pStratum := -1
+	for i, s := range ep.Strata {
+		for _, r := range s.Rules {
+			if r.Head.Predicate == "Q" {
+				qStratum = i
+			}
+			if r.Head.Predicate == "P" {
+				pStratum = i
+			}
+		}
+	}
+	if qStratum == -1 || pStratum == -1 {
+		t.Fatalf("could not find Q (stratum %d) or P (stratum %d)", qStratum, pStratum)
+	}
+	if qStratum >= pStratum {
+		t.Errorf("Q (stratum %d) must be strictly before P (stratum %d) due to negation", qStratum, pStratum)
+	}
+}
+
+// TestStratifyNegationWithinSCC: P uses not P → error.
+func TestStratifyNegationWithinSCC(t *testing.T) {
+	// P(x) :- base(x), not P(x).  — recursive negation
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("P", "x"), posLit("base", "x"), negLit("P", "x")),
+		},
+	}
+	_, errs := plan.Plan(prog, nil)
+	if len(errs) == 0 {
+		t.Fatal("expected stratification error for recursive negation, got none")
+	}
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "unstratifiable") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'unstratifiable' error, got: %v", errs)
+	}
+}
+
+// TestStratifyMutualNegation: P uses not Q and Q uses not P → error (unstratifiable).
+func TestStratifyMutualNegation(t *testing.T) {
+	// P(x) :- base(x), not Q(x).
+	// Q(x) :- base(x), not P(x).
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("P", "x"), posLit("base", "x"), negLit("Q", "x")),
+			rule(atom("Q", "x"), posLit("base", "x"), negLit("P", "x")),
+		},
+	}
+	_, errs := plan.Plan(prog, nil)
+	if len(errs) == 0 {
+		t.Fatal("expected stratification error for mutual negation, got none")
+	}
+}
+
+// TestStratifyAggregateTreatedLikeNegation: aggregate body predicate → strict stratum ordering.
+func TestStratifyAggregateTreatedLikeNegation(t *testing.T) {
+	// Q(x) :- base(x).
+	// P(n) :- count(x | Q(x)) = n.
+	aggLit := datalog.Literal{
+		Positive: true,
+		Agg: &datalog.Aggregate{
+			Func:     "count",
+			Var:      "x",
+			TypeName: "T",
+			Body:     []datalog.Literal{posLit("Q", "x")},
+			ResultVar: datalog.Var{Name: "_v1"},
+		},
+	}
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("Q", "x"), posLit("base", "x")),
+			{
+				Head: atom("P", "_v1"),
+				Body: []datalog.Literal{aggLit},
+			},
+		},
+	}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	qStratum := -1
+	pStratum := -1
+	for i, s := range ep.Strata {
+		for _, r := range s.Rules {
+			if r.Head.Predicate == "Q" {
+				qStratum = i
+			}
+			if r.Head.Predicate == "P" {
+				pStratum = i
+			}
+		}
+	}
+	if qStratum == -1 || pStratum == -1 {
+		t.Fatalf("could not find Q or P in strata")
+	}
+	if qStratum >= pStratum {
+		t.Errorf("Q (stratum %d) must be strictly before P (stratum %d) due to aggregate", qStratum, pStratum)
+	}
+}
+
+// TestStratifyBaseFacts: predicates only in bodies → effectively stratum 0 (no rules for them).
+func TestStratifyBaseFacts(t *testing.T) {
+	// P(x) :- base(x).  — 'base' is a fact relation with no rules.
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("P", "x"), posLit("base", "x")),
+		},
+	}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	// Only P has a rule — 'base' has no rules so it doesn't appear in any stratum.
+	for _, s := range ep.Strata {
+		for _, r := range s.Rules {
+			if r.Head.Predicate == "base" {
+				t.Error("'base' should not appear as a rule head in any stratum")
+			}
+		}
+	}
+}

--- a/ql/plan/validate.go
+++ b/ql/plan/validate.go
@@ -1,0 +1,63 @@
+package plan
+
+import (
+	"fmt"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// ValidateRule checks safety conditions for a single Datalog rule.
+// Every variable in the head must appear in at least one positive body literal.
+// Every variable in a negative literal must appear in a positive literal in the same body.
+func ValidateRule(rule datalog.Rule) []error {
+	var errs []error
+
+	// Collect variables bound by positive body literals and aggregate result vars.
+	positiveVars := map[string]bool{}
+	for _, lit := range rule.Body {
+		if lit.Cmp != nil {
+			continue
+		}
+		if lit.Agg != nil {
+			// The aggregate result variable is bound by the aggregate.
+			if lit.Agg.ResultVar.Name != "" {
+				positiveVars[lit.Agg.ResultVar.Name] = true
+			}
+			continue
+		}
+		if lit.Positive {
+			for _, arg := range lit.Atom.Args {
+				if v, ok := arg.(datalog.Var); ok {
+					positiveVars[v.Name] = true
+				}
+			}
+		}
+	}
+
+	// Check head variables.
+	for _, arg := range rule.Head.Args {
+		if v, ok := arg.(datalog.Var); ok {
+			if !positiveVars[v.Name] {
+				errs = append(errs, fmt.Errorf("unsafe rule: head variable %q does not appear in any positive body literal (predicate %s)", v.Name, rule.Head.Predicate))
+			}
+		}
+	}
+
+	// Check negative literal variables.
+	for _, lit := range rule.Body {
+		if lit.Cmp != nil || lit.Agg != nil {
+			continue
+		}
+		if !lit.Positive {
+			for _, arg := range lit.Atom.Args {
+				if v, ok := arg.(datalog.Var); ok {
+					if !positiveVars[v.Name] {
+						errs = append(errs, fmt.Errorf("unsafe rule: variable %q in negative literal %s does not appear in any positive body literal", v.Name, lit.Atom.Predicate))
+					}
+				}
+			}
+		}
+	}
+
+	return errs
+}

--- a/ql/plan/validate_test.go
+++ b/ql/plan/validate_test.go
@@ -1,0 +1,94 @@
+package plan_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// TestValidateUnsafeHeadVariable: variable in head not in positive body → error.
+func TestValidateUnsafeHeadVariable(t *testing.T) {
+	// P(x, y) :- A(x).  — y is in head but not in any positive body literal.
+	r := datalog.Rule{
+		Head: atom("P", "x", "y"),
+		Body: []datalog.Literal{posLit("A", "x")},
+	}
+	errs := plan.ValidateRule(r)
+	if len(errs) == 0 {
+		t.Fatal("expected error for unsafe head variable, got none")
+	}
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "y") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error mentioning 'y', got: %v", errs)
+	}
+}
+
+// TestValidateUnsafeNegationVariable: variable in negative literal not in positive body → error.
+func TestValidateUnsafeNegationVariable(t *testing.T) {
+	// P(x) :- A(x), not B(z).  — z only appears in negation.
+	r := datalog.Rule{
+		Head: atom("P", "x"),
+		Body: []datalog.Literal{posLit("A", "x"), negLit("B", "z")},
+	}
+	errs := plan.ValidateRule(r)
+	if len(errs) == 0 {
+		t.Fatal("expected error for unsafe negation variable, got none")
+	}
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "z") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error mentioning 'z', got: %v", errs)
+	}
+}
+
+// TestValidateValidRule: properly safe rule → no errors.
+func TestValidateValidRule(t *testing.T) {
+	// P(x, y) :- A(x, y), not B(x).
+	r := datalog.Rule{
+		Head: atom("P", "x", "y"),
+		Body: []datalog.Literal{
+			{Positive: true, Atom: atom("A", "x", "y")},
+			negLit("B", "x"),
+		},
+	}
+	errs := plan.ValidateRule(r)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for safe rule, got: %v", errs)
+	}
+}
+
+// TestValidateFactRule: head with no body → head vars must appear in body (empty body → error if vars present).
+func TestValidateFactRuleNoBody(t *testing.T) {
+	// P(x) :- (no body) — x is unsafe.
+	r := datalog.Rule{
+		Head: atom("P", "x"),
+		Body: nil,
+	}
+	errs := plan.ValidateRule(r)
+	if len(errs) == 0 {
+		t.Fatal("expected error for head variable with no body, got none")
+	}
+}
+
+// TestValidateGroundFact: P() :- (no body) — nullary head, no vars → valid.
+func TestValidateGroundFact(t *testing.T) {
+	r := datalog.Rule{
+		Head: datalog.Atom{Predicate: "P", Args: nil},
+		Body: nil,
+	}
+	errs := plan.ValidateRule(r)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for ground fact, got: %v", errs)
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `ql/plan` package: Tarjan SCC stratification, greedy join ordering, and rule safety validation
- Produces `ExecutionPlan` (strata of `PlannedRule`s with `JoinStep` sequences) from `datalog.Program`
- 20 tests across stratify, join, and validate covering all specified cases

## Stratification

Tarjan's SCC algorithm (O(V+E)) followed by iterative stratum propagation. Positive dependencies allow same stratum; negative/aggregate dependencies force strictly later stratum. Negation within an SCC → `"unstratifiable: predicate X has recursive negation"` error.

## Join ordering

Greedy: at each step, pick the most-bound-var literal; ties broken by size hint (default 1000). Negative literals deferred until all their variables are bound. Comparisons deferred until both operands are bound.

## Validation

`ValidateRule` checks: every head variable must appear in a positive body literal; every variable in a negative literal must appear in a positive literal. Aggregate result variables count as bound.

## What's next (Phase 5 — Evaluator)

- Iterate `ep.Strata` in order; run semi-naive fixpoint per stratum
- Execute `PlannedRule.JoinOrder` as a nested-loop join over the binding map
- After stratum fixpoint, evaluate `Stratum.Aggregates`
- After all strata, evaluate `ep.Query` and emit `Select` terms

Full evaluator contract in `HANDOVER-phase-4.md`.