### PR TITLE
Phase 7: CLI and output formatters

### DIFF
--- a/HANDOVER-phase-7.md
+++ b/HANDOVER-phase-7.md
@@ -1,0 +1,81 @@
+# Phase 7: CLI and Output Formatters — Handover
+
+## What was built
+
+### CLI (`cmd/tsq/main.go`)
+
+Subcommand-based CLI using raw `flag` (zero external deps):
+
+| Command | Purpose |
+|---------|---------|
+| `tsq extract [--dir DIR] [--output FILE]` | Run extraction, write fact DB |
+| `tsq query [--db FILE] [--format sarif\|json\|csv] QUERY_FILE` | Evaluate a QL query against a fact DB |
+| `tsq check QUERY_FILE` | Parse, resolve, and plan a QL file; report errors and capability warnings |
+| `tsq version` | Print version info |
+
+**Global flags:** `--verbose`, `--quiet`, `--timeout DURATION` (parsed before the subcommand).
+
+**Signal handling:** SIGINT/SIGTERM trigger context cancellation for graceful shutdown.
+
+**Error handling:** User-friendly error messages on stderr, non-zero exit codes on failure.
+
+**Exit codes:** 0 = success, 1 = error.
+
+### Output formatters (`output/` package)
+
+| File | Format | Description |
+|------|--------|-------------|
+| `output/sarif.go` | SARIF 2.1.0 | Full SARIF JSON with location heuristics (columns named `file`/`path` → URI, `line`/`startLine` → line, `col`/`column` → column) |
+| `output/json.go` | JSON Lines | One JSON object per result row; IntVal → number, StrVal → string |
+| `output/csv.go` | CSV (RFC 4180) | Header row + data rows; handles commas, quotes, and newlines in values |
+
+### Test files
+
+| File | Tests |
+|------|-------|
+| `output/sarif_test.go` | Empty result set, single result with location, multiple results, SARIF structure validity |
+| `output/json_test.go` | Empty, single row, special characters, integer values, multiple rows |
+| `output/csv_test.go` | Empty, single row, commas in values, newlines in values, quotes in values |
+| `cmd/tsq/main_test.go` | Version prints, unknown subcommand errors, missing args, bad format, nonexistent file |
+
+## Pipeline wiring
+
+The full pipeline from CLI perspective:
+
+```
+[.ql source] → parse.NewParser().Parse()
+             → resolve.Resolve(mod, bridgeImportLoader)
+             → desugar.Desugar(resolved)
+             → plan.Plan(prog, sizeHints)
+             → eval.NewEvaluator(execPlan, factDB)
+             → evaluator.Evaluate(ctx)
+             → ResultSet
+
+[fact DB file] → os.Open → db.ReadDB(f, size) → *db.DB (passed to NewEvaluator)
+```
+
+The bridge import loader (`makeBridgeImportLoader`) maps `tsq::*` import paths to embedded `.qll` files, parses them with `parse.NewParser`, and returns `*ast.Module` for the resolver.
+
+## Design decisions
+
+1. **`run()` function for testability** — `main()` delegates to `run(args, stdout, stderr) int`, making the CLI fully testable without process execution.
+
+2. **Global flags before subcommand** — parsed manually before dispatching to subcommand-specific `flag.FlagSet`. This avoids cobra while keeping clean flag handling.
+
+3. **SARIF location heuristics** — columns are matched by well-known names (`file`, `path`, `line`, `col`, etc.) rather than requiring explicit location metadata in queries. This works naturally with typical tsq query patterns.
+
+4. **JSON Lines not JSON array** — one object per line is streamable and works with `jq`, `grep`, etc. No array wrapping.
+
+5. **Extract requires CGO_ENABLED=1** — tree-sitter binding is CGO. Documented in extract help text. Query/check commands work without CGO.
+
+## CGO note
+
+The `extract` command imports `extract.TreeSitterBackend` which requires CGO for tree-sitter. The `query` and `check` commands do not use tree-sitter at runtime, but because they share the binary, CGO_ENABLED=1 is required at build time.
+
+## What's NOT in this phase
+
+- Interactive REPL
+- Watch mode / incremental rebuilding
+- Configuration file
+- Plugin system
+- Size hints from DB for planner optimization (could be added by iterating schema.Registry and calling `factDB.Relation(name).Tuples()`)

--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -3,11 +3,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -32,7 +34,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "usage: tsq <command> [flags]")
 		fmt.Fprintln(stderr, "commands: extract, query, check, version")
-		return 1
+		return 2
 	}
 
 	// Parse global flags that appear before the subcommand.
@@ -40,7 +42,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	var timeout time.Duration
 
 	// Find the subcommand: skip global flags.
-	subcmdIdx := 0
+	subcmdIdx := -1
 	for i, arg := range args {
 		if arg == "--verbose" || arg == "-verbose" {
 			verbose = true
@@ -62,6 +64,12 @@ func run(args []string, stdout, stderr io.Writer) int {
 		}
 		subcmdIdx = i
 		break
+	}
+
+	if subcmdIdx < 0 {
+		fmt.Fprintln(stderr, "usage: tsq <command> [flags]")
+		fmt.Fprintln(stderr, "commands: extract, query, check, version")
+		return 2
 	}
 
 	subcmd := args[subcmdIdx]
@@ -103,7 +111,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	default:
 		fmt.Fprintf(stderr, "error: unknown command %q\n", subcmd)
 		fmt.Fprintln(stderr, "commands: extract, query, check, version")
-		return 1
+		return 2
 	}
 }
 
