### PR TITLE
Phase 5: Semi-naive evaluator

### DIFF
--- a/HANDOVER-phase-5.md
+++ b/HANDOVER-phase-5.md
@@ -1,0 +1,147 @@
+# Phase 5 Handover: Semi-Naive Evaluator
+
+## What was implemented
+
+Six files in `ql/eval/`:
+
+- `relation.go` — `Value`, `Tuple`, `Relation`, `HashIndex` types
+- `builtin.go` — `EvalComparison`, `EvalArithmetic`, `ValueToString`
+- `join.go` — `EvalRule`, `EvalRuleDelta`, and the join execution internals
+- `aggregate.go` — `EvalAggregate` and `evalLiterals`
+- `seminaive.go` — `Evaluate` (semi-naive fixpoint loop), `ResultSet`
+- `eval.go` — `Evaluator`, `NewEvaluator`, `loadBaseRelations`
+
+Five test files covering all components, including the transitive closure correctness test.
+
+---
+
+## Semi-Naive Algorithm — Worked Example
+
+**Problem:** Transitive closure of a 5-node chain.
+
+```
+Edge(1,2). Edge(2,3). Edge(3,4). Edge(4,5).
+Path(x,y) :- Edge(x,y).
+Path(x,z) :- Edge(x,y), Path(y,z).
+```
+
+**Bootstrap (iteration 0 — EvalRule):**
+
+Both rules are evaluated using all available relations. `Path` doesn't exist yet so the recursive rule produces nothing. After bootstrap:
+```
+Path = {(1,2),(2,3),(3,4),(4,5)}
+ΔPath = {(1,2),(2,3),(3,4),(4,5)}
+```
+
+**Iteration 1 (EvalRuleDelta — delta rule for recursive rule):**
+
+We generate one "delta variant" per body literal that has a non-empty delta. The recursive rule has `Edge(x,y)` and `Path(y,z)`. The delta for `Path` is non-empty; Edge has no delta (it's a base fact). So we use the `Path` delta only:
+
+```
+For each (x,y) in Edge, look up (y,z) in ΔPath:
+  Edge(1,2), ΔPath(2,3) → Path(1,3) [new]
+  Edge(2,3), ΔPath(3,4) → Path(2,4) [new]
+  Edge(3,4), ΔPath(4,5) → Path(3,5) [new]
+  Edge(4,5), ΔPath: no match
+```
+
+New: `ΔPath = {(1,3),(2,4),(3,5)}`
+
+**Iteration 2:**
+```
+Edge(1,2), ΔPath(2,4) → Path(1,4) [new]
+Edge(2,3), ΔPath(3,5) → Path(2,5) [new]
+Edge(3,4), ΔPath(4,...): no match
+Edge(4,5), ΔPath: no match
+```
+
+New: `ΔPath = {(1,4),(2,5)}`
+
+**Iteration 3:**
+```
+Edge(1,2), ΔPath(2,5) → Path(1,5) [new]
+Others: no new tuples.
+```
+
+New: `ΔPath = {(1,5)}`
+
+**Iteration 4:**
+```
+Edge(1,2), ΔPath(1,5): 5 ≠ 2, no join match
+Others: no new tuples.
+```
+
+`ΔPath = {}`. Fixpoint reached. Final `Path` has 10 tuples — all (i,j) reachable pairs.
+
+**Why semi-naive is correct:** At each iteration, at least one body literal uses the delta — ensuring we only process newly added tuples. This avoids re-deriving the same tuples via the same derivation path (which naïve evaluation would do), while the full relations for other body literals ensure we don't miss combinations involving older tuples.
+
+---
+
+## Index Strategy
+
+**Type:** Hash index (map from encoded key to list of tuple indices).
+
+**Key encoding:** `partialKey(tuple, cols)` — encodes values of the specified columns using type tags (`i` for IntVal, `s` for StrVal) and `\x00` as a separator. The `\x00` separator is safe because `\x00` is not a valid UTF-8 character in normal strings.
+
+**Index key for Lookup:** `Lookup([]Value)` takes a slice of values (one per indexed column in order). It re-encodes these using sequential indices (0, 1, 2...) to produce the same key format as the builder.
+
+**Lazy construction:** Indexes are built on first access via `Relation.Index(cols)`. After construction, new tuples added via `Relation.Add()` are incrementally inserted into all existing indexes — so an index fetched before `Add` calls remains consistent.
+
+**Multi-column indexes:** The column bitmask is used as the map key in `Relation.indexes`. Columns are identified by bitmask (uint64), so up to 64 columns are supported. For more than 64 columns, the bitmask would alias — a v1 limitation.
+
+**When indexes are used:**
+- Positive literals with at least one bound argument use the index for that column set.
+- Positive literals with no bound arguments (full scan) iterate all tuples linearly.
+- Negative literals (anti-join) use the index to check for existence; if any match is found, the binding is pruned.
+
+---
+
+## Memory Characteristics
+
+- **Tuples:** Stored as `[]Tuple` (slice of `[]Value` slices). No sharing between tuples.
+- **Deduplication set:** `map[string]struct{}` keyed by the full tuple encoding. Grows linearly with the number of unique tuples.
+- **Indexes:** `map[string][]int` per index. The int slices accumulate tuple indices; on large relations they can be significant (O(n) per index per column set).
+- **Delta relations:** Separate `Relation` objects (same structure). At any time the working set is: full relations + current delta relations. After each fixpoint iteration the previous delta is discarded.
+- **Strings:** Loaded from the DB as Go strings (no interning at the eval layer). Each `StrVal` holds a reference-counted Go string.
+
+**Estimate:** A relation with n tuples and k columns uses O(n·k) for tuples, O(n) for the dedup set (key length ≈ k·avg_value_size), and O(n·i) for i indexes. For typical Datalog queries over a 100k-node TypeScript project (fact DB ~50MB), the working set is 100-500MB depending on query complexity.
+
+---
+
+## What Phase 6 (Bridge) Needs
+
+Phase 6 is the bridge layer — `.qll` files that map fact schema relations to QL predicates. The evaluator is already bridge-agnostic: it evaluates whatever Datalog rules it receives. The bridge doesn't need anything new from the evaluator.
+
+**However**, Phase 6 needs to:
+1. Produce `*datalog.Program` instances that the planner (Phase 4) can stratify and order.
+2. Trust that the evaluator will load base relations from the DB by their schema names — these must match the relation names used in the bridge's Datalog rules.
+
+## What Phase 7 (CLI) Needs
+
+Phase 7 is the CLI entry point. It needs:
+
+1. **`eval.NewEvaluator(execPlan, factDB)`** — takes a `*plan.ExecutionPlan` and a `*db.DB`. The `*db.DB` is obtained by reading a fact DB file with `db.ReadDB`.
+2. **`evaluator.Evaluate(ctx)`** — returns `(*eval.ResultSet, error)`.
+3. **`ResultSet.Columns []string`** — column names for output headers.
+4. **`ResultSet.Rows [][]Value`** — rows; each `Value` is either `IntVal` or `StrVal`.
+5. **`eval.ValueToString(v)`** — for serialising values to CSV/JSON/SARIF.
+
+The pipeline from CLI perspective:
+```
+[.ql source] → parse → resolve → desugar → plan → eval.NewEvaluator → Evaluate → ResultSet
+[fact DB file] ─────────────────────────────────────────────────────→ (loaded inside Evaluate)
+```
+
+Size hints for the planner can be obtained from the DB by calling `factDB.Relation(name).Tuples()` for each relation name before planning.
+
+---
+
+## Known Limitations (v1)
+
+- **Aggregate body is evaluated without planner ordering** (`evalLiterals` in aggregate.go does a naive left-to-right scan, not planner-ordered). This is correct but potentially slow for complex aggregate bodies. Phase 6/7 can fix by pre-planning aggregate bodies.
+- **EvalRuleDelta generates one variant per body literal** — the full semi-naive expansion. For rules with many body literals, this is O(n) variants per rule per iteration. In practice, most rules have 2-5 body literals; this is negligible.
+- **Arithmetic evaluation in rules** is not yet wired (EvalArithmetic exists but is not called from the join engine — arithmetic terms in atoms are not supported). The comparison engine (EvalComparison) is fully wired.
+- **Column bitmask for indexes** uses uint64 — relations with >64 columns would alias. All current fact relations have ≤7 columns.
+- **String separator** (`\x00`) is assumed safe. If a StrVal contains `\x00`, key collisions could occur. All current fact schema strings come from source code identifiers and paths, which don't contain `\x00`.
+
+PR: https://github.com/Gjdoalfnrxu/tsq/pull/10

--- a/ql/eval/aggregate.go
+++ b/ql/eval/aggregate.go
@@ -1,0 +1,205 @@
+package eval
+
+import (
+	"fmt"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// EvalAggregate evaluates a planned aggregate and returns the result relation.
+// The result relation is named agg.ResultRelation and contains
+// (groupKey..., aggregatedValue) tuples.
+func EvalAggregate(agg plan.PlannedAggregate, rels map[string]*Relation) *Relation {
+	// Compute bindings over the aggregate body using raw literals (no planner ordering).
+	bindings := evalLiterals(agg.Agg.Body, rels)
+
+	// Determine which column holds the aggregated value.
+	aggVar := agg.Agg.Var
+	aggExpr := agg.Agg.Expr // may be nil (count doesn't need it)
+
+	// Group bindings by groupBy key.
+	type group struct {
+		key    []Value
+		values []Value // the aggregated values within this group
+	}
+	groupMap := make(map[string]*group)
+	groupOrder := []string{} // preserve insertion order
+
+	for _, b := range bindings {
+		// Build group key.
+		key := make([]Value, len(agg.GroupByVars))
+		valid := true
+		for i, gv := range agg.GroupByVars {
+			v, ok := b[gv.Name]
+			if !ok {
+				valid = false
+				break
+			}
+			key[i] = v
+		}
+		if !valid {
+			continue
+		}
+		gk := tupleKey(Tuple(key))
+
+		// Get the aggregated value.
+		var aggVal Value
+		if aggExpr != nil {
+			v, ok := lookupTerm(aggExpr, b)
+			if !ok {
+				// Try using the aggregate variable directly.
+				v, ok = b[aggVar]
+				if !ok {
+					continue
+				}
+			}
+			aggVal = v
+		} else {
+			// For count: use the aggregate variable binding.
+			v, ok := b[aggVar]
+			if !ok {
+				continue
+			}
+			aggVal = v
+		}
+
+		g, exists := groupMap[gk]
+		if !exists {
+			g = &group{key: key}
+			groupMap[gk] = g
+			groupOrder = append(groupOrder, gk)
+		}
+		g.values = append(g.values, aggVal)
+	}
+
+	// Compute aggregate per group.
+	arity := len(agg.GroupByVars) + 1
+	result := NewRelation(agg.ResultRelation, arity)
+
+	for _, gk := range groupOrder {
+		g := groupMap[gk]
+		aggResult, err := computeAggregate(agg.Agg.Func, g.values)
+		if err != nil {
+			// Skip groups where aggregation fails (e.g., mixed types).
+			continue
+		}
+		t := make(Tuple, arity)
+		copy(t, g.key)
+		t[arity-1] = aggResult
+		result.Add(t)
+	}
+
+	return result
+}
+
+// computeAggregate applies the named aggregate function to a list of Values.
+func computeAggregate(fn string, vals []Value) (Value, error) {
+	if len(vals) == 0 {
+		switch fn {
+		case "count":
+			return IntVal{V: 0}, nil
+		default:
+			return nil, fmt.Errorf("aggregate %q over empty set", fn)
+		}
+	}
+
+	switch fn {
+	case "count":
+		return IntVal{V: int64(len(vals))}, nil
+
+	case "min":
+		result, err := asInt64(vals[0])
+		if err != nil {
+			return nil, fmt.Errorf("min: %w", err)
+		}
+		for _, v := range vals[1:] {
+			iv, err := asInt64(v)
+			if err != nil {
+				return nil, fmt.Errorf("min: %w", err)
+			}
+			if iv < result {
+				result = iv
+			}
+		}
+		return IntVal{V: result}, nil
+
+	case "max":
+		result, err := asInt64(vals[0])
+		if err != nil {
+			return nil, fmt.Errorf("max: %w", err)
+		}
+		for _, v := range vals[1:] {
+			iv, err := asInt64(v)
+			if err != nil {
+				return nil, fmt.Errorf("max: %w", err)
+			}
+			if iv > result {
+				result = iv
+			}
+		}
+		return IntVal{V: result}, nil
+
+	case "sum":
+		var sum int64
+		for _, v := range vals {
+			iv, err := asInt64(v)
+			if err != nil {
+				return nil, fmt.Errorf("sum: %w", err)
+			}
+			sum += iv
+		}
+		return IntVal{V: sum}, nil
+
+	case "avg":
+		var sum int64
+		for _, v := range vals {
+			iv, err := asInt64(v)
+			if err != nil {
+				return nil, fmt.Errorf("avg: %w", err)
+			}
+			sum += iv
+		}
+		return IntVal{V: sum / int64(len(vals))}, nil
+
+	case "rank":
+		// Ordinal rank — return position in group (1-indexed).
+		// For a simple implementation, rank is just the count of values seen.
+		// Full rank-within-group-by-order is more complex; this is the v1 approximation.
+		return IntVal{V: int64(len(vals))}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown aggregate function %q", fn)
+	}
+}
+
+func asInt64(v Value) (int64, error) {
+	iv, ok := v.(IntVal)
+	if !ok {
+		return 0, fmt.Errorf("expected IntVal, got %T (%v)", v, v)
+	}
+	return iv.V, nil
+}
+
+// evalLiterals evaluates a sequence of Datalog literals (from an aggregate
+// body) naively, returning all resulting bindings.
+// This mirrors evalJoinSteps but works on []datalog.Literal directly,
+// without planner-ordered JoinSteps.
+func evalLiterals(lits []datalog.Literal, rels map[string]*Relation) []binding {
+	current := []binding{make(binding)}
+	for _, lit := range lits {
+		if len(current) == 0 {
+			return nil
+		}
+		if lit.Cmp != nil {
+			current = applyComparison(lit.Cmp, current)
+		} else if lit.Agg != nil {
+			// Nested aggregate in body — skip for v1.
+		} else if lit.Positive {
+			current = applyPositive(lit.Atom, rels, current)
+		} else {
+			current = applyNegative(lit.Atom, rels, current)
+		}
+	}
+	return current
+}

--- a/ql/eval/aggregate.go
+++ b/ql/eval/aggregate.go
@@ -7,10 +7,10 @@ import (
 	"github.com/Gjdoalfnrxu/tsq/ql/plan"
 )
 
-// EvalAggregate evaluates a planned aggregate and returns the result relation.
+// Aggregate evaluates a planned aggregate and returns the result relation.
 // The result relation is named agg.ResultRelation and contains
 // (groupKey..., aggregatedValue) tuples.
-func EvalAggregate(agg plan.PlannedAggregate, rels map[string]*Relation) *Relation {
+func Aggregate(agg plan.PlannedAggregate, rels map[string]*Relation) *Relation {
 	// Compute bindings over the aggregate body using raw literals (no planner ordering).
 	bindings := evalLiterals(agg.Agg.Body, rels)
 

--- a/ql/eval/aggregate_test.go
+++ b/ql/eval/aggregate_test.go
@@ -57,7 +57,7 @@ func TestAggCount(t *testing.T) {
 	rels := map[string]*Relation{"R": rel}
 
 	agg := makeAgg("R", "v", []string{"g"}, "count", "cnt")
-	result := EvalAggregate(agg, rels)
+	result := Aggregate(agg, rels)
 
 	if result.Len() != 2 {
 		t.Fatalf("expected 2 groups, got %d", result.Len())
@@ -83,7 +83,7 @@ func TestAggCountNoGroup(t *testing.T) {
 	rels := map[string]*Relation{"R": rel}
 
 	agg := makeAgg("R", "x", nil, "count", "cnt")
-	result := EvalAggregate(agg, rels)
+	result := Aggregate(agg, rels)
 
 	if result.Len() != 1 {
 		t.Fatalf("expected 1 result, got %d", result.Len())
@@ -104,7 +104,7 @@ func TestAggMin(t *testing.T) {
 	rels := map[string]*Relation{"R": rel}
 
 	agg := makeAgg("R", "v", []string{"g"}, "min", "minv")
-	result := EvalAggregate(agg, rels)
+	result := Aggregate(agg, rels)
 
 	if result.Len() != 1 {
 		t.Fatalf("expected 1 group, got %d", result.Len())
@@ -125,7 +125,7 @@ func TestAggMax(t *testing.T) {
 	rels := map[string]*Relation{"R": rel}
 
 	agg := makeAgg("R", "v", []string{"g"}, "max", "maxv")
-	result := EvalAggregate(agg, rels)
+	result := Aggregate(agg, rels)
 
 	if result.Len() != 1 {
 		t.Fatalf("expected 1 group, got %d", result.Len())
@@ -146,7 +146,7 @@ func TestAggSum(t *testing.T) {
 	rels := map[string]*Relation{"R": rel}
 
 	agg := makeAgg("R", "v", []string{"g"}, "sum", "sumv")
-	result := EvalAggregate(agg, rels)
+	result := Aggregate(agg, rels)
 
 	if result.Len() != 2 {
 		t.Fatalf("expected 2 groups, got %d", result.Len())
@@ -173,7 +173,7 @@ func TestAggAvg(t *testing.T) {
 	rels := map[string]*Relation{"R": rel}
 
 	agg := makeAgg("R", "v", []string{"g"}, "avg", "avgv")
-	result := EvalAggregate(agg, rels)
+	result := Aggregate(agg, rels)
 
 	if result.Len() != 1 {
 		t.Fatalf("expected 1 group, got %d", result.Len())
@@ -190,7 +190,7 @@ func TestAggEmptyInput(t *testing.T) {
 	rels := map[string]*Relation{"R": rel}
 
 	agg := makeAgg("R", "v", []string{"g"}, "count", "cnt")
-	result := EvalAggregate(agg, rels)
+	result := Aggregate(agg, rels)
 
 	// No groups → empty result.
 	if result.Len() != 0 {

--- a/ql/eval/aggregate_test.go
+++ b/ql/eval/aggregate_test.go
@@ -1,0 +1,199 @@
+package eval
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// makeAgg builds a PlannedAggregate for testing.
+// inputRel: name of the source relation in rels.
+// aggVar: the variable to aggregate.
+// groupByVars: variables forming the group key.
+// fn: aggregate function name.
+// resultRelation: name of the output relation.
+func makeAgg(inputRel, aggVar string, groupByVars []string, fn, resultRelation string) plan.PlannedAggregate {
+	groupBy := make([]datalog.Var, len(groupByVars))
+	for i, n := range groupByVars {
+		groupBy[i] = datalog.Var{Name: n}
+	}
+
+	bodyArgs := make([]datalog.Term, len(groupByVars)+1)
+	for i, n := range groupByVars {
+		bodyArgs[i] = datalog.Var{Name: n}
+	}
+	bodyArgs[len(groupByVars)] = datalog.Var{Name: aggVar}
+
+	return plan.PlannedAggregate{
+		ResultRelation: resultRelation,
+		GroupByVars:    groupBy,
+		Agg: datalog.Aggregate{
+			Func:      fn,
+			Var:       aggVar,
+			ResultVar: datalog.Var{Name: resultRelation},
+			Body: []datalog.Literal{
+				{
+					Positive: true,
+					Atom: datalog.Atom{
+						Predicate: inputRel,
+						Args:      bodyArgs,
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestAggCount tests count aggregate.
+func TestAggCount(t *testing.T) {
+	// Relation: (group, value)
+	rel := makeRelation("R", 2,
+		IntVal{1}, IntVal{10},
+		IntVal{1}, IntVal{20},
+		IntVal{1}, IntVal{30},
+		IntVal{2}, IntVal{40},
+	)
+	rels := map[string]*Relation{"R": rel}
+
+	agg := makeAgg("R", "v", []string{"g"}, "count", "cnt")
+	result := EvalAggregate(agg, rels)
+
+	if result.Len() != 2 {
+		t.Fatalf("expected 2 groups, got %d", result.Len())
+	}
+	// Find group 1 → count 3, group 2 → count 1.
+	counts := map[int64]int64{}
+	for _, row := range result.Tuples() {
+		groupVal := row[0].(IntVal).V
+		cntVal := row[1].(IntVal).V
+		counts[groupVal] = cntVal
+	}
+	if counts[1] != 3 {
+		t.Errorf("group 1: expected count=3, got %d", counts[1])
+	}
+	if counts[2] != 1 {
+		t.Errorf("group 2: expected count=1, got %d", counts[2])
+	}
+}
+
+// TestAggCountNoGroup tests count with no group-by.
+func TestAggCountNoGroup(t *testing.T) {
+	rel := makeRelation("R", 1, IntVal{1}, IntVal{2}, IntVal{3})
+	rels := map[string]*Relation{"R": rel}
+
+	agg := makeAgg("R", "x", nil, "count", "cnt")
+	result := EvalAggregate(agg, rels)
+
+	if result.Len() != 1 {
+		t.Fatalf("expected 1 result, got %d", result.Len())
+	}
+	cnt := result.Tuples()[0][0].(IntVal).V
+	if cnt != 3 {
+		t.Errorf("expected count=3, got %d", cnt)
+	}
+}
+
+// TestAggMin tests min aggregate.
+func TestAggMin(t *testing.T) {
+	rel := makeRelation("R", 2,
+		IntVal{1}, IntVal{50},
+		IntVal{1}, IntVal{10},
+		IntVal{1}, IntVal{30},
+	)
+	rels := map[string]*Relation{"R": rel}
+
+	agg := makeAgg("R", "v", []string{"g"}, "min", "minv")
+	result := EvalAggregate(agg, rels)
+
+	if result.Len() != 1 {
+		t.Fatalf("expected 1 group, got %d", result.Len())
+	}
+	minVal := result.Tuples()[0][1].(IntVal).V
+	if minVal != 10 {
+		t.Errorf("expected min=10, got %d", minVal)
+	}
+}
+
+// TestAggMax tests max aggregate.
+func TestAggMax(t *testing.T) {
+	rel := makeRelation("R", 2,
+		IntVal{1}, IntVal{5},
+		IntVal{1}, IntVal{100},
+		IntVal{1}, IntVal{42},
+	)
+	rels := map[string]*Relation{"R": rel}
+
+	agg := makeAgg("R", "v", []string{"g"}, "max", "maxv")
+	result := EvalAggregate(agg, rels)
+
+	if result.Len() != 1 {
+		t.Fatalf("expected 1 group, got %d", result.Len())
+	}
+	maxVal := result.Tuples()[0][1].(IntVal).V
+	if maxVal != 100 {
+		t.Errorf("expected max=100, got %d", maxVal)
+	}
+}
+
+// TestAggSum tests sum aggregate.
+func TestAggSum(t *testing.T) {
+	rel := makeRelation("R", 2,
+		IntVal{1}, IntVal{10},
+		IntVal{1}, IntVal{20},
+		IntVal{2}, IntVal{5},
+	)
+	rels := map[string]*Relation{"R": rel}
+
+	agg := makeAgg("R", "v", []string{"g"}, "sum", "sumv")
+	result := EvalAggregate(agg, rels)
+
+	if result.Len() != 2 {
+		t.Fatalf("expected 2 groups, got %d", result.Len())
+	}
+	sums := map[int64]int64{}
+	for _, row := range result.Tuples() {
+		sums[row[0].(IntVal).V] = row[1].(IntVal).V
+	}
+	if sums[1] != 30 {
+		t.Errorf("group 1 sum: expected 30, got %d", sums[1])
+	}
+	if sums[2] != 5 {
+		t.Errorf("group 2 sum: expected 5, got %d", sums[2])
+	}
+}
+
+// TestAggAvg tests avg aggregate (integer division).
+func TestAggAvg(t *testing.T) {
+	rel := makeRelation("R", 2,
+		IntVal{1}, IntVal{10},
+		IntVal{1}, IntVal{20},
+		IntVal{1}, IntVal{30},
+	)
+	rels := map[string]*Relation{"R": rel}
+
+	agg := makeAgg("R", "v", []string{"g"}, "avg", "avgv")
+	result := EvalAggregate(agg, rels)
+
+	if result.Len() != 1 {
+		t.Fatalf("expected 1 group, got %d", result.Len())
+	}
+	avgVal := result.Tuples()[0][1].(IntVal).V
+	if avgVal != 20 { // (10+20+30)/3 = 20
+		t.Errorf("expected avg=20, got %d", avgVal)
+	}
+}
+
+// TestAggEmptyInput tests aggregates over empty input.
+func TestAggEmptyInput(t *testing.T) {
+	rel := NewRelation("R", 2)
+	rels := map[string]*Relation{"R": rel}
+
+	agg := makeAgg("R", "v", []string{"g"}, "count", "cnt")
+	result := EvalAggregate(agg, rels)
+
+	// No groups → empty result.
+	if result.Len() != 0 {
+		t.Errorf("expected 0 results for empty input, got %d", result.Len())
+	}
+}

--- a/ql/eval/builtin.go
+++ b/ql/eval/builtin.go
@@ -5,12 +5,12 @@ import (
 	"strconv"
 )
 
-// EvalComparison evaluates a comparison between two Values.
+// Compare evaluates a comparison between two Values.
 // Handles "=", "!=", "<", ">", "<=", ">=".
 // IntVal vs IntVal: numeric comparison.
 // StrVal vs StrVal: lexicographic comparison.
 // Mixed types: "!=" returns true, "=" returns false, others return error.
-func EvalComparison(op string, left, right Value) (bool, error) {
+func Compare(op string, left, right Value) (bool, error) {
 	switch l := left.(type) {
 	case IntVal:
 		switch r := right.(type) {
@@ -84,10 +84,10 @@ func mixedTypeComparison(op string) (bool, error) {
 	}
 }
 
-// EvalArithmetic evaluates an arithmetic operation between two Values.
+// Arithmetic evaluates an arithmetic operation between two Values.
 // Handles "+", "-", "*", "/", "%".
 // IntVal only for numeric ops; StrVal "+" as concatenation.
-func EvalArithmetic(op string, left, right Value) (Value, error) {
+func Arithmetic(op string, left, right Value) (Value, error) {
 	if op == "+" {
 		// Allow string concatenation.
 		ls, lok := left.(StrVal)

--- a/ql/eval/builtin.go
+++ b/ql/eval/builtin.go
@@ -1,0 +1,138 @@
+package eval
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// EvalComparison evaluates a comparison between two Values.
+// Handles "=", "!=", "<", ">", "<=", ">=".
+// IntVal vs IntVal: numeric comparison.
+// StrVal vs StrVal: lexicographic comparison.
+// Mixed types: "!=" returns true, "=" returns false, others return error.
+func EvalComparison(op string, left, right Value) (bool, error) {
+	switch l := left.(type) {
+	case IntVal:
+		switch r := right.(type) {
+		case IntVal:
+			return compareInts(op, l.V, r.V)
+		case StrVal:
+			return mixedTypeComparison(op)
+		default:
+			return false, fmt.Errorf("unsupported value type %T", right)
+		}
+	case StrVal:
+		switch r := right.(type) {
+		case StrVal:
+			return compareStrings(op, l.V, r.V)
+		case IntVal:
+			return mixedTypeComparison(op)
+		default:
+			return false, fmt.Errorf("unsupported value type %T", right)
+		}
+	default:
+		return false, fmt.Errorf("unsupported value type %T", left)
+	}
+}
+
+func compareInts(op string, l, r int64) (bool, error) {
+	switch op {
+	case "=":
+		return l == r, nil
+	case "!=":
+		return l != r, nil
+	case "<":
+		return l < r, nil
+	case ">":
+		return l > r, nil
+	case "<=":
+		return l <= r, nil
+	case ">=":
+		return l >= r, nil
+	default:
+		return false, fmt.Errorf("unknown comparison operator %q", op)
+	}
+}
+
+func compareStrings(op string, l, r string) (bool, error) {
+	switch op {
+	case "=":
+		return l == r, nil
+	case "!=":
+		return l != r, nil
+	case "<":
+		return l < r, nil
+	case ">":
+		return l > r, nil
+	case "<=":
+		return l <= r, nil
+	case ">=":
+		return l >= r, nil
+	default:
+		return false, fmt.Errorf("unknown comparison operator %q", op)
+	}
+}
+
+func mixedTypeComparison(op string) (bool, error) {
+	switch op {
+	case "=":
+		return false, nil
+	case "!=":
+		return true, nil
+	default:
+		return false, fmt.Errorf("cannot apply %q to values of different types", op)
+	}
+}
+
+// EvalArithmetic evaluates an arithmetic operation between two Values.
+// Handles "+", "-", "*", "/", "%".
+// IntVal only for numeric ops; StrVal "+" as concatenation.
+func EvalArithmetic(op string, left, right Value) (Value, error) {
+	if op == "+" {
+		// Allow string concatenation.
+		ls, lok := left.(StrVal)
+		rs, rok := right.(StrVal)
+		if lok && rok {
+			return StrVal{V: ls.V + rs.V}, nil
+		}
+	}
+
+	l, lok := left.(IntVal)
+	r, rok := right.(IntVal)
+	if !lok || !rok {
+		return nil, fmt.Errorf("arithmetic operator %q requires IntVal operands (got %T, %T)", op, left, right)
+	}
+
+	switch op {
+	case "+":
+		return IntVal{V: l.V + r.V}, nil
+	case "-":
+		return IntVal{V: l.V - r.V}, nil
+	case "*":
+		return IntVal{V: l.V * r.V}, nil
+	case "/":
+		if r.V == 0 {
+			return nil, fmt.Errorf("division by zero")
+		}
+		return IntVal{V: l.V / r.V}, nil
+	case "%":
+		if r.V == 0 {
+			return nil, fmt.Errorf("modulo by zero")
+		}
+		return IntVal{V: l.V % r.V}, nil
+	default:
+		return nil, fmt.Errorf("unknown arithmetic operator %q", op)
+	}
+}
+
+// ValueToString returns a human-readable string for a Value.
+func ValueToString(v Value) string {
+	switch vv := v.(type) {
+	case IntVal:
+		return strconv.FormatInt(vv.V, 10)
+	case StrVal:
+		return vv.V
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}

--- a/ql/eval/eval.go
+++ b/ql/eval/eval.go
@@ -1,2 +1,79 @@
 // Package eval implements semi-naive bottom-up Datalog evaluation.
 package eval
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Gjdoalfnrxu/tsq/extract/db"
+	"github.com/Gjdoalfnrxu/tsq/extract/schema"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// Evaluator loads base facts and evaluates a planned query.
+type Evaluator struct {
+	execPlan *plan.ExecutionPlan
+	factDB   *db.DB
+}
+
+// NewEvaluator creates an Evaluator that will load base facts from factDB.
+func NewEvaluator(execPlan *plan.ExecutionPlan, factDB *db.DB) *Evaluator {
+	return &Evaluator{
+		execPlan: execPlan,
+		factDB:   factDB,
+	}
+}
+
+// Evaluate runs the evaluation and returns results.
+func (e *Evaluator) Evaluate(ctx context.Context) (*ResultSet, error) {
+	baseRels, err := loadBaseRelations(e.factDB)
+	if err != nil {
+		return nil, fmt.Errorf("eval: load base relations: %w", err)
+	}
+	return Evaluate(ctx, e.execPlan, baseRels)
+}
+
+// loadBaseRelations converts a db.DB into a map of eval.Relation objects.
+// It iterates all registered schema relations and loads any that are present
+// in the DB.
+func loadBaseRelations(factDB *db.DB) (map[string]*Relation, error) {
+	rels := make(map[string]*Relation)
+
+	for _, def := range schema.Registry {
+		dbRel := factDB.Relation(def.Name)
+		// db.Relation always returns a (possibly empty) Relation for registered names.
+		n := dbRel.Tuples()
+		if n == 0 {
+			// Create an empty relation so lookups work correctly.
+			rels[def.Name] = NewRelation(def.Name, len(def.Columns))
+			continue
+		}
+
+		rel := NewRelation(def.Name, len(def.Columns))
+		for ti := 0; ti < n; ti++ {
+			t := make(Tuple, len(def.Columns))
+			for ci, colDef := range def.Columns {
+				switch colDef.Type {
+				case schema.TypeInt32, schema.TypeEntityRef:
+					v, err := dbRel.GetInt(ti, ci)
+					if err != nil {
+						return nil, fmt.Errorf("relation %q tuple %d col %d: %w", def.Name, ti, ci, err)
+					}
+					t[ci] = IntVal{V: int64(v)}
+				case schema.TypeString:
+					s, err := dbRel.GetString(factDB, ti, ci)
+					if err != nil {
+						return nil, fmt.Errorf("relation %q tuple %d col %d: %w", def.Name, ti, ci, err)
+					}
+					t[ci] = StrVal{V: s}
+				default:
+					return nil, fmt.Errorf("relation %q col %d: unknown column type %d", def.Name, ci, colDef.Type)
+				}
+			}
+			rel.Add(t)
+		}
+		rels[def.Name] = rel
+	}
+
+	return rels, nil
+}

--- a/ql/eval/eval_test.go
+++ b/ql/eval/eval_test.go
@@ -15,7 +15,8 @@ import (
 // simple query plan, evaluates it, and checks results.
 //
 // Fact: Node(id=1, file=10, kind="function", startLine=1, startCol=0, endLine=5, endCol=1)
-//       Node(id=2, file=10, kind="call",     startLine=3, startCol=2, endLine=3, endCol=10)
+//
+//	Node(id=2, file=10, kind="call",     startLine=3, startCol=2, endLine=3, endCol=10)
 //
 // Query: Find all Node(id, _, kind, _, _, _, _) where kind = "function" → expect id=1.
 func TestEvaluatorIntegration(t *testing.T) {

--- a/ql/eval/eval_test.go
+++ b/ql/eval/eval_test.go
@@ -1,5 +1,183 @@
 package eval_test
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"testing"
 
-func TestPlaceholder(t *testing.T) {}
+	"github.com/Gjdoalfnrxu/tsq/extract/db"
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// TestEvaluatorIntegration builds a small in-memory fact DB, constructs a
+// simple query plan, evaluates it, and checks results.
+//
+// Fact: Node(id=1, file=10, kind="function", startLine=1, startCol=0, endLine=5, endCol=1)
+//       Node(id=2, file=10, kind="call",     startLine=3, startCol=2, endLine=3, endCol=10)
+//
+// Query: Find all Node(id, _, kind, _, _, _, _) where kind = "function" → expect id=1.
+func TestEvaluatorIntegration(t *testing.T) {
+	// Build a fact DB.
+	factDB := db.NewDB()
+	nodeRel := factDB.Relation("Node")
+
+	// Node(id, file, kind, startLine, startCol, endLine, endCol)
+	if err := nodeRel.AddTuple(factDB,
+		int32(1), int32(10), "function", int32(1), int32(0), int32(5), int32(1),
+	); err != nil {
+		t.Fatalf("AddTuple: %v", err)
+	}
+	if err := nodeRel.AddTuple(factDB,
+		int32(2), int32(10), "call", int32(3), int32(2), int32(3), int32(10),
+	); err != nil {
+		t.Fatalf("AddTuple: %v", err)
+	}
+
+	// Serialise and re-read to test the full pipeline.
+	var buf bytes.Buffer
+	if err := factDB.Encode(&buf); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	data := buf.Bytes()
+	readDB, err := db.ReadDB(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("ReadDB: %v", err)
+	}
+
+	// Plan: one stratum, one rule: FuncNode(id) :- Node(id, _, "function", _, _, _, _).
+	// Then query: select id where FuncNode(id).
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{
+			{
+				Rules: []plan.PlannedRule{
+					{
+						Head: datalog.Atom{
+							Predicate: "FuncNode",
+							Args:      []datalog.Term{datalog.Var{Name: "id"}},
+						},
+						JoinOrder: []plan.JoinStep{
+							{
+								Literal: datalog.Literal{
+									Positive: true,
+									Atom: datalog.Atom{
+										Predicate: "Node",
+										Args: []datalog.Term{
+											datalog.Var{Name: "id"},
+											datalog.Wildcard{},
+											datalog.StringConst{Value: "function"},
+											datalog.Wildcard{},
+											datalog.Wildcard{},
+											datalog.Wildcard{},
+											datalog.Wildcard{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Query: &plan.PlannedQuery{
+			Select: []datalog.Term{datalog.Var{Name: "id"}},
+			JoinOrder: []plan.JoinStep{
+				{
+					Literal: datalog.Literal{
+						Positive: true,
+						Atom: datalog.Atom{
+							Predicate: "FuncNode",
+							Args:      []datalog.Term{datalog.Var{Name: "id"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	evaluator := eval.NewEvaluator(ep, readDB)
+	rs, err := evaluator.Evaluate(context.Background())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 result row, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+
+	// The id column should be 1 (the function node).
+	row := rs.Rows[0]
+	id, ok := row[0].(eval.IntVal)
+	if !ok {
+		t.Fatalf("expected IntVal, got %T", row[0])
+	}
+	if id.V != 1 {
+		t.Errorf("expected id=1, got %d", id.V)
+	}
+}
+
+// TestEvaluatorEmptyDB verifies that evaluation over an empty DB produces
+// no results without panicking.
+func TestEvaluatorEmptyDB(t *testing.T) {
+	factDB := db.NewDB()
+
+	var buf bytes.Buffer
+	if err := factDB.Encode(&buf); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	data := buf.Bytes()
+	readDB, err := db.ReadDB(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("ReadDB: %v", err)
+	}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{
+			{
+				Rules: []plan.PlannedRule{
+					{
+						Head: datalog.Atom{
+							Predicate: "Q",
+							Args:      []datalog.Term{datalog.Var{Name: "x"}},
+						},
+						JoinOrder: []plan.JoinStep{
+							{
+								Literal: datalog.Literal{
+									Positive: true,
+									Atom: datalog.Atom{
+										Predicate: "Node",
+										Args:      []datalog.Term{datalog.Var{Name: "x"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Query: &plan.PlannedQuery{
+			Select: []datalog.Term{datalog.Var{Name: "x"}},
+			JoinOrder: []plan.JoinStep{
+				{
+					Literal: datalog.Literal{
+						Positive: true,
+						Atom: datalog.Atom{
+							Predicate: "Q",
+							Args:      []datalog.Term{datalog.Var{Name: "x"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	evaluator := eval.NewEvaluator(ep, readDB)
+	rs, err := evaluator.Evaluate(context.Background())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(rs.Rows) != 0 {
+		t.Errorf("expected 0 rows for empty DB, got %d", len(rs.Rows))
+	}
+}

--- a/ql/eval/join.go
+++ b/ql/eval/join.go
@@ -40,21 +40,28 @@ func lookupTerm(t datalog.Term, b binding) (Value, bool) {
 	}
 }
 
-// EvalRule evaluates a single PlannedRule against the given relations.
+// Rule evaluates a single PlannedRule against the given relations.
 // Returns all result tuples for the rule head.
-func EvalRule(rule plan.PlannedRule, rels map[string]*Relation) []Tuple {
+func Rule(rule plan.PlannedRule, rels map[string]*Relation) []Tuple {
 	initial := []binding{make(binding)}
 	bindings := evalJoinSteps(rule.JoinOrder, rels, initial)
 	return projectHead(rule.Head, bindings)
 }
 
-// EvalRuleDelta evaluates a rule in semi-naive mode.
-// It generates one variant per body literal, substituting that literal's
-// relation with the delta relation (new tuples only). Results are unioned
-// and returned; tuples already in the head full relation are excluded.
-func EvalRuleDelta(rule plan.PlannedRule, rels map[string]*Relation, deltaRels map[string]*Relation) []Tuple {
-	// Build the augmented relation set for each variant.
-	// For each step i that has a delta, generate results using delta for that step.
+// RuleDelta evaluates a rule in semi-naive mode.
+// It generates one variant per body literal, substituting ONLY that literal's
+// position with the delta relation (new tuples only). Results are unioned
+// and returned.
+//
+// The substitution is position-aware: for a rule like
+//
+//	Path(x,z) :- Path(x,y), Path(y,z)
+//
+// when di=0, only the first Path literal uses delta; the second uses full.
+// When di=1, only the second Path literal uses delta; the first uses full.
+// This avoids the delta×delta over-counting that a global predicate replacement
+// would produce.
+func RuleDelta(rule plan.PlannedRule, rels map[string]*Relation, deltaRels map[string]*Relation) []Tuple {
 	seen := make(map[string]struct{})
 	var results []Tuple
 
@@ -72,10 +79,9 @@ func EvalRuleDelta(rule plan.PlannedRule, rels map[string]*Relation, deltaRels m
 			continue
 		}
 
-		// Build a merged relation view where step i uses delta only.
-		deltaView := buildDeltaView(rels, deltaRels, pred, delta, di)
+		// Evaluate the join sequence with delta substitution only at step di.
 		initial := []binding{make(binding)}
-		bindings := evalJoinSteps(rule.JoinOrder, deltaView, initial)
+		bindings := evalJoinStepsWithDelta(rule.JoinOrder, rels, deltaRels, di, delta, initial)
 		tuples := projectHead(rule.Head, bindings)
 		for _, t := range tuples {
 			k := tupleKey(t)
@@ -88,23 +94,6 @@ func EvalRuleDelta(rule plan.PlannedRule, rels map[string]*Relation, deltaRels m
 	return results
 }
 
-// buildDeltaView returns a map of relations where the named predicate is
-// replaced by a relation containing only the delta tuples (for delta at
-// step di). All other relations are passed through unchanged.
-func buildDeltaView(rels map[string]*Relation, deltaRels map[string]*Relation, pred string, delta *Relation, _ int) map[string]*Relation {
-	view := make(map[string]*Relation, len(rels))
-	for k, v := range rels {
-		view[k] = v
-	}
-	// Replace with delta-only relation.
-	dr := NewRelation(pred, delta.Arity)
-	for _, t := range delta.Tuples() {
-		dr.Add(t)
-	}
-	view[pred] = dr
-	return view
-}
-
 // evalJoinSteps processes a sequence of JoinSteps, starting from the given
 // bindings, and returns all final bindings.
 func evalJoinSteps(steps []plan.JoinStep, rels map[string]*Relation, initial []binding) []binding {
@@ -114,6 +103,34 @@ func evalJoinSteps(steps []plan.JoinStep, rels map[string]*Relation, initial []b
 			return nil
 		}
 		current = applyStep(step, rels, current)
+	}
+	return current
+}
+
+// evalJoinStepsWithDelta processes a sequence of JoinSteps like evalJoinSteps,
+// but at step deltaIdx it substitutes the relation for deltaRel (the delta
+// relation for that predicate). All other steps use the full relations in rels.
+// This ensures only one literal position is delta-substituted per variant,
+// which is required for correct semi-naive evaluation.
+func evalJoinStepsWithDelta(steps []plan.JoinStep, rels map[string]*Relation, deltaRels map[string]*Relation, deltaIdx int, deltaRel *Relation, initial []binding) []binding {
+	current := initial
+	for i, step := range steps {
+		if len(current) == 0 {
+			return nil
+		}
+		if i == deltaIdx {
+			// Use the delta relation for this step only.
+			// Build a merged map where only this literal's predicate is replaced.
+			pred := step.Literal.Atom.Predicate
+			merged := make(map[string]*Relation, len(rels)+1)
+			for k, v := range rels {
+				merged[k] = v
+			}
+			merged[pred] = deltaRel
+			current = applyStep(step, merged, current)
+		} else {
+			current = applyStep(step, rels, current)
+		}
 	}
 	return current
 }
@@ -149,7 +166,7 @@ func applyComparison(cmp *datalog.Comparison, bindings []binding) []binding {
 			// Unbound variable in comparison — skip (shouldn't happen with valid plans).
 			continue
 		}
-		ok, err := EvalComparison(cmp.Op, lv, rv)
+		ok, err := Compare(cmp.Op, lv, rv)
 		if err == nil && ok {
 			out = append(out, b)
 		}
@@ -211,7 +228,7 @@ func applyPositive(atom datalog.Atom, rels map[string]*Relation, bindings []bind
 					match = false
 					break
 				}
-				eq, err := EvalComparison("=", t[col], boundVals[j])
+				eq, err := Compare("=", t[col], boundVals[j])
 				if err != nil || !eq {
 					match = false
 					break
@@ -281,7 +298,7 @@ func applyNegative(atom datalog.Atom, rels map[string]*Relation, bindings []bind
 					match = false
 					break
 				}
-				eq, err := EvalComparison("=", t[col], boundVals[j])
+				eq, err := Compare("=", t[col], boundVals[j])
 				if err != nil || !eq {
 					match = false
 					break

--- a/ql/eval/join.go
+++ b/ql/eval/join.go
@@ -1,0 +1,323 @@
+package eval
+
+import (
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// binding is a partial assignment of Datalog variable names to Values.
+type binding map[string]Value
+
+// clone makes a shallow copy of a binding.
+func (b binding) clone() binding {
+	nb := make(binding, len(b))
+	for k, v := range b {
+		nb[k] = v
+	}
+	return nb
+}
+
+// lookupTerm resolves a Term against current bindings.
+// Returns (value, true) if fully resolved, or (nil, false) if the term is an
+// unbound variable.
+func lookupTerm(t datalog.Term, b binding) (Value, bool) {
+	switch tv := t.(type) {
+	case datalog.Var:
+		if tv.Name == "_" {
+			// Wildcard — always unbound (caller handles)
+			return nil, false
+		}
+		v, ok := b[tv.Name]
+		return v, ok
+	case datalog.IntConst:
+		return IntVal{V: tv.Value}, true
+	case datalog.StringConst:
+		return StrVal{V: tv.Value}, true
+	case datalog.Wildcard:
+		return nil, false
+	default:
+		return nil, false
+	}
+}
+
+// EvalRule evaluates a single PlannedRule against the given relations.
+// Returns all result tuples for the rule head.
+func EvalRule(rule plan.PlannedRule, rels map[string]*Relation) []Tuple {
+	initial := []binding{make(binding)}
+	bindings := evalJoinSteps(rule.JoinOrder, rels, initial)
+	return projectHead(rule.Head, bindings)
+}
+
+// EvalRuleDelta evaluates a rule in semi-naive mode.
+// It generates one variant per body literal, substituting that literal's
+// relation with the delta relation (new tuples only). Results are unioned
+// and returned; tuples already in the head full relation are excluded.
+func EvalRuleDelta(rule plan.PlannedRule, rels map[string]*Relation, deltaRels map[string]*Relation) []Tuple {
+	// Build the augmented relation set for each variant.
+	// For each step i that has a delta, generate results using delta for that step.
+	seen := make(map[string]struct{})
+	var results []Tuple
+
+	for di, step := range rule.JoinOrder {
+		// Only positive atom steps with a delta can be "delta variants".
+		if step.Literal.Cmp != nil || step.Literal.Agg != nil {
+			continue
+		}
+		if !step.Literal.Positive {
+			continue
+		}
+		pred := step.Literal.Atom.Predicate
+		delta, hasDelta := deltaRels[pred]
+		if !hasDelta || delta.Len() == 0 {
+			continue
+		}
+
+		// Build a merged relation view where step i uses delta only.
+		deltaView := buildDeltaView(rels, deltaRels, pred, delta, di)
+		initial := []binding{make(binding)}
+		bindings := evalJoinSteps(rule.JoinOrder, deltaView, initial)
+		tuples := projectHead(rule.Head, bindings)
+		for _, t := range tuples {
+			k := tupleKey(t)
+			if _, exists := seen[k]; !exists {
+				seen[k] = struct{}{}
+				results = append(results, t)
+			}
+		}
+	}
+	return results
+}
+
+// buildDeltaView returns a map of relations where the named predicate is
+// replaced by a relation containing only the delta tuples (for delta at
+// step di). All other relations are passed through unchanged.
+func buildDeltaView(rels map[string]*Relation, deltaRels map[string]*Relation, pred string, delta *Relation, _ int) map[string]*Relation {
+	view := make(map[string]*Relation, len(rels))
+	for k, v := range rels {
+		view[k] = v
+	}
+	// Replace with delta-only relation.
+	dr := NewRelation(pred, delta.Arity)
+	for _, t := range delta.Tuples() {
+		dr.Add(t)
+	}
+	view[pred] = dr
+	return view
+}
+
+// evalJoinSteps processes a sequence of JoinSteps, starting from the given
+// bindings, and returns all final bindings.
+func evalJoinSteps(steps []plan.JoinStep, rels map[string]*Relation, initial []binding) []binding {
+	current := initial
+	for _, step := range steps {
+		if len(current) == 0 {
+			return nil
+		}
+		current = applyStep(step, rels, current)
+	}
+	return current
+}
+
+// applyStep applies a single JoinStep to the current set of bindings.
+func applyStep(step plan.JoinStep, rels map[string]*Relation, bindings []binding) []binding {
+	lit := step.Literal
+
+	// Comparison filter.
+	if lit.Cmp != nil {
+		return applyComparison(lit.Cmp, bindings)
+	}
+
+	// Aggregate sub-goal (handled at stratum level; skip here).
+	if lit.Agg != nil {
+		return bindings
+	}
+
+	if lit.Positive {
+		return applyPositive(lit.Atom, rels, bindings)
+	}
+	// Negative (anti-join).
+	return applyNegative(lit.Atom, rels, bindings)
+}
+
+// applyComparison filters bindings by evaluating the comparison against each.
+func applyComparison(cmp *datalog.Comparison, bindings []binding) []binding {
+	var out []binding
+	for _, b := range bindings {
+		lv, lok := lookupTerm(cmp.Left, b)
+		rv, rok := lookupTerm(cmp.Right, b)
+		if !lok || !rok {
+			// Unbound variable in comparison — skip (shouldn't happen with valid plans).
+			continue
+		}
+		ok, err := EvalComparison(cmp.Op, lv, rv)
+		if err == nil && ok {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// applyPositive extends bindings by probing the named relation.
+func applyPositive(atom datalog.Atom, rels map[string]*Relation, bindings []binding) []binding {
+	rel, ok := rels[atom.Predicate]
+	if !ok || rel == nil || rel.Len() == 0 {
+		return nil
+	}
+
+	var out []binding
+	for _, b := range bindings {
+		// Determine which columns are bound and which are free variables.
+		boundCols := make([]int, 0, len(atom.Args))
+		boundVals := make([]Value, 0, len(atom.Args))
+		freeVars := make([]struct {
+			name string
+			col  int
+		}, 0, len(atom.Args))
+
+		for i, arg := range atom.Args {
+			if v, ok := lookupTerm(arg, b); ok {
+				boundCols = append(boundCols, i)
+				boundVals = append(boundVals, v)
+			} else if vv, isVar := arg.(datalog.Var); isVar && vv.Name != "_" {
+				freeVars = append(freeVars, struct {
+					name string
+					col  int
+				}{vv.Name, i})
+			}
+			// Wildcards are ignored.
+		}
+
+		// Use index if we have bound columns.
+		var matchingIdxs []int
+		if len(boundCols) > 0 {
+			idx := rel.Index(boundCols)
+			matchingIdxs = idx.Lookup(boundVals)
+		} else {
+			// Full scan.
+			matchingIdxs = make([]int, len(rel.Tuples()))
+			for i := range rel.Tuples() {
+				matchingIdxs[i] = i
+			}
+		}
+
+		tuples := rel.Tuples()
+		for _, ti := range matchingIdxs {
+			t := tuples[ti]
+			// Verify bound columns match (index lookup already filters, but
+			// for multi-col with partial hash we re-check).
+			match := true
+			for j, col := range boundCols {
+				if col >= len(t) {
+					match = false
+					break
+				}
+				eq, err := EvalComparison("=", t[col], boundVals[j])
+				if err != nil || !eq {
+					match = false
+					break
+				}
+			}
+			if !match {
+				continue
+			}
+
+			// Extend binding with free variables.
+			nb := b.clone()
+			for _, fv := range freeVars {
+				if fv.col < len(t) {
+					nb[fv.name] = t[fv.col]
+				}
+			}
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// applyNegative filters bindings by requiring NO matching tuple exists (anti-join).
+func applyNegative(atom datalog.Atom, rels map[string]*Relation, bindings []binding) []binding {
+	rel, ok := rels[atom.Predicate]
+
+	var out []binding
+	for _, b := range bindings {
+		if !ok || rel == nil || rel.Len() == 0 {
+			// No relation = no matching tuples = anti-join succeeds.
+			out = append(out, b)
+			continue
+		}
+
+		// Determine bound columns.
+		boundCols := make([]int, 0, len(atom.Args))
+		boundVals := make([]Value, 0, len(atom.Args))
+		for i, arg := range atom.Args {
+			if v, ok := lookupTerm(arg, b); ok {
+				boundCols = append(boundCols, i)
+				boundVals = append(boundVals, v)
+			}
+		}
+
+		var matchingIdxs []int
+		if len(boundCols) > 0 {
+			idx := rel.Index(boundCols)
+			matchingIdxs = idx.Lookup(boundVals)
+		} else {
+			// No bound columns — any tuple would match.
+			if rel.Len() > 0 {
+				// Match found → anti-join fails.
+				continue
+			}
+			out = append(out, b)
+			continue
+		}
+
+		// Verify matches exist.
+		hasMatch := false
+		tuples := rel.Tuples()
+		for _, ti := range matchingIdxs {
+			t := tuples[ti]
+			match := true
+			for j, col := range boundCols {
+				if col >= len(t) {
+					match = false
+					break
+				}
+				eq, err := EvalComparison("=", t[col], boundVals[j])
+				if err != nil || !eq {
+					match = false
+					break
+				}
+			}
+			if match {
+				hasMatch = true
+				break
+			}
+		}
+
+		if !hasMatch {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// projectHead builds head tuples from fully-resolved bindings.
+func projectHead(head datalog.Atom, bindings []binding) []Tuple {
+	var out []Tuple
+	for _, b := range bindings {
+		t := make(Tuple, len(head.Args))
+		valid := true
+		for i, arg := range head.Args {
+			v, ok := lookupTerm(arg, b)
+			if !ok {
+				// Unbound head variable — this binding is incomplete.
+				valid = false
+				break
+			}
+			t[i] = v
+		}
+		if valid {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/ql/eval/join_test.go
+++ b/ql/eval/join_test.go
@@ -1,0 +1,223 @@
+package eval
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// makeRelation is a helper that builds a Relation from raw int/string slices.
+// vals is a flat list: [col0row0, col1row0, col0row1, col1row1, ...]
+func makeRelation(name string, arity int, vals ...Value) *Relation {
+	r := NewRelation(name, arity)
+	for i := 0; i+arity <= len(vals); i += arity {
+		t := make(Tuple, arity)
+		copy(t, vals[i:i+arity])
+		r.Add(t)
+	}
+	return r
+}
+
+// positiveStep builds a positive JoinStep from an atom.
+func positiveStep(pred string, args ...datalog.Term) plan.JoinStep {
+	return plan.JoinStep{
+		Literal: datalog.Literal{
+			Positive: true,
+			Atom:     datalog.Atom{Predicate: pred, Args: args},
+		},
+	}
+}
+
+// negativeStep builds a negative JoinStep from an atom.
+func negativeStep(pred string, args ...datalog.Term) plan.JoinStep {
+	return plan.JoinStep{
+		Literal: datalog.Literal{
+			Positive: false,
+			Atom:     datalog.Atom{Predicate: pred, Args: args},
+		},
+		IsFilter: true,
+	}
+}
+
+// cmpStep builds a comparison JoinStep.
+func cmpStep(op string, left, right datalog.Term) plan.JoinStep {
+	return plan.JoinStep{
+		Literal: datalog.Literal{
+			Positive: true,
+			Cmp:      &datalog.Comparison{Op: op, Left: left, Right: right},
+		},
+		IsFilter: true,
+	}
+}
+
+func v(name string) datalog.Var      { return datalog.Var{Name: name} }
+func ic(n int64) datalog.IntConst    { return datalog.IntConst{Value: n} }
+func sc(s string) datalog.StringConst { return datalog.StringConst{Value: s} }
+
+// head builds a PlannedRule head atom.
+func head(pred string, args ...datalog.Term) datalog.Atom {
+	return datalog.Atom{Predicate: pred, Args: args}
+}
+
+// Test 2-relation join: Edge(x,y) ∧ Edge(y,z) → Path(x,z)
+// Edge: (1,2),(2,3),(3,4)
+// 2-hop paths via common intermediate:
+//   x=1,y=2 → Edge(2,z): z=3 → Path(1,3)
+//   x=2,y=3 → Edge(3,z): z=4 → Path(2,4)
+//   x=3,y=4 → no Edge(4,...) → nothing
+// Result: 2 tuples.
+func TestEvalRuleTwoRelationJoin(t *testing.T) {
+	edge := makeRelation("Edge", 2,
+		IntVal{1}, IntVal{2},
+		IntVal{2}, IntVal{3},
+		IntVal{3}, IntVal{4},
+	)
+	rels := map[string]*Relation{"Edge": edge}
+
+	rule := plan.PlannedRule{
+		Head: head("Path", v("x"), v("z")),
+		JoinOrder: []plan.JoinStep{
+			positiveStep("Edge", v("x"), v("y")),
+			positiveStep("Edge", v("y"), v("z")),
+		},
+	}
+
+	results := EvalRule(rule, rels)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 path tuples (2-hops), got %d: %v", len(results), results)
+	}
+	expected := map[string]bool{
+		tupleKey(Tuple{IntVal{1}, IntVal{3}}): true,
+		tupleKey(Tuple{IntVal{2}, IntVal{4}}): true,
+	}
+	for _, r := range results {
+		if !expected[tupleKey(r)] {
+			t.Errorf("unexpected tuple: %v", r)
+		}
+	}
+}
+
+// Test 3-relation join: R(x,y) ∧ S(y,z) ∧ T(z,w) → Q(x,w)
+func TestEvalRuleThreeRelationJoin(t *testing.T) {
+	R := makeRelation("R", 2, IntVal{1}, IntVal{2})
+	S := makeRelation("S", 2, IntVal{2}, IntVal{3})
+	T := makeRelation("T", 2, IntVal{3}, IntVal{4})
+	rels := map[string]*Relation{"R": R, "S": S, "T": T}
+
+	rule := plan.PlannedRule{
+		Head: head("Q", v("x"), v("w")),
+		JoinOrder: []plan.JoinStep{
+			positiveStep("R", v("x"), v("y")),
+			positiveStep("S", v("y"), v("z")),
+			positiveStep("T", v("z"), v("w")),
+		},
+	}
+
+	results := EvalRule(rule, rels)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d: %v", len(results), results)
+	}
+	got := results[0]
+	if got[0] != (IntVal{1}) || got[1] != (IntVal{4}) {
+		t.Errorf("expected (1,4), got %v", got)
+	}
+}
+
+// Test no-match join: no common key between A and B.
+func TestEvalRuleNoMatch(t *testing.T) {
+	A := makeRelation("A", 2, IntVal{1}, IntVal{2})
+	B := makeRelation("B", 2, IntVal{99}, IntVal{100})
+	rels := map[string]*Relation{"A": A, "B": B}
+
+	rule := plan.PlannedRule{
+		Head: head("Q", v("x"), v("z")),
+		JoinOrder: []plan.JoinStep{
+			positiveStep("A", v("x"), v("y")),
+			positiveStep("B", v("y"), v("z")), // y from A won't match B's first col
+		},
+	}
+
+	results := EvalRule(rule, rels)
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d: %v", len(results), results)
+	}
+}
+
+// Test comparison filter: R(x,y) ∧ x < 3 → Q(x,y)
+func TestEvalRuleComparisonFilter(t *testing.T) {
+	R := makeRelation("R", 2,
+		IntVal{1}, IntVal{10},
+		IntVal{2}, IntVal{20},
+		IntVal{3}, IntVal{30},
+		IntVal{4}, IntVal{40},
+	)
+	rels := map[string]*Relation{"R": R}
+
+	rule := plan.PlannedRule{
+		Head: head("Q", v("x"), v("y")),
+		JoinOrder: []plan.JoinStep{
+			positiveStep("R", v("x"), v("y")),
+			cmpStep("<", v("x"), ic(3)),
+		},
+	}
+
+	results := EvalRule(rule, rels)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results (x=1,x=2), got %d: %v", len(results), results)
+	}
+}
+
+// Test self-join: Edge(x,y) ∧ Edge(x,y) → Q(x,y)
+func TestEvalRuleSelfJoin(t *testing.T) {
+	edge := makeRelation("Edge", 2,
+		IntVal{1}, IntVal{2},
+		IntVal{2}, IntVal{3},
+	)
+	rels := map[string]*Relation{"Edge": edge}
+
+	rule := plan.PlannedRule{
+		Head: head("Q", v("x"), v("y")),
+		JoinOrder: []plan.JoinStep{
+			positiveStep("Edge", v("x"), v("y")),
+			positiveStep("Edge", v("x"), v("y")), // same binding constraint
+		},
+	}
+
+	results := EvalRule(rule, rels)
+	// Each edge should match exactly itself once.
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d: %v", len(results), results)
+	}
+}
+
+// Test anti-join (negative literal): A(x) ∧ not B(x) → Q(x)
+func TestEvalRuleAntiJoin(t *testing.T) {
+	A := makeRelation("A", 1, IntVal{1}, IntVal{2}, IntVal{3})
+	B := makeRelation("B", 1, IntVal{2})
+	rels := map[string]*Relation{"A": A, "B": B}
+
+	rule := plan.PlannedRule{
+		Head: head("Q", v("x")),
+		JoinOrder: []plan.JoinStep{
+			positiveStep("A", v("x")),
+			negativeStep("B", v("x")),
+		},
+	}
+
+	results := EvalRule(rule, rels)
+	// x=2 is in B, so excluded. Expected: x=1, x=3.
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d: %v", len(results), results)
+	}
+	seen := map[int64]bool{}
+	for _, r := range results {
+		seen[r[0].(IntVal).V] = true
+	}
+	if !seen[1] || !seen[3] {
+		t.Errorf("expected x=1 and x=3 in results, got %v", results)
+	}
+	if seen[2] {
+		t.Error("x=2 should be excluded by anti-join")
+	}
+}

--- a/ql/eval/join_test.go
+++ b/ql/eval/join_test.go
@@ -51,9 +51,8 @@ func cmpStep(op string, left, right datalog.Term) plan.JoinStep {
 	}
 }
 
-func v(name string) datalog.Var      { return datalog.Var{Name: name} }
-func ic(n int64) datalog.IntConst    { return datalog.IntConst{Value: n} }
-func sc(s string) datalog.StringConst { return datalog.StringConst{Value: s} }
+func v(name string) datalog.Var   { return datalog.Var{Name: name} }
+func ic(n int64) datalog.IntConst { return datalog.IntConst{Value: n} }
 
 // head builds a PlannedRule head atom.
 func head(pred string, args ...datalog.Term) datalog.Atom {
@@ -63,9 +62,11 @@ func head(pred string, args ...datalog.Term) datalog.Atom {
 // Test 2-relation join: Edge(x,y) ∧ Edge(y,z) → Path(x,z)
 // Edge: (1,2),(2,3),(3,4)
 // 2-hop paths via common intermediate:
-//   x=1,y=2 → Edge(2,z): z=3 → Path(1,3)
-//   x=2,y=3 → Edge(3,z): z=4 → Path(2,4)
-//   x=3,y=4 → no Edge(4,...) → nothing
+//
+//	x=1,y=2 → Edge(2,z): z=3 → Path(1,3)
+//	x=2,y=3 → Edge(3,z): z=4 → Path(2,4)
+//	x=3,y=4 → no Edge(4,...) → nothing
+//
 // Result: 2 tuples.
 func TestEvalRuleTwoRelationJoin(t *testing.T) {
 	edge := makeRelation("Edge", 2,
@@ -83,7 +84,7 @@ func TestEvalRuleTwoRelationJoin(t *testing.T) {
 		},
 	}
 
-	results := EvalRule(rule, rels)
+	results := Rule(rule, rels)
 	if len(results) != 2 {
 		t.Fatalf("expected 2 path tuples (2-hops), got %d: %v", len(results), results)
 	}
@@ -114,7 +115,7 @@ func TestEvalRuleThreeRelationJoin(t *testing.T) {
 		},
 	}
 
-	results := EvalRule(rule, rels)
+	results := Rule(rule, rels)
 	if len(results) != 1 {
 		t.Fatalf("expected 1 result, got %d: %v", len(results), results)
 	}
@@ -138,7 +139,7 @@ func TestEvalRuleNoMatch(t *testing.T) {
 		},
 	}
 
-	results := EvalRule(rule, rels)
+	results := Rule(rule, rels)
 	if len(results) != 0 {
 		t.Fatalf("expected 0 results, got %d: %v", len(results), results)
 	}
@@ -162,7 +163,7 @@ func TestEvalRuleComparisonFilter(t *testing.T) {
 		},
 	}
 
-	results := EvalRule(rule, rels)
+	results := Rule(rule, rels)
 	if len(results) != 2 {
 		t.Fatalf("expected 2 results (x=1,x=2), got %d: %v", len(results), results)
 	}
@@ -184,7 +185,7 @@ func TestEvalRuleSelfJoin(t *testing.T) {
 		},
 	}
 
-	results := EvalRule(rule, rels)
+	results := Rule(rule, rels)
 	// Each edge should match exactly itself once.
 	if len(results) != 2 {
 		t.Fatalf("expected 2 results, got %d: %v", len(results), results)
@@ -205,7 +206,7 @@ func TestEvalRuleAntiJoin(t *testing.T) {
 		},
 	}
 
-	results := EvalRule(rule, rels)
+	results := Rule(rule, rels)
 	// x=2 is in B, so excluded. Expected: x=1, x=3.
 	if len(results) != 2 {
 		t.Fatalf("expected 2 results, got %d: %v", len(results), results)

--- a/ql/eval/relation.go
+++ b/ql/eval/relation.go
@@ -68,15 +68,26 @@ func partialKey(t Tuple, cols []int) string {
 	return b.String()
 }
 
-// colMask builds a uint64 bitmask from a list of column indices.
-func colMask(cols []int) uint64 {
-	var mask uint64
-	for _, c := range cols {
-		if c < 64 {
-			mask |= 1 << uint(c)
+// sortedColKey returns a canonical string key for a column list, based on the
+// sorted column indices. This ensures Index([0,2]) and Index([2,0]) produce
+// the same key, and that Lookup always uses the same ordering as Index build.
+func sortedColKey(cols []int) string {
+	// Copy and sort so the key is order-independent.
+	sorted := make([]int, len(cols))
+	copy(sorted, cols)
+	for i := 1; i < len(sorted); i++ {
+		for j := i; j > 0 && sorted[j] < sorted[j-1]; j-- {
+			sorted[j], sorted[j-1] = sorted[j-1], sorted[j]
 		}
 	}
-	return mask
+	var b strings.Builder
+	for i, c := range sorted {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, "%d", c)
+	}
+	return b.String()
 }
 
 // HashIndex maps a key (values of specific columns) to matching tuple indices.
@@ -104,8 +115,7 @@ type Relation struct {
 	Arity   int
 	tuples  []Tuple
 	set     map[string]struct{} // deduplication
-	Delta   []Tuple             // new tuples from last iteration (semi-naive)
-	indexes map[uint64]*HashIndex
+	indexes map[string]*HashIndex
 }
 
 // NewRelation creates an empty relation.
@@ -114,7 +124,7 @@ func NewRelation(name string, arity int) *Relation {
 		Name:    name,
 		Arity:   arity,
 		set:     make(map[string]struct{}),
-		indexes: make(map[uint64]*HashIndex),
+		indexes: make(map[string]*HashIndex),
 	}
 }
 
@@ -127,11 +137,10 @@ func (r *Relation) Add(t Tuple) bool {
 	}
 	r.set[k] = struct{}{}
 	r.tuples = append(r.tuples, t)
-	// Invalidate all indexes since the tuple list grew.
-	for mask, idx := range r.indexes {
+	// Update all existing indexes incrementally.
+	for _, idx := range r.indexes {
 		colKey := partialKey(t, idx.cols)
 		idx.index[colKey] = append(idx.index[colKey], len(r.tuples)-1)
-		_ = mask
 	}
 	return true
 }
@@ -153,19 +162,28 @@ func (r *Relation) Len() int {
 }
 
 // Index returns (building lazily) a HashIndex over the given columns.
+// cols is sorted canonically so Index([0,2]) and Index([2,0]) share one index.
 func (r *Relation) Index(cols []int) *HashIndex {
-	mask := colMask(cols)
-	if hi, ok := r.indexes[mask]; ok {
+	// Canonicalise col order for the map key and index build.
+	sorted := make([]int, len(cols))
+	copy(sorted, cols)
+	for i := 1; i < len(sorted); i++ {
+		for j := i; j > 0 && sorted[j] < sorted[j-1]; j-- {
+			sorted[j], sorted[j-1] = sorted[j-1], sorted[j]
+		}
+	}
+	key := sortedColKey(sorted)
+	if hi, ok := r.indexes[key]; ok {
 		return hi
 	}
 	hi := &HashIndex{
-		cols:  cols,
+		cols:  sorted,
 		index: make(map[string][]int, len(r.tuples)),
 	}
 	for i, t := range r.tuples {
-		k := partialKey(t, cols)
+		k := partialKey(t, sorted)
 		hi.index[k] = append(hi.index[k], i)
 	}
-	r.indexes[mask] = hi
+	r.indexes[key] = hi
 	return hi
 }

--- a/ql/eval/relation.go
+++ b/ql/eval/relation.go
@@ -1,0 +1,171 @@
+package eval
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Value is a typed Datalog value.
+type Value interface{ evalValue() }
+
+// IntVal is an integer (or entity ref) Datalog value.
+type IntVal struct{ V int64 }
+
+// StrVal is a string Datalog value.
+type StrVal struct{ V string }
+
+func (IntVal) evalValue() {}
+func (StrVal) evalValue() {}
+
+// Tuple is a row of values.
+type Tuple []Value
+
+// tupleKey encodes a Tuple as a string suitable for use as a map key.
+// Uses \x00 as separator (assumes strings don't contain \x00).
+func tupleKey(t Tuple) string {
+	if len(t) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, v := range t {
+		if i > 0 {
+			b.WriteByte('\x00')
+		}
+		switch vv := v.(type) {
+		case IntVal:
+			fmt.Fprintf(&b, "i%d", vv.V)
+		case StrVal:
+			b.WriteByte('s')
+			b.WriteString(vv.V)
+		default:
+			b.WriteString("?")
+		}
+	}
+	return b.String()
+}
+
+// partialKey encodes specific columns of a Tuple as a map key.
+func partialKey(t Tuple, cols []int) string {
+	var b strings.Builder
+	for i, col := range cols {
+		if i > 0 {
+			b.WriteByte('\x00')
+		}
+		if col >= len(t) {
+			b.WriteString("nil")
+			continue
+		}
+		switch vv := t[col].(type) {
+		case IntVal:
+			fmt.Fprintf(&b, "i%d", vv.V)
+		case StrVal:
+			b.WriteByte('s')
+			b.WriteString(vv.V)
+		default:
+			b.WriteString("?")
+		}
+	}
+	return b.String()
+}
+
+// colMask builds a uint64 bitmask from a list of column indices.
+func colMask(cols []int) uint64 {
+	var mask uint64
+	for _, c := range cols {
+		if c < 64 {
+			mask |= 1 << uint(c)
+		}
+	}
+	return mask
+}
+
+// HashIndex maps a key (values of specific columns) to matching tuple indices.
+type HashIndex struct {
+	cols  []int
+	index map[string][]int // key → list of indices into the parent relation's tuples
+}
+
+// Lookup returns the tuple indices (into the owning Relation's Tuples slice)
+// matching the given key values on the indexed columns.
+// key[i] is the value to match for hi.cols[i].
+func (hi *HashIndex) Lookup(key []Value) []int {
+	// Build a lookup key from the values directly (not via column re-indexing).
+	seqCols := make([]int, len(key))
+	for i := range key {
+		seqCols[i] = i
+	}
+	k := partialKey(Tuple(key), seqCols)
+	return hi.index[k]
+}
+
+// Relation is an in-memory set of tuples with lazy hash indexes.
+type Relation struct {
+	Name    string
+	Arity   int
+	tuples  []Tuple
+	set     map[string]struct{} // deduplication
+	Delta   []Tuple             // new tuples from last iteration (semi-naive)
+	indexes map[uint64]*HashIndex
+}
+
+// NewRelation creates an empty relation.
+func NewRelation(name string, arity int) *Relation {
+	return &Relation{
+		Name:    name,
+		Arity:   arity,
+		set:     make(map[string]struct{}),
+		indexes: make(map[uint64]*HashIndex),
+	}
+}
+
+// Add adds a tuple to the relation. Returns true if the tuple was new (actually added).
+// Invalidates all indexes.
+func (r *Relation) Add(t Tuple) bool {
+	k := tupleKey(t)
+	if _, exists := r.set[k]; exists {
+		return false
+	}
+	r.set[k] = struct{}{}
+	r.tuples = append(r.tuples, t)
+	// Invalidate all indexes since the tuple list grew.
+	for mask, idx := range r.indexes {
+		colKey := partialKey(t, idx.cols)
+		idx.index[colKey] = append(idx.index[colKey], len(r.tuples)-1)
+		_ = mask
+	}
+	return true
+}
+
+// Contains reports whether the relation contains the given tuple.
+func (r *Relation) Contains(t Tuple) bool {
+	_, ok := r.set[tupleKey(t)]
+	return ok
+}
+
+// Tuples returns all tuples in the relation.
+func (r *Relation) Tuples() []Tuple {
+	return r.tuples
+}
+
+// Len returns the number of tuples.
+func (r *Relation) Len() int {
+	return len(r.tuples)
+}
+
+// Index returns (building lazily) a HashIndex over the given columns.
+func (r *Relation) Index(cols []int) *HashIndex {
+	mask := colMask(cols)
+	if hi, ok := r.indexes[mask]; ok {
+		return hi
+	}
+	hi := &HashIndex{
+		cols:  cols,
+		index: make(map[string][]int, len(r.tuples)),
+	}
+	for i, t := range r.tuples {
+		k := partialKey(t, cols)
+		hi.index[k] = append(hi.index[k], i)
+	}
+	r.indexes[mask] = hi
+	return hi
+}

--- a/ql/eval/relation_test.go
+++ b/ql/eval/relation_test.go
@@ -1,0 +1,118 @@
+package eval
+
+import (
+	"testing"
+)
+
+func TestRelationAddDedup(t *testing.T) {
+	r := NewRelation("test", 2)
+	t1 := Tuple{IntVal{1}, StrVal{"a"}}
+	t2 := Tuple{IntVal{2}, StrVal{"b"}}
+	t3 := Tuple{IntVal{1}, StrVal{"a"}} // duplicate of t1
+
+	if !r.Add(t1) {
+		t.Fatal("expected Add(t1) to return true (new)")
+	}
+	if !r.Add(t2) {
+		t.Fatal("expected Add(t2) to return true (new)")
+	}
+	if r.Add(t3) {
+		t.Fatal("expected Add(t3) to return false (duplicate)")
+	}
+	if r.Len() != 2 {
+		t.Fatalf("expected 2 tuples, got %d", r.Len())
+	}
+}
+
+func TestRelationContains(t *testing.T) {
+	r := NewRelation("test", 2)
+	t1 := Tuple{IntVal{42}, StrVal{"hello"}}
+	r.Add(t1)
+
+	if !r.Contains(t1) {
+		t.Error("Contains should return true for added tuple")
+	}
+	if r.Contains(Tuple{IntVal{99}, StrVal{"hello"}}) {
+		t.Error("Contains should return false for absent tuple")
+	}
+}
+
+func TestRelationEmpty(t *testing.T) {
+	r := NewRelation("empty", 3)
+	if r.Len() != 0 {
+		t.Errorf("expected 0, got %d", r.Len())
+	}
+	if len(r.Tuples()) != 0 {
+		t.Error("expected empty tuples slice")
+	}
+	if r.Contains(Tuple{IntVal{1}, IntVal{2}, IntVal{3}}) {
+		t.Error("empty relation should contain nothing")
+	}
+}
+
+func TestRelationIndexSingleColumn(t *testing.T) {
+	r := NewRelation("rel", 3)
+	r.Add(Tuple{IntVal{1}, StrVal{"a"}, IntVal{10}})
+	r.Add(Tuple{IntVal{1}, StrVal{"b"}, IntVal{20}})
+	r.Add(Tuple{IntVal{2}, StrVal{"a"}, IntVal{30}})
+	r.Add(Tuple{IntVal{3}, StrVal{"c"}, IntVal{40}})
+
+	idx := r.Index([]int{0}) // index on first column
+	hits := idx.Lookup([]Value{IntVal{1}})
+	if len(hits) != 2 {
+		t.Fatalf("expected 2 hits for key=1, got %d", len(hits))
+	}
+	// Verify the tuples at those indices are correct.
+	tuples := r.Tuples()
+	for _, hi := range hits {
+		if tuples[hi][0] != (IntVal{1}) {
+			t.Errorf("expected first col = 1, got %v", tuples[hi][0])
+		}
+	}
+
+	hits2 := idx.Lookup([]Value{IntVal{99}})
+	if len(hits2) != 0 {
+		t.Error("expected 0 hits for absent key")
+	}
+}
+
+func TestRelationIndexMultiColumn(t *testing.T) {
+	r := NewRelation("rel", 3)
+	r.Add(Tuple{IntVal{1}, StrVal{"x"}, IntVal{10}})
+	r.Add(Tuple{IntVal{1}, StrVal{"x"}, IntVal{20}})
+	r.Add(Tuple{IntVal{1}, StrVal{"y"}, IntVal{30}})
+	r.Add(Tuple{IntVal{2}, StrVal{"x"}, IntVal{40}})
+
+	// Index on (col0, col1).
+	idx := r.Index([]int{0, 1})
+	hits := idx.Lookup([]Value{IntVal{1}, StrVal{"x"}})
+	if len(hits) != 2 {
+		t.Fatalf("expected 2 hits for (1, x), got %d: %v", len(hits), hits)
+	}
+	hits2 := idx.Lookup([]Value{IntVal{1}, StrVal{"y"}})
+	if len(hits2) != 1 {
+		t.Fatalf("expected 1 hit for (1, y), got %d", len(hits2))
+	}
+	hits3 := idx.Lookup([]Value{IntVal{2}, StrVal{"x"}})
+	if len(hits3) != 1 {
+		t.Fatalf("expected 1 hit for (2, x), got %d", len(hits3))
+	}
+}
+
+func TestRelationIndexAfterAdd(t *testing.T) {
+	// Index is built lazily; verify it is consistent after adding more tuples.
+	r := NewRelation("rel", 2)
+	r.Add(Tuple{IntVal{1}, StrVal{"a"}})
+	idx := r.Index([]int{0}) // build index now
+	r.Add(Tuple{IntVal{1}, StrVal{"b"}})
+	r.Add(Tuple{IntVal{2}, StrVal{"c"}})
+
+	hits := idx.Lookup([]Value{IntVal{1}})
+	if len(hits) != 2 {
+		t.Fatalf("expected 2 hits after incremental add, got %d", len(hits))
+	}
+	hits2 := idx.Lookup([]Value{IntVal{2}})
+	if len(hits2) != 1 {
+		t.Fatalf("expected 1 hit for key=2, got %d", len(hits2))
+	}
+}

--- a/ql/eval/seminaive.go
+++ b/ql/eval/seminaive.go
@@ -1,0 +1,147 @@
+package eval
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// ResultSet holds the query results.
+type ResultSet struct {
+	Columns []string // column names (from query select)
+	Rows    [][]Value
+}
+
+// Evaluate executes an ExecutionPlan over base facts and returns results.
+func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[string]*Relation) (*ResultSet, error) {
+	// allRels starts with base facts; derived relations are added as we go.
+	allRels := make(map[string]*Relation, len(baseRels))
+	for k, v := range baseRels {
+		allRels[k] = v
+	}
+
+	for si, stratum := range execPlan.Strata {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("cancelled before stratum %d: %w", si, err)
+		}
+
+		// Ensure head relations exist.
+		for _, rule := range stratum.Rules {
+			headName := rule.Head.Predicate
+			if _, ok := allRels[headName]; !ok {
+				allRels[headName] = NewRelation(headName, len(rule.Head.Args))
+			}
+		}
+
+		// Bootstrap: evaluate each rule once using full relations as source.
+		deltaRels := make(map[string]*Relation)
+		for _, rule := range stratum.Rules {
+			headName := rule.Head.Predicate
+			headRel := allRels[headName]
+
+			newTuples := EvalRule(rule, allRels)
+			for _, t := range newTuples {
+				if headRel.Add(t) {
+					dr, ok := deltaRels[headName]
+					if !ok {
+						dr = NewRelation(headName, headRel.Arity)
+						deltaRels[headName] = dr
+					}
+					dr.Add(t)
+				}
+			}
+		}
+
+		// Semi-naive fixpoint.
+		for {
+			if err := ctx.Err(); err != nil {
+				return nil, fmt.Errorf("cancelled in fixpoint stratum %d: %w", si, err)
+			}
+
+			// Check if any delta is non-empty.
+			anyDelta := false
+			for _, dr := range deltaRels {
+				if dr.Len() > 0 {
+					anyDelta = true
+					break
+				}
+			}
+			if !anyDelta {
+				break
+			}
+
+			nextDelta := make(map[string]*Relation)
+			for _, rule := range stratum.Rules {
+				headName := rule.Head.Predicate
+				headRel := allRels[headName]
+
+				newTuples := EvalRuleDelta(rule, allRels, deltaRels)
+				for _, t := range newTuples {
+					if headRel.Add(t) {
+						dr, ok := nextDelta[headName]
+						if !ok {
+							dr = NewRelation(headName, headRel.Arity)
+							nextDelta[headName] = dr
+						}
+						dr.Add(t)
+					}
+				}
+			}
+			deltaRels = nextDelta
+		}
+
+		// Evaluate aggregates after fixpoint.
+		for _, agg := range stratum.Aggregates {
+			resultRel := EvalAggregate(agg, allRels)
+			allRels[agg.ResultRelation] = resultRel
+		}
+	}
+
+	// Evaluate the query.
+	if execPlan.Query == nil {
+		return &ResultSet{}, nil
+	}
+
+	return evalQuery(execPlan.Query, allRels), nil
+}
+
+// evalQuery evaluates the planned query and returns a ResultSet.
+func evalQuery(q *plan.PlannedQuery, allRels map[string]*Relation) *ResultSet {
+	initial := []binding{make(binding)}
+	bindings := evalJoinSteps(q.JoinOrder, allRels, initial)
+
+	rs := &ResultSet{}
+
+	// Build column names from select terms.
+	for i, sel := range q.Select {
+		switch sv := sel.(type) {
+		case interface{ Name() string }:
+			rs.Columns = append(rs.Columns, sv.Name())
+		default:
+			rs.Columns = append(rs.Columns, fmt.Sprintf("col%d", i))
+		}
+	}
+	if len(rs.Columns) == 0 {
+		for i := range q.Select {
+			rs.Columns = append(rs.Columns, fmt.Sprintf("col%d", i))
+		}
+	}
+
+	for _, b := range bindings {
+		row := make([]Value, len(q.Select))
+		valid := true
+		for i, sel := range q.Select {
+			v, ok := lookupTerm(sel, b)
+			if !ok {
+				valid = false
+				break
+			}
+			row[i] = v
+		}
+		if valid {
+			rs.Rows = append(rs.Rows, row)
+		}
+	}
+	return rs
+}

--- a/ql/eval/seminaive.go
+++ b/ql/eval/seminaive.go
@@ -40,7 +40,7 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 			headName := rule.Head.Predicate
 			headRel := allRels[headName]
 
-			newTuples := EvalRule(rule, allRels)
+			newTuples := Rule(rule, allRels)
 			for _, t := range newTuples {
 				if headRel.Add(t) {
 					dr, ok := deltaRels[headName]
@@ -76,7 +76,7 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 				headName := rule.Head.Predicate
 				headRel := allRels[headName]
 
-				newTuples := EvalRuleDelta(rule, allRels, deltaRels)
+				newTuples := RuleDelta(rule, allRels, deltaRels)
 				for _, t := range newTuples {
 					if headRel.Add(t) {
 						dr, ok := nextDelta[headName]
@@ -93,7 +93,7 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 
 		// Evaluate aggregates after fixpoint.
 		for _, agg := range stratum.Aggregates {
-			resultRel := EvalAggregate(agg, allRels)
+			resultRel := Aggregate(agg, allRels)
 			allRels[agg.ResultRelation] = resultRel
 		}
 	}

--- a/ql/eval/seminaive_test.go
+++ b/ql/eval/seminaive_test.go
@@ -1,0 +1,288 @@
+package eval
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// TestSeminaiveNonRecursive verifies that a single non-recursive rule
+// terminates in one iteration and produces correct results.
+func TestSeminaiveNonRecursive(t *testing.T) {
+	// Rule: Q(x,y) :- A(x,y).
+	A := makeRelation("A", 2,
+		IntVal{1}, IntVal{2},
+		IntVal{3}, IntVal{4},
+	)
+	baseRels := map[string]*Relation{"A": A}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{
+			{
+				Rules: []plan.PlannedRule{
+					{
+						Head: datalog.Atom{Predicate: "Q", Args: []datalog.Term{v("x"), v("y")}},
+						JoinOrder: []plan.JoinStep{
+							positiveStep("A", v("x"), v("y")),
+						},
+					},
+				},
+			},
+		},
+		Query: &plan.PlannedQuery{
+			Select: []datalog.Term{v("x"), v("y")},
+			JoinOrder: []plan.JoinStep{
+				positiveStep("Q", v("x"), v("y")),
+			},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(rs.Rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestSeminaiveTransitiveClosure verifies semi-naive evaluation computes
+// the transitive closure of a 5-node chain correctly.
+//
+// Base: Edge(1,2), Edge(2,3), Edge(3,4), Edge(4,5)
+// Rules:
+//
+//	Path(x,y) :- Edge(x,y).
+//	Path(x,z) :- Edge(x,y), Path(y,z).
+//
+// Expected Path: all pairs (i,j) where i < j and a path exists.
+// For a chain 1→2→3→4→5:
+//
+//	(1,2),(1,3),(1,4),(1,5)
+//	(2,3),(2,4),(2,5)
+//	(3,4),(3,5)
+//	(4,5)
+//
+// = 4+3+2+1 = 10 pairs.
+func TestSeminaiveTransitiveClosure(t *testing.T) {
+	edge := makeRelation("Edge", 2,
+		IntVal{1}, IntVal{2},
+		IntVal{2}, IntVal{3},
+		IntVal{3}, IntVal{4},
+		IntVal{4}, IntVal{5},
+	)
+	baseRels := map[string]*Relation{"Edge": edge}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{
+			{
+				Rules: []plan.PlannedRule{
+					// Path(x,y) :- Edge(x,y).
+					{
+						Head: datalog.Atom{Predicate: "Path", Args: []datalog.Term{v("x"), v("y")}},
+						JoinOrder: []plan.JoinStep{
+							positiveStep("Edge", v("x"), v("y")),
+						},
+					},
+					// Path(x,z) :- Edge(x,y), Path(y,z).
+					{
+						Head: datalog.Atom{Predicate: "Path", Args: []datalog.Term{v("x"), v("z")}},
+						JoinOrder: []plan.JoinStep{
+							positiveStep("Edge", v("x"), v("y")),
+							positiveStep("Path", v("y"), v("z")),
+						},
+					},
+				},
+			},
+		},
+		Query: &plan.PlannedQuery{
+			Select: []datalog.Term{v("a"), v("b")},
+			JoinOrder: []plan.JoinStep{
+				positiveStep("Path", v("a"), v("b")),
+			},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+
+	// Collect all (from, to) pairs.
+	got := make(map[[2]int64]bool)
+	for _, row := range rs.Rows {
+		from := row[0].(IntVal).V
+		to := row[1].(IntVal).V
+		got[[2]int64{from, to}] = true
+	}
+
+	// All expected reachability pairs.
+	expected := [][2]int64{
+		{1, 2}, {1, 3}, {1, 4}, {1, 5},
+		{2, 3}, {2, 4}, {2, 5},
+		{3, 4}, {3, 5},
+		{4, 5},
+	}
+
+	if len(rs.Rows) != len(expected) {
+		t.Fatalf("expected %d path tuples, got %d: %v", len(expected), len(rs.Rows), rs.Rows)
+	}
+	for _, pair := range expected {
+		if !got[pair] {
+			t.Errorf("missing path (%d,%d)", pair[0], pair[1])
+		}
+	}
+}
+
+// TestSeminaiveTwoStrataWithNegation verifies two strata where the second
+// uses negation over results computed in the first.
+//
+// Stratum 0: A(x) :- Base(x).
+// Stratum 1: B(x) :- Base(x), not A(x).  [should be empty]
+//
+// Since A contains everything in Base, B should be empty.
+func TestSeminaiveTwoStrataWithNegation(t *testing.T) {
+	base := makeRelation("Base", 1, IntVal{1}, IntVal{2}, IntVal{3})
+	baseRels := map[string]*Relation{"Base": base}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{
+			// Stratum 0: A(x) :- Base(x).
+			{
+				Rules: []plan.PlannedRule{
+					{
+						Head: datalog.Atom{Predicate: "A", Args: []datalog.Term{v("x")}},
+						JoinOrder: []plan.JoinStep{
+							positiveStep("Base", v("x")),
+						},
+					},
+				},
+			},
+			// Stratum 1: B(x) :- Base(x), not A(x).
+			{
+				Rules: []plan.PlannedRule{
+					{
+						Head: datalog.Atom{Predicate: "B", Args: []datalog.Term{v("x")}},
+						JoinOrder: []plan.JoinStep{
+							positiveStep("Base", v("x")),
+							negativeStep("A", v("x")),
+						},
+					},
+				},
+			},
+		},
+		Query: &plan.PlannedQuery{
+			Select: []datalog.Term{v("x")},
+			JoinOrder: []plan.JoinStep{
+				positiveStep("B", v("x")),
+			},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(rs.Rows) != 0 {
+		t.Errorf("expected 0 rows (B should be empty), got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestSeminaiveAggregateAfterFixpoint verifies that an aggregate is evaluated
+// after the stratum's fixpoint, not during it.
+//
+// Base: Val(1), Val(2), Val(3).
+// Stratum 0: A(x) :- Val(x). [fixpoint: A = {1,2,3}]
+//            count(x | A(x)) → Cnt(3).
+func TestSeminaiveAggregateAfterFixpoint(t *testing.T) {
+	val := makeRelation("Val", 1, IntVal{1}, IntVal{2}, IntVal{3})
+	baseRels := map[string]*Relation{"Val": val}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{
+			{
+				Rules: []plan.PlannedRule{
+					{
+						Head: datalog.Atom{Predicate: "A", Args: []datalog.Term{v("x")}},
+						JoinOrder: []plan.JoinStep{
+							positiveStep("Val", v("x")),
+						},
+					},
+				},
+				Aggregates: []plan.PlannedAggregate{
+					{
+						ResultRelation: "Cnt",
+						GroupByVars:    nil,
+						Agg: datalog.Aggregate{
+							Func:      "count",
+							Var:       "x",
+							ResultVar: datalog.Var{Name: "Cnt"},
+							Body: []datalog.Literal{
+								{
+									Positive: true,
+									Atom: datalog.Atom{
+										Predicate: "A",
+										Args:      []datalog.Term{v("x")},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Query: &plan.PlannedQuery{
+			Select: []datalog.Term{v("n")},
+			JoinOrder: []plan.JoinStep{
+				positiveStep("Cnt", v("n")),
+			},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	cnt := rs.Rows[0][0].(IntVal).V
+	if cnt != 3 {
+		t.Errorf("expected count=3, got %d", cnt)
+	}
+}
+
+// TestSeminaiveCancellation verifies context cancellation is respected.
+func TestSeminaiveCancellation(t *testing.T) {
+	// Build a trivial plan that would otherwise succeed.
+	A := makeRelation("A", 1, IntVal{1})
+	baseRels := map[string]*Relation{"A": A}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{
+			{
+				Rules: []plan.PlannedRule{
+					{
+						Head: datalog.Atom{Predicate: "B", Args: []datalog.Term{v("x")}},
+						JoinOrder: []plan.JoinStep{
+							positiveStep("A", v("x")),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := Evaluate(ctx, ep, baseRels)
+	if err == nil {
+		// It may succeed because the stratum finished before the cancellation
+		// check if the stratum has no fixpoint iteration needed. That's fine —
+		// the important thing is it does not panic.
+		t.Log("no error returned for pre-cancelled context (stratum may have completed)")
+	}
+}

--- a/ql/eval/seminaive_test.go
+++ b/ql/eval/seminaive_test.go
@@ -195,7 +195,8 @@ func TestSeminaiveTwoStrataWithNegation(t *testing.T) {
 //
 // Base: Val(1), Val(2), Val(3).
 // Stratum 0: A(x) :- Val(x). [fixpoint: A = {1,2,3}]
-//            count(x | A(x)) → Cnt(3).
+//
+//	count(x | A(x)) → Cnt(3).
 func TestSeminaiveAggregateAfterFixpoint(t *testing.T) {
 	val := makeRelation("Val", 1, IntVal{1}, IntVal{2}, IntVal{3})
 	baseRels := map[string]*Relation{"Val": val}
@@ -251,6 +252,84 @@ func TestSeminaiveAggregateAfterFixpoint(t *testing.T) {
 	cnt := rs.Rows[0][0].(IntVal).V
 	if cnt != 3 {
 		t.Errorf("expected count=3, got %d", cnt)
+	}
+}
+
+// TestSeminaiveSelfRecursivePath verifies correct semi-naive evaluation for
+// a purely self-recursive path rule on a 4-node chain: 1→2→3→4.
+//
+// Rules:
+//
+//	Path(x,y) :- Edge(x,y).
+//	Path(x,z) :- Path(x,y), Path(y,z).
+//
+// Expected 6 pairs: (1,2),(2,3),(3,4),(1,3),(2,4),(1,4).
+// The purely self-recursive rule requires position-aware delta substitution:
+// each semi-naive variant must use delta at exactly ONE of the two Path
+// positions, not both. Using delta at both would over-count and miss pairs.
+func TestSeminaiveSelfRecursivePath(t *testing.T) {
+	edge := makeRelation("Edge", 2,
+		IntVal{1}, IntVal{2},
+		IntVal{2}, IntVal{3},
+		IntVal{3}, IntVal{4},
+	)
+	baseRels := map[string]*Relation{"Edge": edge}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{
+			{
+				Rules: []plan.PlannedRule{
+					// Path(x,y) :- Edge(x,y).
+					{
+						Head: datalog.Atom{Predicate: "Path", Args: []datalog.Term{v("x"), v("y")}},
+						JoinOrder: []plan.JoinStep{
+							positiveStep("Edge", v("x"), v("y")),
+						},
+					},
+					// Path(x,z) :- Path(x,y), Path(y,z).
+					{
+						Head: datalog.Atom{Predicate: "Path", Args: []datalog.Term{v("x"), v("z")}},
+						JoinOrder: []plan.JoinStep{
+							positiveStep("Path", v("x"), v("y")),
+							positiveStep("Path", v("y"), v("z")),
+						},
+					},
+				},
+			},
+		},
+		Query: &plan.PlannedQuery{
+			Select: []datalog.Term{v("a"), v("b")},
+			JoinOrder: []plan.JoinStep{
+				positiveStep("Path", v("a"), v("b")),
+			},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+
+	got := make(map[[2]int64]bool)
+	for _, row := range rs.Rows {
+		from := row[0].(IntVal).V
+		to := row[1].(IntVal).V
+		got[[2]int64{from, to}] = true
+	}
+
+	expected := [][2]int64{
+		{1, 2}, {2, 3}, {3, 4},
+		{1, 3}, {2, 4},
+		{1, 4},
+	}
+
+	if len(rs.Rows) != len(expected) {
+		t.Fatalf("expected %d path tuples, got %d: %v", len(expected), len(rs.Rows), rs.Rows)
+	}
+	for _, pair := range expected {
+		if !got[pair] {
+			t.Errorf("missing path (%d,%d)", pair[0], pair[1])
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Implements `ql/eval` package: in-memory `Relation` with lazy `HashIndex`, semi-naive bottom-up fixpoint loop, join/anti-join/comparison execution, aggregate evaluation (count/min/max/sum/avg), and top-level `Evaluator` that loads base facts from `extract/db`
- 27 tests across 5 test files; transitive closure on a 5-node chain verified correct (10 reachable pairs)
- Fixed a HashIndex `Lookup` key-encoding bug discovered during integration testing

## Key design decisions

- **HashIndex key encoding:** `\x00`-separated type-tagged values (`i<int>` / `s<str>`). Indexes built lazily on first access; incrementally updated on subsequent `Add` calls.
- **EvalRuleDelta:** For each body literal with a non-empty delta, generates one evaluation variant using only that literal's delta relation. Results are unioned and deduplicated. This is the standard semi-naive expansion.
- **Aggregate bodies:** Evaluated with naive left-to-right literal ordering (no planner involvement). Correct; a future optimisation would pre-plan aggregate bodies.
- **Wildcard terms:** Matched in join execution by being absent from both bound-column and free-variable lists — they contribute neither constraints nor bindings.

## Test plan

- [x] `go build ./ql/eval/...` — passes
- [x] `go vet ./ql/eval/...` — passes  
- [x] `go test ./ql/eval/... -v` — all 27 tests pass
- [x] `go test ./ql/...` — all ql packages pass
- [x] Transitive closure test (`TestSeminaiveTransitiveClosure`) — 5-node chain, 10 reachable pairs
- [x] Integration test (`TestEvaluatorIntegration`) — round-trips through DB writer, reader, evaluator