@@ -114,6 +122,9 @@ func cmdExtract(ctx context.Context, args []string, stdout, stderr io.Writer) in
 	outputFile := fs.String("output", "tsq.db", "output fact database file")
 
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
 		return 1
 	}
 
@@ -122,27 +133,48 @@ func cmdExtract(ctx context.Context, args []string, stdout, stderr io.Writer) in
 	database := db.NewDB()
 	walker := extract.NewFactWalker(database)
 	backend := &extract.TreeSitterBackend{}
+	defer func() {
+		if err := backend.Close(); err != nil {
+			fmt.Fprintf(stderr, "warning: close backend: %v\n", err)
+		}
+	}()
 
 	cfg := extract.ProjectConfig{RootDir: *dir}
 	if err := walker.Run(ctx, backend, cfg); err != nil {
 		fmt.Fprintf(stderr, "error: extraction failed: %v\n", err)
 		return 1
 	}
-	if err := backend.Close(); err != nil {
-		fmt.Fprintf(stderr, "warning: close backend: %v\n", err)
-	}
 
-	f, err := os.Create(*outputFile)
+	// Write to a temp file first, rename on success to avoid partial output.
+	outDir := filepath.Dir(*outputFile)
+	tmpFile, err := os.CreateTemp(outDir, ".tsq-*.db.tmp")
 	if err != nil {
-		fmt.Fprintf(stderr, "error: create output file: %v\n", err)
+		fmt.Fprintf(stderr, "error: create temp file: %v\n", err)
 		return 1
 	}
-	defer f.Close()
+	tmpPath := tmpFile.Name()
+	success := false
+	defer func() {
+		if !success {
+			os.Remove(tmpPath)
+		}
+	}()
 
-	if err := database.Encode(f); err != nil {
+	if err := database.Encode(tmpFile); err != nil {
+		tmpFile.Close()
 		fmt.Fprintf(stderr, "error: write database: %v\n", err)
 		return 1
 	}
+	if err := tmpFile.Close(); err != nil {
+		fmt.Fprintf(stderr, "error: close temp file: %v\n", err)
+		return 1
+	}
+
+	if err := os.Rename(tmpPath, *outputFile); err != nil {
+		fmt.Fprintf(stderr, "error: rename output file: %v\n", err)
+		return 1
+	}
+	success = true
 
 	fmt.Fprintf(stderr, "wrote %s\n", *outputFile)
 	return 0
@@ -155,13 +187,16 @@ func cmdQuery(ctx context.Context, args []string, stdout, stderr io.Writer) int 
 	format := fs.String("format", "json", "output format: sarif, json, csv")
 
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
 		return 1
 	}
 
 	if fs.NArg() < 1 {
 		fmt.Fprintln(stderr, "error: query requires a QUERY_FILE argument")
 		fmt.Fprintln(stderr, "usage: tsq query [--db FILE] [--format sarif|json|csv] QUERY_FILE")
-		return 1
+		return 2
 	}
 	queryFile := fs.Arg(0)
 
@@ -210,13 +245,16 @@ func cmdCheck(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
 		return 1
 	}
 
 	if fs.NArg() < 1 {
 		fmt.Fprintln(stderr, "error: check requires a QUERY_FILE argument")
 		fmt.Fprintln(stderr, "usage: tsq check QUERY_FILE")
-		return 1
+		return 2
 	}
 	queryFile := fs.Arg(0)
 

--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -1,10 +1,397 @@
 // Package main is the entry point for the tsq CLI.
 package main
 
-import "fmt"
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
 
-const version = "0.0.1-dev"
+	"github.com/Gjdoalfnrxu/tsq/bridge"
+	"github.com/Gjdoalfnrxu/tsq/extract"
+	"github.com/Gjdoalfnrxu/tsq/extract/db"
+	"github.com/Gjdoalfnrxu/tsq/output"
+	"github.com/Gjdoalfnrxu/tsq/ql/ast"
+	"github.com/Gjdoalfnrxu/tsq/ql/desugar"
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+	"github.com/Gjdoalfnrxu/tsq/ql/parse"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+	"github.com/Gjdoalfnrxu/tsq/ql/resolve"
+)
+
+const version = "0.1.0"
+
+// run executes the CLI with the given args, writing to stdout/stderr.
+// Returns the exit code.
+func run(args []string, stdout, stderr io.Writer) int {
+	if len(args) < 1 {
+		fmt.Fprintln(stderr, "usage: tsq <command> [flags]")
+		fmt.Fprintln(stderr, "commands: extract, query, check, version")
+		return 1
+	}
+
+	// Parse global flags that appear before the subcommand.
+	var verbose, quiet bool
+	var timeout time.Duration
+
+	// Find the subcommand: skip global flags.
+	subcmdIdx := 0
+	for i, arg := range args {
+		if arg == "--verbose" || arg == "-verbose" {
+			verbose = true
+			continue
+		}
+		if arg == "--quiet" || arg == "-quiet" {
+			quiet = true
+			continue
+		}
+		if strings.HasPrefix(arg, "--timeout=") || strings.HasPrefix(arg, "-timeout=") {
+			parts := strings.SplitN(arg, "=", 2)
+			d, err := time.ParseDuration(parts[1])
+			if err != nil {
+				fmt.Fprintf(stderr, "error: invalid --timeout value: %v\n", err)
+				return 1
+			}
+			timeout = d
+			continue
+		}
+		subcmdIdx = i
+		break
+	}
+
+	subcmd := args[subcmdIdx]
+	subargs := args[subcmdIdx+1:]
+
+	// Set up context with signal handling and timeout.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		select {
+		case <-sigCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	if timeout > 0 {
+		var tcancel context.CancelFunc
+		ctx, tcancel = context.WithTimeout(ctx, timeout)
+		defer tcancel()
+	}
+
+	_ = verbose // available for future use
+	_ = quiet
+
+	switch subcmd {
+	case "version":
+		fmt.Fprintf(stdout, "tsq version %s\n", version)
+		return 0
+	case "extract":
+		return cmdExtract(ctx, subargs, stdout, stderr)
+	case "query":
+		return cmdQuery(ctx, subargs, stdout, stderr)
+	case "check":
+		return cmdCheck(subargs, stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "error: unknown command %q\n", subcmd)
+		fmt.Fprintln(stderr, "commands: extract, query, check, version")
+		return 1
+	}
+}
+
+func cmdExtract(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("extract", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	dir := fs.String("dir", ".", "project root directory")
+	outputFile := fs.String("output", "tsq.db", "output fact database file")
+
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	fmt.Fprintf(stderr, "extracting from %s (requires CGO_ENABLED=1 for tree-sitter)...\n", *dir)
+
+	database := db.NewDB()
+	walker := extract.NewFactWalker(database)
+	backend := &extract.TreeSitterBackend{}
+
+	cfg := extract.ProjectConfig{RootDir: *dir}
+	if err := walker.Run(ctx, backend, cfg); err != nil {
+		fmt.Fprintf(stderr, "error: extraction failed: %v\n", err)
+		return 1
+	}
+	if err := backend.Close(); err != nil {
+		fmt.Fprintf(stderr, "warning: close backend: %v\n", err)
+	}
+
+	f, err := os.Create(*outputFile)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: create output file: %v\n", err)
+		return 1
+	}
+	defer f.Close()
+
+	if err := database.Encode(f); err != nil {
+		fmt.Fprintf(stderr, "error: write database: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(stderr, "wrote %s\n", *outputFile)
+	return 0
+}
+
+func cmdQuery(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("query", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	dbFile := fs.String("db", "tsq.db", "fact database file")
+	format := fs.String("format", "json", "output format: sarif, json, csv")
+
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	if fs.NArg() < 1 {
+		fmt.Fprintln(stderr, "error: query requires a QUERY_FILE argument")
+		fmt.Fprintln(stderr, "usage: tsq query [--db FILE] [--format sarif|json|csv] QUERY_FILE")
+		return 1
+	}
+	queryFile := fs.Arg(0)
+
+	// Validate format.
+	switch *format {
+	case "json", "sarif", "csv":
+	default:
+		fmt.Fprintf(stderr, "error: unknown format %q (must be json, sarif, or csv)\n", *format)
+		return 1
+	}
+
+	// Read and compile the query.
+	rs, err := compileAndEval(ctx, queryFile, *dbFile)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	// Format output.
+	switch *format {
+	case "json":
+		if err := output.WriteJSONLines(stdout, rs); err != nil {
+			fmt.Fprintf(stderr, "error: write JSON output: %v\n", err)
+			return 1
+		}
+	case "sarif":
+		opts := output.SARIFOptions{
+			QueryName:   strings.TrimSuffix(queryFile, ".ql"),
+			ToolVersion: version,
+		}
+		if err := output.WriteSARIF(stdout, rs, opts); err != nil {
+			fmt.Fprintf(stderr, "error: write SARIF output: %v\n", err)
+			return 1
+		}
+	case "csv":
+		if err := output.WriteCSV(stdout, rs); err != nil {
+			fmt.Fprintf(stderr, "error: write CSV output: %v\n", err)
+			return 1
+		}
+	}
+	return 0
+}
+
+func cmdCheck(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("check", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	if fs.NArg() < 1 {
+		fmt.Fprintln(stderr, "error: check requires a QUERY_FILE argument")
+		fmt.Fprintln(stderr, "usage: tsq check QUERY_FILE")
+		return 1
+	}
+	queryFile := fs.Arg(0)
+
+	src, err := os.ReadFile(queryFile)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: read query file: %v\n", err)
+		return 1
+	}
+
+	// Parse.
+	p := parse.NewParser(string(src), queryFile)
+	mod, err := p.Parse()
+	if err != nil {
+		fmt.Fprintf(stderr, "parse error: %v\n", err)
+		return 1
+	}
+
+	// Resolve with bridge loader.
+	bridgeFiles := bridge.LoadBridge()
+	importLoader := makeBridgeImportLoader(bridgeFiles)
+	resolved, err := resolve.Resolve(mod, importLoader)
+	if err != nil {
+		fmt.Fprintf(stderr, "resolve error: %v\n", err)
+		return 1
+	}
+
+	hasErrors := false
+	if len(resolved.Errors) > 0 {
+		for _, e := range resolved.Errors {
+			fmt.Fprintf(stderr, "  %s\n", e.Error())
+		}
+		hasErrors = true
+	}
+
+	// Desugar.
+	prog, dsErrors := desugar.Desugar(resolved)
+	if len(dsErrors) > 0 {
+		for _, e := range dsErrors {
+			fmt.Fprintf(stderr, "  desugar: %v\n", e)
+		}
+		hasErrors = true
+	}
+
+	// Plan.
+	_, planErrors := plan.Plan(prog, nil)
+	if len(planErrors) > 0 {
+		for _, e := range planErrors {
+			fmt.Fprintf(stderr, "  plan: %v\n", e)
+		}
+		hasErrors = true
+	}
+
+	// Capability warnings.
+	manifest := bridge.V1Manifest()
+	var imports []string
+	for _, imp := range mod.Imports {
+		imports = append(imports, imp.Path)
+	}
+	warnings := manifest.CheckQuery(imports)
+	for _, w := range warnings {
+		fmt.Fprintf(stdout, "warning: import %q uses unavailable feature (%s, expected %s)\n",
+			w.Import, w.Reason, w.VersionTarget)
+	}
+
+	if hasErrors {
+		fmt.Fprintln(stderr, "check: errors found")
+		return 1
+	}
+
+	fmt.Fprintln(stdout, "check: ok")
+	return 0
+}
+
+// compileAndEval reads a .ql file, compiles it, loads a fact DB, and evaluates.
+func compileAndEval(ctx context.Context, queryFile, dbFile string) (*eval.ResultSet, error) {
+	src, err := os.ReadFile(queryFile)
+	if err != nil {
+		return nil, fmt.Errorf("read query file: %w", err)
+	}
+
+	// Parse.
+	p := parse.NewParser(string(src), queryFile)
+	mod, err := p.Parse()
+	if err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+
+	// Resolve.
+	bridgeFiles := bridge.LoadBridge()
+	importLoader := makeBridgeImportLoader(bridgeFiles)
+	resolved, err := resolve.Resolve(mod, importLoader)
+	if err != nil {
+		return nil, fmt.Errorf("resolve: %w", err)
+	}
+	if len(resolved.Errors) > 0 {
+		var msgs []string
+		for _, e := range resolved.Errors {
+			msgs = append(msgs, e.Error())
+		}
+		return nil, fmt.Errorf("resolve errors:\n  %s", strings.Join(msgs, "\n  "))
+	}
+
+	// Desugar.
+	prog, dsErrors := desugar.Desugar(resolved)
+	if len(dsErrors) > 0 {
+		var msgs []string
+		for _, e := range dsErrors {
+			msgs = append(msgs, e.Error())
+		}
+		return nil, fmt.Errorf("desugar errors:\n  %s", strings.Join(msgs, "\n  "))
+	}
+
+	// Plan.
+	execPlan, planErrors := plan.Plan(prog, nil)
+	if len(planErrors) > 0 {
+		var msgs []string
+		for _, e := range planErrors {
+			msgs = append(msgs, e.Error())
+		}
+		return nil, fmt.Errorf("plan errors:\n  %s", strings.Join(msgs, "\n  "))
+	}
+
+	// Load fact DB.
+	f, err := os.Open(dbFile)
+	if err != nil {
+		return nil, fmt.Errorf("open fact DB: %w", err)
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat fact DB: %w", err)
+	}
+
+	factDB, err := db.ReadDB(f, fi.Size())
+	if err != nil {
+		return nil, fmt.Errorf("read fact DB: %w", err)
+	}
+
+	// Evaluate.
+	evaluator := eval.NewEvaluator(execPlan, factDB)
+	rs, err := evaluator.Evaluate(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("evaluate: %w", err)
+	}
+	return rs, nil
+}
+
+// makeBridgeImportLoader creates an import loader that parses bridge .qll files.
+func makeBridgeImportLoader(bridgeFiles map[string][]byte) func(path string) (*ast.Module, error) {
+	pathToFile := map[string]string{
+		"tsq::base":        "tsq_base.qll",
+		"tsq::functions":   "tsq_functions.qll",
+		"tsq::calls":       "tsq_calls.qll",
+		"tsq::variables":   "tsq_variables.qll",
+		"tsq::expressions": "tsq_expressions.qll",
+		"tsq::jsx":         "tsq_jsx.qll",
+		"tsq::imports":     "tsq_imports.qll",
+		"tsq::errors":      "tsq_errors.qll",
+	}
+	return func(path string) (*ast.Module, error) {
+		filename, ok := pathToFile[path]
+		if !ok {
+			return nil, fmt.Errorf("unknown import: %s", path)
+		}
+		data, ok := bridgeFiles[filename]
+		if !ok {
+			return nil, fmt.Errorf("missing bridge file: %s", filename)
+		}
+		p := parse.NewParser(string(data), filename)
+		return p.Parse()
+	}
+}
 
 func main() {
-	fmt.Printf("tsq version %s\n", version)
+	code := run(os.Args[1:], os.Stdout, os.Stderr)
+	os.Exit(code)
 }

--- a/cmd/tsq/main_test.go
+++ b/cmd/tsq/main_test.go
@@ -1,9 +1,84 @@
 package main
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
 
 func TestVersion(t *testing.T) {
-	if version == "" {
-		t.Fatal("version must not be empty")
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"version"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "tsq version") {
+		t.Errorf("stdout = %q, want 'tsq version ...'", stdout.String())
+	}
+}
+
+func TestUnknownSubcommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"bogus"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "unknown command") {
+		t.Errorf("stderr = %q, want 'unknown command'", stderr.String())
+	}
+}
+
+func TestNoArgs(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Errorf("stderr = %q, want usage info", stderr.String())
+	}
+}
+
+func TestQueryMissingArgs(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"query"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "QUERY_FILE") {
+		t.Errorf("stderr = %q, want mention of QUERY_FILE", stderr.String())
+	}
+}
+
+func TestCheckMissingArgs(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"check"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "QUERY_FILE") {
+		t.Errorf("stderr = %q, want mention of QUERY_FILE", stderr.String())
+	}
+}
+
+func TestQueryBadFormat(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"query", "--format", "xml", "test.ql"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "unknown format") {
+		t.Errorf("stderr = %q, want 'unknown format'", stderr.String())
+	}
+}
+
+func TestCheckNonexistentFile(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"check", "/nonexistent/file.ql"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "error:") {
+		t.Errorf("stderr = %q, want error message", stderr.String())
 	}
 }

--- a/cmd/tsq/main_test.go
+++ b/cmd/tsq/main_test.go
@@ -20,8 +20,8 @@ func TestVersion(t *testing.T) {
 func TestUnknownSubcommand(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"bogus"}, &stdout, &stderr)
-	if code != 1 {
-		t.Fatalf("exit code = %d, want 1", code)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
 	}
 	if !strings.Contains(stderr.String(), "unknown command") {
 		t.Errorf("stderr = %q, want 'unknown command'", stderr.String())
@@ -31,8 +31,8 @@ func TestUnknownSubcommand(t *testing.T) {
 func TestNoArgs(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{}, &stdout, &stderr)
-	if code != 1 {
-		t.Fatalf("exit code = %d, want 1", code)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
 	}
 	if !strings.Contains(stderr.String(), "usage:") {
 		t.Errorf("stderr = %q, want usage info", stderr.String())
@@ -42,8 +42,8 @@ func TestNoArgs(t *testing.T) {
 func TestQueryMissingArgs(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"query"}, &stdout, &stderr)
-	if code != 1 {
-		t.Fatalf("exit code = %d, want 1", code)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
 	}
 	if !strings.Contains(stderr.String(), "QUERY_FILE") {
 		t.Errorf("stderr = %q, want mention of QUERY_FILE", stderr.String())
@@ -53,8 +53,8 @@ func TestQueryMissingArgs(t *testing.T) {
 func TestCheckMissingArgs(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"check"}, &stdout, &stderr)
-	if code != 1 {
-		t.Fatalf("exit code = %d, want 1", code)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
 	}
 	if !strings.Contains(stderr.String(), "QUERY_FILE") {
 		t.Errorf("stderr = %q, want mention of QUERY_FILE", stderr.String())
@@ -80,5 +80,89 @@ func TestCheckNonexistentFile(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "error:") {
 		t.Errorf("stderr = %q, want error message", stderr.String())
+	}
+}
+
+// Regression: global flags only should print usage, not "unknown command --verbose".
+func TestGlobalFlagsOnly(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--verbose"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if strings.Contains(stderr.String(), "unknown command") {
+		t.Errorf("stderr should show usage, not 'unknown command'; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Errorf("stderr = %q, want usage info", stderr.String())
+	}
+}
+
+func TestGlobalFlagsMultiple(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--verbose", "--quiet"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Errorf("stderr = %q, want usage info", stderr.String())
+	}
+}
+
+// Regression: -h/--help should return exit code 0 for all subcommands.
+func TestHelpExitCode(t *testing.T) {
+	for _, args := range [][]string{
+		{"extract", "-h"},
+		{"extract", "--help"},
+		{"query", "-h"},
+		{"query", "--help"},
+		{"check", "-h"},
+		{"check", "--help"},
+	} {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run(args, &stdout, &stderr)
+			if code != 0 {
+				t.Errorf("exit code = %d, want 0 for %v", code, args)
+			}
+		})
+	}
+}
+
+// Regression: usage errors return exit code 2, runtime errors return 1.
+func TestUsageErrorExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{"no args", []string{}, 2},
+		{"unknown command", []string{"bogus"}, 2},
+		{"global flags only", []string{"--verbose"}, 2},
+		{"query missing file", []string{"query"}, 2},
+		{"check missing file", []string{"check"}, 2},
+		// Runtime errors should be 1.
+		{"check nonexistent file", []string{"check", "/nonexistent/file.ql"}, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run(tt.args, &stdout, &stderr)
+			if code != tt.want {
+				t.Errorf("exit code = %d, want %d; stderr: %s", code, tt.want, stderr.String())
+			}
+		})
+	}
+}
+
+// Regression: global flags followed by a valid subcommand should work.
+func TestGlobalFlagsBeforeSubcommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--verbose", "version"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "tsq version") {
+		t.Errorf("stdout = %q, want 'tsq version ...'", stdout.String())
 	}
 }

--- a/output/csv.go
+++ b/output/csv.go
@@ -1,1 +1,38 @@
 package output
+
+import (
+	"encoding/csv"
+	"io"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+)
+
+// WriteCSV writes the ResultSet as CSV with a header row to w.
+// Uses standard CSV encoding (RFC 4180): fields containing commas, quotes,
+// or newlines are quoted, and embedded quotes are doubled.
+func WriteCSV(w io.Writer, rs *eval.ResultSet) error {
+	cw := csv.NewWriter(w)
+
+	// Write header.
+	if err := cw.Write(rs.Columns); err != nil {
+		return err
+	}
+
+	// Write data rows.
+	record := make([]string, len(rs.Columns))
+	for _, row := range rs.Rows {
+		for i := range rs.Columns {
+			if i < len(row) {
+				record[i] = eval.ValueToString(row[i])
+			} else {
+				record[i] = ""
+			}
+		}
+		if err := cw.Write(record); err != nil {
+			return err
+		}
+	}
+
+	cw.Flush()
+	return cw.Error()
+}

--- a/output/csv_test.go
+++ b/output/csv_test.go
@@ -1,0 +1,124 @@
+package output
+
+import (
+	"bytes"
+	"encoding/csv"
+	"strings"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+)
+
+func TestWriteCSV_Empty(t *testing.T) {
+	rs := &eval.ResultSet{
+		Columns: []string{"name", "file"},
+		Rows:    nil,
+	}
+	var buf bytes.Buffer
+	if err := WriteCSV(&buf, rs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have header only.
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 1 {
+		t.Errorf("lines = %d, want 1 (header only)", len(lines))
+	}
+	if lines[0] != "name,file" {
+		t.Errorf("header = %q, want name,file", lines[0])
+	}
+}
+
+func TestWriteCSV_SingleRow(t *testing.T) {
+	rs := &eval.ResultSet{
+		Columns: []string{"name", "value"},
+		Rows: [][]eval.Value{
+			{eval.StrVal{V: "foo"}, eval.IntVal{V: 42}},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteCSV(&buf, rs); err != nil {
+		t.Fatal(err)
+	}
+
+	r := csv.NewReader(strings.NewReader(buf.String()))
+	records, err := r.ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("records = %d, want 2 (header + 1 row)", len(records))
+	}
+	if records[1][0] != "foo" {
+		t.Errorf("col0 = %q, want foo", records[1][0])
+	}
+	if records[1][1] != "42" {
+		t.Errorf("col1 = %q, want 42", records[1][1])
+	}
+}
+
+func TestWriteCSV_CommasInValues(t *testing.T) {
+	rs := &eval.ResultSet{
+		Columns: []string{"msg"},
+		Rows: [][]eval.Value{
+			{eval.StrVal{V: "hello, world"}},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteCSV(&buf, rs); err != nil {
+		t.Fatal(err)
+	}
+
+	r := csv.NewReader(strings.NewReader(buf.String()))
+	records, err := r.ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if records[1][0] != "hello, world" {
+		t.Errorf("msg = %q, want 'hello, world'", records[1][0])
+	}
+}
+
+func TestWriteCSV_NewlinesInValues(t *testing.T) {
+	rs := &eval.ResultSet{
+		Columns: []string{"msg"},
+		Rows: [][]eval.Value{
+			{eval.StrVal{V: "line1\nline2"}},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteCSV(&buf, rs); err != nil {
+		t.Fatal(err)
+	}
+
+	r := csv.NewReader(strings.NewReader(buf.String()))
+	records, err := r.ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if records[1][0] != "line1\nline2" {
+		t.Errorf("msg = %q, want 'line1\\nline2'", records[1][0])
+	}
+}
+
+func TestWriteCSV_QuotesInValues(t *testing.T) {
+	rs := &eval.ResultSet{
+		Columns: []string{"msg"},
+		Rows: [][]eval.Value{
+			{eval.StrVal{V: `say "hi"`}},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteCSV(&buf, rs); err != nil {
+		t.Fatal(err)
+	}
+
+	r := csv.NewReader(strings.NewReader(buf.String()))
+	records, err := r.ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if records[1][0] != `say "hi"` {
+		t.Errorf("msg = %q, want 'say \"hi\"'", records[1][0])
+	}
+}

--- a/output/json.go
+++ b/output/json.go
@@ -1,1 +1,38 @@
 package output
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+)
+
+// WriteJSONLines writes one JSON object per result row to w.
+// Each object maps column names to values.
+func WriteJSONLines(w io.Writer, rs *eval.ResultSet) error {
+	enc := json.NewEncoder(w)
+	// Do not escape HTML entities — plain JSON.
+	enc.SetEscapeHTML(false)
+
+	for _, row := range rs.Rows {
+		obj := make(map[string]interface{}, len(rs.Columns))
+		for i, col := range rs.Columns {
+			if i >= len(row) {
+				obj[col] = nil
+				continue
+			}
+			switch v := row[i].(type) {
+			case eval.IntVal:
+				obj[col] = v.V
+			case eval.StrVal:
+				obj[col] = v.V
+			default:
+				obj[col] = eval.ValueToString(row[i])
+			}
+		}
+		if err := enc.Encode(obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/output/json_test.go
+++ b/output/json_test.go
@@ -1,0 +1,120 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+)
+
+func TestWriteJSONLines_Empty(t *testing.T) {
+	rs := &eval.ResultSet{
+		Columns: []string{"name"},
+		Rows:    nil,
+	}
+	var buf bytes.Buffer
+	if err := WriteJSONLines(&buf, rs); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output, got %q", buf.String())
+	}
+}
+
+func TestWriteJSONLines_SingleRow(t *testing.T) {
+	rs := &eval.ResultSet{
+		Columns: []string{"name", "file"},
+		Rows: [][]eval.Value{
+			{eval.StrVal{V: "hello"}, eval.StrVal{V: "main.ts"}},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteJSONLines(&buf, rs); err != nil {
+		t.Fatal(err)
+	}
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &obj); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if obj["name"] != "hello" {
+		t.Errorf("name = %v, want hello", obj["name"])
+	}
+	if obj["file"] != "main.ts" {
+		t.Errorf("file = %v, want main.ts", obj["file"])
+	}
+}
+
+func TestWriteJSONLines_SpecialCharacters(t *testing.T) {
+	rs := &eval.ResultSet{
+		Columns: []string{"msg"},
+		Rows: [][]eval.Value{
+			{eval.StrVal{V: "hello \"world\" \n\ttab"}},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteJSONLines(&buf, rs); err != nil {
+		t.Fatal(err)
+	}
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &obj); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if obj["msg"] != "hello \"world\" \n\ttab" {
+		t.Errorf("msg = %v", obj["msg"])
+	}
+}
+
+func TestWriteJSONLines_IntegerValues(t *testing.T) {
+	rs := &eval.ResultSet{
+		Columns: []string{"id", "line"},
+		Rows: [][]eval.Value{
+			{eval.IntVal{V: 42}, eval.IntVal{V: 100}},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteJSONLines(&buf, rs); err != nil {
+		t.Fatal(err)
+	}
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &obj); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	// JSON numbers decode as float64.
+	if obj["id"] != float64(42) {
+		t.Errorf("id = %v, want 42", obj["id"])
+	}
+	if obj["line"] != float64(100) {
+		t.Errorf("line = %v, want 100", obj["line"])
+	}
+}
+
+func TestWriteJSONLines_MultipleRows(t *testing.T) {
+	rs := &eval.ResultSet{
+		Columns: []string{"x"},
+		Rows: [][]eval.Value{
+			{eval.StrVal{V: "a"}},
+			{eval.StrVal{V: "b"}},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteJSONLines(&buf, rs); err != nil {
+		t.Fatal(err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("lines = %d, want 2", len(lines))
+	}
+	// Each line must be valid JSON.
+	for i, line := range lines {
+		var obj map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			t.Errorf("line %d invalid JSON: %v", i, err)
+		}
+	}
+}

--- a/output/sarif.go
+++ b/output/sarif.go
@@ -1,2 +1,191 @@
 // Package output implements result formatters (SARIF, JSON, CSV).
 package output
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+)
+
+// SARIF 2.1.0 types — minimal subset needed for output.
+
+type sarifLog struct {
+	Schema  string     `json:"$schema"`
+	Version string     `json:"version"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool    sarifTool     `json:"tool"`
+	Results []sarifResult `json:"results"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type sarifResult struct {
+	RuleID    string          `json:"ruleId"`
+	Level     string          `json:"level"`
+	Message   sarifMessage    `json:"message"`
+	Locations []sarifLocation `json:"locations,omitempty"`
+}
+
+type sarifMessage struct {
+	Text string `json:"text"`
+}
+
+type sarifLocation struct {
+	PhysicalLocation *sarifPhysicalLocation `json:"physicalLocation,omitempty"`
+}
+
+type sarifPhysicalLocation struct {
+	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
+	Region           *sarifRegion          `json:"region,omitempty"`
+}
+
+type sarifArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+type sarifRegion struct {
+	StartLine   int `json:"startLine,omitempty"`
+	StartColumn int `json:"startColumn,omitempty"`
+}
+
+// SARIFOptions controls SARIF output.
+type SARIFOptions struct {
+	QueryName   string // used as ruleId
+	ToolVersion string // tool version string
+}
+
+// WriteSARIF writes the ResultSet as SARIF 2.1.0 JSON to w.
+// Column heuristics for location: columns named "file"/"path" are used for URI,
+// columns named "line"/"startLine" for line, "col"/"column"/"startCol" for column.
+func WriteSARIF(w io.Writer, rs *eval.ResultSet, opts SARIFOptions) error {
+	if opts.QueryName == "" {
+		opts.QueryName = "tsq-query"
+	}
+	if opts.ToolVersion == "" {
+		opts.ToolVersion = "0.0.1-dev"
+	}
+
+	// Build column index for location heuristics.
+	colIdx := make(map[string]int, len(rs.Columns))
+	for i, c := range rs.Columns {
+		colIdx[c] = i
+	}
+
+	var results []sarifResult
+	for _, row := range rs.Rows {
+		msg := buildRowMessage(rs.Columns, row)
+		r := sarifResult{
+			RuleID:  opts.QueryName,
+			Level:   "warning",
+			Message: sarifMessage{Text: msg},
+		}
+
+		// Try to build a location from well-known column names.
+		loc := tryBuildLocation(colIdx, row)
+		if loc != nil {
+			r.Locations = []sarifLocation{*loc}
+		}
+
+		results = append(results, r)
+	}
+
+	log := sarifLog{
+		Schema:  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+		Version: "2.1.0",
+		Runs: []sarifRun{
+			{
+				Tool: sarifTool{
+					Driver: sarifDriver{
+						Name:    "tsq",
+						Version: opts.ToolVersion,
+					},
+				},
+				Results: results,
+			},
+		},
+	}
+
+	// Ensure Results is always an array, not null.
+	if log.Runs[0].Results == nil {
+		log.Runs[0].Results = []sarifResult{}
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(log)
+}
+
+// buildRowMessage creates a text summary of a result row.
+func buildRowMessage(columns []string, row []eval.Value) string {
+	if len(columns) == 0 || len(row) == 0 {
+		return "query result"
+	}
+	// Use first column value as the message.
+	return eval.ValueToString(row[0])
+}
+
+// tryBuildLocation attempts to extract a SARIF location from well-known column names.
+func tryBuildLocation(colIdx map[string]int, row []eval.Value) *sarifLocation {
+	fileCol := -1
+	for _, name := range []string{"file", "path", "filepath", "uri"} {
+		if idx, ok := colIdx[name]; ok {
+			fileCol = idx
+			break
+		}
+	}
+	if fileCol < 0 || fileCol >= len(row) {
+		return nil
+	}
+
+	uri := eval.ValueToString(row[fileCol])
+	loc := &sarifLocation{
+		PhysicalLocation: &sarifPhysicalLocation{
+			ArtifactLocation: sarifArtifactLocation{URI: uri},
+		},
+	}
+
+	// Try to find line.
+	lineCol := -1
+	for _, name := range []string{"line", "startLine", "start_line"} {
+		if idx, ok := colIdx[name]; ok {
+			lineCol = idx
+			break
+		}
+	}
+
+	colCol := -1
+	for _, name := range []string{"col", "column", "startCol", "start_col"} {
+		if idx, ok := colIdx[name]; ok {
+			colCol = idx
+			break
+		}
+	}
+
+	if lineCol >= 0 && lineCol < len(row) {
+		region := &sarifRegion{}
+		if iv, ok := row[lineCol].(eval.IntVal); ok {
+			region.StartLine = int(iv.V)
+		}
+		if colCol >= 0 && colCol < len(row) {
+			if iv, ok := row[colCol].(eval.IntVal); ok {
+				region.StartColumn = int(iv.V)
+			}
+		}
+		if region.StartLine > 0 || region.StartColumn > 0 {
+			loc.PhysicalLocation.Region = region
+		}
+	}
+
+	return loc
+}

--- a/output/sarif_test.go
+++ b/output/sarif_test.go
@@ -1,0 +1,139 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+)
+
+func TestWriteSARIF_Empty(t *testing.T) {
+	rs := &eval.ResultSet{
+		Columns: []string{"name"},
+		Rows:    nil,
+	}
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, rs, SARIFOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Must be valid JSON.
+	var log sarifLog
+	if err := json.Unmarshal(buf.Bytes(), &log); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if log.Version != "2.1.0" {
+		t.Errorf("version = %q, want 2.1.0", log.Version)
+	}
+	if len(log.Runs) != 1 {
+		t.Fatalf("runs = %d, want 1", len(log.Runs))
+	}
+	if len(log.Runs[0].Results) != 0 {
+		t.Errorf("results = %d, want 0", len(log.Runs[0].Results))
+	}
+	// Results should be [] not null.
+	if strings.Contains(buf.String(), `"results": null`) {
+		t.Error("results should be empty array, not null")
+	}
+}
+
+func TestWriteSARIF_SingleResultWithLocation(t *testing.T) {
+	rs := &eval.ResultSet{
+		Columns: []string{"name", "file", "line", "col"},
+		Rows: [][]eval.Value{
+			{eval.StrVal{V: "unusedVar"}, eval.StrVal{V: "src/main.ts"}, eval.IntVal{V: 42}, eval.IntVal{V: 10}},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, rs, SARIFOptions{QueryName: "unused-vars"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var log sarifLog
+	if err := json.Unmarshal(buf.Bytes(), &log); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if len(log.Runs[0].Results) != 1 {
+		t.Fatalf("results = %d, want 1", len(log.Runs[0].Results))
+	}
+	r := log.Runs[0].Results[0]
+	if r.RuleID != "unused-vars" {
+		t.Errorf("ruleId = %q, want unused-vars", r.RuleID)
+	}
+	if r.Message.Text != "unusedVar" {
+		t.Errorf("message = %q, want unusedVar", r.Message.Text)
+	}
+	if len(r.Locations) != 1 {
+		t.Fatalf("locations = %d, want 1", len(r.Locations))
+	}
+	pl := r.Locations[0].PhysicalLocation
+	if pl == nil {
+		t.Fatal("physicalLocation is nil")
+	}
+	if pl.ArtifactLocation.URI != "src/main.ts" {
+		t.Errorf("uri = %q, want src/main.ts", pl.ArtifactLocation.URI)
+	}
+	if pl.Region == nil {
+		t.Fatal("region is nil")
+	}
+	if pl.Region.StartLine != 42 {
+		t.Errorf("startLine = %d, want 42", pl.Region.StartLine)
+	}
+	if pl.Region.StartColumn != 10 {
+		t.Errorf("startColumn = %d, want 10", pl.Region.StartColumn)
+	}
+}
+
+func TestWriteSARIF_MultipleResults(t *testing.T) {
+	rs := &eval.ResultSet{
+		Columns: []string{"msg"},
+		Rows: [][]eval.Value{
+			{eval.StrVal{V: "first"}},
+			{eval.StrVal{V: "second"}},
+			{eval.StrVal{V: "third"}},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, rs, SARIFOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	var log sarifLog
+	if err := json.Unmarshal(buf.Bytes(), &log); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(log.Runs[0].Results) != 3 {
+		t.Errorf("results = %d, want 3", len(log.Runs[0].Results))
+	}
+}
+
+func TestWriteSARIF_ValidStructure(t *testing.T) {
+	rs := &eval.ResultSet{
+		Columns: []string{"file", "line"},
+		Rows: [][]eval.Value{
+			{eval.StrVal{V: "a.ts"}, eval.IntVal{V: 1}},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, rs, SARIFOptions{ToolVersion: "1.0.0"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify required SARIF fields.
+	var raw map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := raw["$schema"]; !ok {
+		t.Error("missing $schema field")
+	}
+	if _, ok := raw["version"]; !ok {
+		t.Error("missing version field")
+	}
+	if _, ok := raw["runs"]; !ok {
+		t.Error("missing runs field")
+	}
+}


### PR DESCRIPTION
## Summary

- Subcommand CLI (`extract`, `query`, `check`, `version`) using raw `flag` package — zero external deps
- Output formatters: SARIF 2.1.0, JSON Lines, CSV with full edge-case handling
- Full pipeline wiring: `.ql` source → parse → resolve (with bridge loader) → desugar → plan → eval → formatted output
- Signal handling (SIGINT/SIGTERM) with graceful context cancellation
- 21 new tests across output formatters and CLI

## Test plan

- [x] `go test ./output/ -count=1` — 14 tests pass (SARIF, JSON, CSV formatters)
- [x] `go test ./cmd/tsq/ -count=1` — 7 tests pass (version, unknown cmd, missing args, bad format, nonexistent file)
- [x] `go test ./... -count=1` — full suite green (all 14 packages)