### PR TITLE
feat: v2 Phase B — call graph construction (CHA + RTA)

### DIFF
--- a/HANDOVER-v2-phase-b.md
+++ b/HANDOVER-v2-phase-b.md
@@ -1,0 +1,75 @@
+# v2 Phase B Handover: Call Graph Construction (CHA + RTA)
+
+## What was built
+
+### 1. Call graph rules (`extract/rules/callgraph.go`)
+
+New `extract/rules` package with `CallGraphRules()` returning 7 programmatically constructed Datalog rules:
+
+1. **Direct resolution** — `CallTarget(call, fn)` via `CallCalleeSym` + `FunctionSymbol`
+2. **Concrete class dispatch** — `CallTarget(call, fn)` via `MethodCall` + `ExprType` + `ClassDecl` + `MethodDecl`
+3. **CHA interface dispatch** — `CallTarget(call, fn)` via `MethodCall` + `ExprType` + `InterfaceDecl` + `Implements` + `MethodDecl`
+4. **Inheritance** — `MethodDeclInherited(childId, name, fn)` via `Extends` + `MethodDecl` + `not MethodDeclDirect`
+5. **Direct method base** — `MethodDeclDirect(classId, name, fn)` via `MethodDecl` + `ClassDecl`
+6. **Instantiated** — `Instantiated(classId)` via `NewExpr`
+7. **RTA** — `CallTargetRTA(call, fn)` like CHA but filtered by `Instantiated(classId)`
+
+All rules are built using `datalog.Rule`, `datalog.Atom`, `datalog.Literal`, `datalog.Var` types. All pass validation, stratification (negation in rule 4 is safe — `MethodDeclDirect` is defined in a lower stratum than `MethodDeclInherited`), and produce correct results through the planner + evaluator.
+
+### 2. System rules injection (`extract/rules/merge.go`)
+
+`MergeSystemRules(prog, systemRules)` returns a new `*datalog.Program` combining system rules with user rules, preserving the original program. System rules are prepended so they're available to user queries.
+
+### 3. Bridge file (`bridge/tsq_callgraph.qll`)
+
+User-facing QL classes: `CallTarget`, `CallTargetRTA`, `Instantiated`. Registered in `embed.go` (embed directive + file list + import path mapping) and `manifest.go` (available classes list including `MethodDeclDirect` and `MethodDeclInherited`).
+
+### 4. Schema additions (`extract/schema/relations.go`)
+
+Five derived relations registered: `CallTarget`, `CallTargetRTA`, `Instantiated`, `MethodDeclDirect`, `MethodDeclInherited`.
+
+### 5. Tests (`extract/rules/callgraph_test.go`)
+
+12 tests covering:
+- Direct resolution
+- Concrete class method dispatch
+- CHA interface dispatch (multiple implementors)
+- RTA filtering (only instantiated classes)
+- Inheritance (parent method inherited by child)
+- Override blocking (child override prevents inheritance)
+- **CHA superset RTA property** — verifies every RTA target exists in CHA
+- `MergeSystemRules` correctness
+- `Instantiated` deduplication
+- Rule count (7)
+- All rules pass `ValidateRule`
+- All rules stratify successfully via `Plan()`
+
+## Files changed
+
+- `extract/rules/callgraph.go` — NEW: call graph rules
+- `extract/rules/merge.go` — NEW: system rules merge function
+- `extract/rules/callgraph_test.go` — NEW: 12 tests
+- `bridge/tsq_callgraph.qll` — NEW: bridge classes
+- `bridge/embed.go` — updated embed + loader
+- `bridge/manifest.go` — added 5 available classes
+- `bridge/embed_test.go` — updated expected file count (10 -> 11)
+- `bridge/manifest_test.go` — updated expected class count (45 -> 50)
+- `extract/schema/relations.go` — added 5 derived relations
+- `extract/schema/relations_test.go` — updated expected relation count (45 -> 50)
+
+## Integration notes
+
+To use call graph rules in the pipeline:
+```go
+import "github.com/Gjdoalfnrxu/tsq/extract/rules"
+
+// After desugaring user query:
+merged := rules.MergeSystemRules(userProg, rules.CallGraphRules())
+ep, errs := plan.Plan(merged, sizeHints)
+```
+
+## Next steps
+
+- Wire `MergeSystemRules` into the CLI pipeline (cmd/tsq) so call graph rules are automatically injected
+- Add end-to-end tests extracting TypeScript fixtures with classes/interfaces and verifying call targets
+- Consider adding `MethodDeclInherited` to `MethodDecl` unification so inherited methods participate in call resolution

--- a/bridge/embed.go
+++ b/bridge/embed.go
@@ -2,7 +2,7 @@ package bridge
 
 import "embed"
 
-//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll
+//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll
 var bridgeFS embed.FS
 
 // LoadBridge returns all embedded .qll files as a map from filename to contents.
@@ -18,6 +18,7 @@ func LoadBridge() map[string][]byte {
 		"tsq_errors.qll",
 		"tsq_types.qll",
 		"tsq_symbols.qll",
+		"tsq_callgraph.qll",
 	}
 	result := make(map[string][]byte, len(files))
 	for _, name := range files {
@@ -53,6 +54,7 @@ func BridgeImportLoader(bridgeFiles map[string][]byte, parseFn func(src, file st
 		"tsq::errors":      "tsq_errors.qll",
 		"tsq::types":       "tsq_types.qll",
 		"tsq::symbols":     "tsq_symbols.qll",
+		"tsq::callgraph":   "tsq_callgraph.qll",
 	}
 	return func(path string) (interface{}, bool) {
 		filename, ok := pathToFile[path]

--- a/bridge/embed_test.go
+++ b/bridge/embed_test.go
@@ -17,6 +17,7 @@ func TestLoadBridgeReturnsAllFiles(t *testing.T) {
 		"tsq_errors.qll",
 		"tsq_types.qll",
 		"tsq_symbols.qll",
+		"tsq_callgraph.qll",
 	}
 	files := LoadBridge()
 	if len(files) != len(expected) {

--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -89,6 +89,12 @@ func v2Manifest() *CapabilityManifest {
 			{Name: "ReturnStmt", Relation: "ReturnStmt", File: "tsq_functions.qll"},
 			{Name: "FunctionContains", Relation: "FunctionContains", File: "tsq_functions.qll"},
 			{Name: "SymInFunction", Relation: "SymInFunction", File: "tsq_symbols.qll"},
+			// v2 Phase B: call graph derived relations
+			{Name: "CallTarget", Relation: "CallTarget", File: "tsq_callgraph.qll"},
+			{Name: "CallTargetRTA", Relation: "CallTargetRTA", File: "tsq_callgraph.qll"},
+			{Name: "Instantiated", Relation: "Instantiated", File: "tsq_callgraph.qll"},
+			{Name: "MethodDeclDirect", Relation: "MethodDeclDirect", File: "tsq_callgraph.qll"},
+			{Name: "MethodDeclInherited", Relation: "MethodDeclInherited", File: "tsq_callgraph.qll"},
 		},
 		Unavailable: []UnavailableClass{
 			{Name: "DataFlow", Reason: "IPA-dependent; requires inter-procedural analysis engine", VersionTarget: "v3"},

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -9,8 +9,8 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	m := V1Manifest()
 	// v2: 28 original + 5 promoted from unavailable + 12 new v2 = 45
 	// But some relations share bridge classes. Count: 28 + 17 = 45
-	if got := len(m.Available); got != 45 {
-		t.Errorf("expected 45 available classes, got %d", got)
+	if got := len(m.Available); got != 50 {
+		t.Errorf("expected 50 available classes, got %d", got)
 	}
 }
 

--- a/bridge/tsq_callgraph.qll
+++ b/bridge/tsq_callgraph.qll
@@ -1,0 +1,53 @@
+/**
+ * Bridge library for call graph derived relations (v2 Phase B).
+ * Maps CallTarget (CHA), CallTargetRTA, and Instantiated derived from
+ * system Datalog rules over base type-aware facts.
+ */
+
+/**
+ * A resolved call target (CHA — Class Hierarchy Analysis).
+ * Holds when `call` may invoke `fn` based on class hierarchy analysis,
+ * including direct calls, concrete method dispatch, and interface dispatch
+ * to all implementing classes.
+ */
+class CallTarget extends @call_target {
+    CallTarget() { CallTarget(this, _) }
+
+    /** Gets the call site. */
+    int getCall() { result = this }
+
+    /** Gets the target function. */
+    int getFunction() { CallTarget(this, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "CallTarget" }
+}
+
+/**
+ * A resolved call target (RTA — Rapid Type Analysis).
+ * Stricter than CHA: only includes targets where the implementing class
+ * has been instantiated (via `new`) somewhere in the program.
+ */
+class CallTargetRTA extends @call_target_rta {
+    CallTargetRTA() { CallTargetRTA(this, _) }
+
+    /** Gets the call site. */
+    int getCall() { result = this }
+
+    /** Gets the target function. */
+    int getFunction() { CallTargetRTA(this, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "CallTargetRTA" }
+}
+
+/**
+ * An instantiated class (observed via `new ClassName()`).
+ * Used by RTA to prune infeasible call targets.
+ */
+class Instantiated extends @instantiated {
+    Instantiated() { Instantiated(this) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "Instantiated" }
+}

--- a/extract/rules/callgraph.go
+++ b/extract/rules/callgraph.go
@@ -1,0 +1,114 @@
+// Package rules provides system-level Datalog rules for derived relations.
+// These rules are injected alongside user-written QL queries to compute
+// call graphs, inheritance chains, and other derived facts.
+package rules
+
+import (
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// v returns a Var term.
+func v(name string) datalog.Var { return datalog.Var{Name: name} }
+
+// w returns a Wildcard term.
+func w() datalog.Wildcard { return datalog.Wildcard{} }
+
+// pos returns a positive literal from predicate and args.
+func pos(pred string, args ...datalog.Term) datalog.Literal {
+	return datalog.Literal{
+		Positive: true,
+		Atom:     datalog.Atom{Predicate: pred, Args: args},
+	}
+}
+
+// neg returns a negative literal from predicate and args.
+func neg(pred string, args ...datalog.Term) datalog.Literal {
+	return datalog.Literal{
+		Positive: false,
+		Atom:     datalog.Atom{Predicate: pred, Args: args},
+	}
+}
+
+// rule builds a Rule from head predicate/args and body literals.
+func rule(headPred string, headArgs []datalog.Term, body ...datalog.Literal) datalog.Rule {
+	return datalog.Rule{
+		Head: datalog.Atom{Predicate: headPred, Args: headArgs},
+		Body: body,
+	}
+}
+
+// CallGraphRules returns the system Datalog rules for call graph construction.
+// These implement CHA (Class Hierarchy Analysis) and RTA (Rapid Type Analysis).
+func CallGraphRules() []datalog.Rule {
+	return []datalog.Rule{
+		// 1. Direct resolution: CallTarget(call, fn) :- CallCalleeSym(call, sym), FunctionSymbol(sym, fn).
+		rule("CallTarget",
+			[]datalog.Term{v("call"), v("fn")},
+			pos("CallCalleeSym", v("call"), v("sym")),
+			pos("FunctionSymbol", v("sym"), v("fn")),
+		),
+
+		// 2. Method on concrete class:
+		//    CallTarget(call, fn) :- MethodCall(call, recv, name), ExprType(recv, classId),
+		//                            ClassDecl(classId, _, _), MethodDecl(classId, name, fn).
+		rule("CallTarget",
+			[]datalog.Term{v("call"), v("fn")},
+			pos("MethodCall", v("call"), v("recv"), v("name")),
+			pos("ExprType", v("recv"), v("classId")),
+			pos("ClassDecl", v("classId"), w(), w()),
+			pos("MethodDecl", v("classId"), v("name"), v("fn")),
+		),
+
+		// 3. CHA for interfaces:
+		//    CallTarget(call, fn) :- MethodCall(call, recv, name), ExprType(recv, ifaceId),
+		//                            InterfaceDecl(ifaceId, _, _), Implements(classId, ifaceId),
+		//                            MethodDecl(classId, name, fn).
+		rule("CallTarget",
+			[]datalog.Term{v("call"), v("fn")},
+			pos("MethodCall", v("call"), v("recv"), v("name")),
+			pos("ExprType", v("recv"), v("ifaceId")),
+			pos("InterfaceDecl", v("ifaceId"), w(), w()),
+			pos("Implements", v("classId"), v("ifaceId")),
+			pos("MethodDecl", v("classId"), v("name"), v("fn")),
+		),
+
+		// 4. Inheritance (inherited methods):
+		//    MethodDeclInherited(childId, name, fn) :- Extends(childId, parentId),
+		//        MethodDecl(parentId, name, fn), not MethodDeclDirect(childId, name, _).
+		rule("MethodDeclInherited",
+			[]datalog.Term{v("childId"), v("name"), v("fn")},
+			pos("Extends", v("childId"), v("parentId")),
+			pos("MethodDecl", v("parentId"), v("name"), v("fn")),
+			neg("MethodDeclDirect", v("childId"), v("name"), w()),
+		),
+
+		// 5. MethodDeclDirect base case:
+		//    MethodDeclDirect(classId, name, fn) :- MethodDecl(classId, name, fn), ClassDecl(classId, _, _).
+		rule("MethodDeclDirect",
+			[]datalog.Term{v("classId"), v("name"), v("fn")},
+			pos("MethodDecl", v("classId"), v("name"), v("fn")),
+			pos("ClassDecl", v("classId"), w(), w()),
+		),
+
+		// 6. Instantiated:
+		//    Instantiated(classId) :- NewExpr(_, classId).
+		rule("Instantiated",
+			[]datalog.Term{v("classId")},
+			pos("NewExpr", w(), v("classId")),
+		),
+
+		// 7. RTA:
+		//    CallTargetRTA(call, fn) :- MethodCall(call, recv, name), ExprType(recv, ifaceId),
+		//        InterfaceDecl(ifaceId, _, _), Implements(classId, ifaceId),
+		//        Instantiated(classId), MethodDecl(classId, name, fn).
+		rule("CallTargetRTA",
+			[]datalog.Term{v("call"), v("fn")},
+			pos("MethodCall", v("call"), v("recv"), v("name")),
+			pos("ExprType", v("recv"), v("ifaceId")),
+			pos("InterfaceDecl", v("ifaceId"), w(), w()),
+			pos("Implements", v("classId"), v("ifaceId")),
+			pos("Instantiated", v("classId")),
+			pos("MethodDecl", v("classId"), v("name"), v("fn")),
+		),
+	}
+}

--- a/extract/rules/callgraph_test.go
+++ b/extract/rules/callgraph_test.go
@@ -1,0 +1,455 @@
+package rules
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// makeRel creates a relation with the given tuples. Each tuple is arity values.
+func makeRel(name string, arity int, vals ...eval.Value) *eval.Relation {
+	r := eval.NewRelation(name, arity)
+	for i := 0; i < len(vals); i += arity {
+		t := make(eval.Tuple, arity)
+		for j := 0; j < arity; j++ {
+			t[j] = vals[i+j]
+		}
+		r.Add(t)
+	}
+	return r
+}
+
+func iv(n int64) eval.IntVal  { return eval.IntVal{V: n} }
+func sv(s string) eval.StrVal { return eval.StrVal{V: s} }
+
+// planAndEval plans the given rules+query and evaluates over baseRels.
+func planAndEval(t *testing.T, rules []datalog.Rule, query *datalog.Query, baseRels map[string]*eval.Relation) *eval.ResultSet {
+	t.Helper()
+	prog := &datalog.Program{Rules: rules, Query: query}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) > 0 {
+		t.Fatalf("Plan errors: %v", errs)
+	}
+	rs, err := eval.Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate error: %v", err)
+	}
+	return rs
+}
+
+// resultContains checks if any row matches the given tuple.
+func resultContains(rs *eval.ResultSet, vals ...eval.Value) bool {
+	for _, row := range rs.Rows {
+		if len(row) != len(vals) {
+			continue
+		}
+		match := true
+		for i, v := range vals {
+			if row[i] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDirectResolution tests rule 1: direct call through symbol.
+func TestDirectResolution(t *testing.T) {
+	// call=10, sym=20, fn=30
+	baseRels := map[string]*eval.Relation{
+		"CallCalleeSym":  makeRel("CallCalleeSym", 2, iv(10), iv(20)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(20), iv(30)),
+		// Empty relations needed by other rules
+		"MethodCall":    eval.NewRelation("MethodCall", 3),
+		"ExprType":      eval.NewRelation("ExprType", 2),
+		"ClassDecl":     eval.NewRelation("ClassDecl", 3),
+		"InterfaceDecl": eval.NewRelation("InterfaceDecl", 3),
+		"MethodDecl":    eval.NewRelation("MethodDecl", 3),
+		"Implements":    eval.NewRelation("Implements", 2),
+		"Extends":       eval.NewRelation("Extends", 2),
+		"NewExpr":       eval.NewRelation("NewExpr", 2),
+	}
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("call"), v("fn")},
+		Body: []datalog.Literal{
+			pos("CallTarget", v("call"), v("fn")),
+		},
+	}
+
+	rs := planAndEval(t, CallGraphRules(), query, baseRels)
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 CallTarget row, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(10), iv(30)) {
+		t.Errorf("expected CallTarget(10, 30), got %v", rs.Rows)
+	}
+}
+
+// TestMethodOnConcreteClass tests rule 2: method dispatch on concrete class.
+func TestMethodOnConcreteClass(t *testing.T) {
+	// call=1, recv=2, classId=100, name="foo", fn=200
+	baseRels := map[string]*eval.Relation{
+		"MethodCall":     makeRel("MethodCall", 3, iv(1), iv(2), sv("foo")),
+		"ExprType":       makeRel("ExprType", 2, iv(2), iv(100)),
+		"ClassDecl":      makeRel("ClassDecl", 3, iv(100), sv("MyClass"), iv(999)),
+		"MethodDecl":     makeRel("MethodDecl", 3, iv(100), sv("foo"), iv(200)),
+		"CallCalleeSym":  eval.NewRelation("CallCalleeSym", 2),
+		"FunctionSymbol": eval.NewRelation("FunctionSymbol", 2),
+		"InterfaceDecl":  eval.NewRelation("InterfaceDecl", 3),
+		"Implements":     eval.NewRelation("Implements", 2),
+		"Extends":        eval.NewRelation("Extends", 2),
+		"NewExpr":        eval.NewRelation("NewExpr", 2),
+	}
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("call"), v("fn")},
+		Body: []datalog.Literal{
+			pos("CallTarget", v("call"), v("fn")),
+		},
+	}
+
+	rs := planAndEval(t, CallGraphRules(), query, baseRels)
+	if !resultContains(rs, iv(1), iv(200)) {
+		t.Errorf("expected CallTarget(1, 200), got %v", rs.Rows)
+	}
+}
+
+// TestCHAInterfaceDispatch tests rule 3: CHA dispatches to all implementors.
+func TestCHAInterfaceDispatch(t *testing.T) {
+	// Interface IFoo (id=50), implemented by ClassA (id=100) and ClassB (id=101).
+	// Both have method "bar". call=1, recv=2, ifaceId=50.
+	baseRels := map[string]*eval.Relation{
+		"MethodCall":    makeRel("MethodCall", 3, iv(1), iv(2), sv("bar")),
+		"ExprType":      makeRel("ExprType", 2, iv(2), iv(50)),
+		"InterfaceDecl": makeRel("InterfaceDecl", 3, iv(50), sv("IFoo"), iv(999)),
+		"Implements": makeRel("Implements", 2,
+			iv(100), iv(50),
+			iv(101), iv(50),
+		),
+		"MethodDecl": makeRel("MethodDecl", 3,
+			iv(100), sv("bar"), iv(300),
+			iv(101), sv("bar"), iv(301),
+		),
+		"ClassDecl": makeRel("ClassDecl", 3,
+			iv(100), sv("ClassA"), iv(999),
+			iv(101), sv("ClassB"), iv(999),
+		),
+		"CallCalleeSym":  eval.NewRelation("CallCalleeSym", 2),
+		"FunctionSymbol": eval.NewRelation("FunctionSymbol", 2),
+		"Extends":        eval.NewRelation("Extends", 2),
+		"NewExpr":        eval.NewRelation("NewExpr", 2),
+	}
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("call"), v("fn")},
+		Body: []datalog.Literal{
+			pos("CallTarget", v("call"), v("fn")),
+		},
+	}
+
+	rs := planAndEval(t, CallGraphRules(), query, baseRels)
+	if len(rs.Rows) != 2 {
+		t.Fatalf("CHA: expected 2 targets, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(1), iv(300)) {
+		t.Errorf("missing CallTarget(1, 300)")
+	}
+	if !resultContains(rs, iv(1), iv(301)) {
+		t.Errorf("missing CallTarget(1, 301)")
+	}
+}
+
+// TestRTAOnlyInstantiated tests rule 7: RTA prunes non-instantiated classes.
+func TestRTAOnlyInstantiated(t *testing.T) {
+	// Same setup as CHA but only ClassA is instantiated.
+	baseRels := map[string]*eval.Relation{
+		"MethodCall":    makeRel("MethodCall", 3, iv(1), iv(2), sv("bar")),
+		"ExprType":      makeRel("ExprType", 2, iv(2), iv(50)),
+		"InterfaceDecl": makeRel("InterfaceDecl", 3, iv(50), sv("IFoo"), iv(999)),
+		"Implements": makeRel("Implements", 2,
+			iv(100), iv(50),
+			iv(101), iv(50),
+		),
+		"MethodDecl": makeRel("MethodDecl", 3,
+			iv(100), sv("bar"), iv(300),
+			iv(101), sv("bar"), iv(301),
+		),
+		"ClassDecl": makeRel("ClassDecl", 3,
+			iv(100), sv("ClassA"), iv(999),
+			iv(101), sv("ClassB"), iv(999),
+		),
+		"NewExpr":        makeRel("NewExpr", 2, iv(500), iv(100)), // only ClassA instantiated
+		"CallCalleeSym":  eval.NewRelation("CallCalleeSym", 2),
+		"FunctionSymbol": eval.NewRelation("FunctionSymbol", 2),
+		"Extends":        eval.NewRelation("Extends", 2),
+	}
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("call"), v("fn")},
+		Body: []datalog.Literal{
+			pos("CallTargetRTA", v("call"), v("fn")),
+		},
+	}
+
+	rs := planAndEval(t, CallGraphRules(), query, baseRels)
+	if len(rs.Rows) != 1 {
+		t.Fatalf("RTA: expected 1 target, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(1), iv(300)) {
+		t.Errorf("expected CallTargetRTA(1, 300), got %v", rs.Rows)
+	}
+}
+
+// TestInheritance tests rules 4 and 5: inherited methods.
+func TestInheritance(t *testing.T) {
+	// Parent class (id=100) has method "greet" (fn=200).
+	// Child class (id=101) extends Parent but does NOT override "greet".
+	// MethodDeclInherited should derive (101, "greet", 200).
+	baseRels := map[string]*eval.Relation{
+		"ClassDecl": makeRel("ClassDecl", 3,
+			iv(100), sv("Parent"), iv(999),
+			iv(101), sv("Child"), iv(999),
+		),
+		"MethodDecl": makeRel("MethodDecl", 3,
+			iv(100), sv("greet"), iv(200),
+		),
+		"Extends":        makeRel("Extends", 2, iv(101), iv(100)),
+		"InterfaceDecl":  eval.NewRelation("InterfaceDecl", 3),
+		"Implements":     eval.NewRelation("Implements", 2),
+		"MethodCall":     eval.NewRelation("MethodCall", 3),
+		"ExprType":       eval.NewRelation("ExprType", 2),
+		"CallCalleeSym":  eval.NewRelation("CallCalleeSym", 2),
+		"FunctionSymbol": eval.NewRelation("FunctionSymbol", 2),
+		"NewExpr":        eval.NewRelation("NewExpr", 2),
+	}
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("childId"), v("name"), v("fn")},
+		Body: []datalog.Literal{
+			pos("MethodDeclInherited", v("childId"), v("name"), v("fn")),
+		},
+	}
+
+	rs := planAndEval(t, CallGraphRules(), query, baseRels)
+	if len(rs.Rows) != 1 {
+		t.Fatalf("Inheritance: expected 1 inherited method, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(101), sv("greet"), iv(200)) {
+		t.Errorf("expected MethodDeclInherited(101, greet, 200), got %v", rs.Rows)
+	}
+}
+
+// TestInheritanceOverrideBlocks tests that a child override blocks inheritance.
+func TestInheritanceOverrideBlocks(t *testing.T) {
+	// Parent has method "greet" (fn=200), Child also has "greet" (fn=201).
+	// MethodDeclInherited should be EMPTY because child overrides.
+	baseRels := map[string]*eval.Relation{
+		"ClassDecl": makeRel("ClassDecl", 3,
+			iv(100), sv("Parent"), iv(999),
+			iv(101), sv("Child"), iv(999),
+		),
+		"MethodDecl": makeRel("MethodDecl", 3,
+			iv(100), sv("greet"), iv(200),
+			iv(101), sv("greet"), iv(201),
+		),
+		"Extends":        makeRel("Extends", 2, iv(101), iv(100)),
+		"InterfaceDecl":  eval.NewRelation("InterfaceDecl", 3),
+		"Implements":     eval.NewRelation("Implements", 2),
+		"MethodCall":     eval.NewRelation("MethodCall", 3),
+		"ExprType":       eval.NewRelation("ExprType", 2),
+		"CallCalleeSym":  eval.NewRelation("CallCalleeSym", 2),
+		"FunctionSymbol": eval.NewRelation("FunctionSymbol", 2),
+		"NewExpr":        eval.NewRelation("NewExpr", 2),
+	}
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("childId"), v("name"), v("fn")},
+		Body: []datalog.Literal{
+			pos("MethodDeclInherited", v("childId"), v("name"), v("fn")),
+		},
+	}
+
+	rs := planAndEval(t, CallGraphRules(), query, baseRels)
+	if len(rs.Rows) != 0 {
+		t.Fatalf("Override: expected 0 inherited methods, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestCHASupersetsRTA verifies the property: CHA >= RTA (every RTA target is a CHA target).
+func TestCHASupersetsRTA(t *testing.T) {
+	// 3 classes implement IFoo, only 2 are instantiated.
+	baseRels := map[string]*eval.Relation{
+		"MethodCall": makeRel("MethodCall", 3,
+			iv(1), iv(2), sv("do"),
+			iv(3), iv(4), sv("do"),
+		),
+		"ExprType": makeRel("ExprType", 2,
+			iv(2), iv(50),
+			iv(4), iv(50),
+		),
+		"InterfaceDecl": makeRel("InterfaceDecl", 3, iv(50), sv("IFoo"), iv(999)),
+		"Implements": makeRel("Implements", 2,
+			iv(100), iv(50),
+			iv(101), iv(50),
+			iv(102), iv(50),
+		),
+		"MethodDecl": makeRel("MethodDecl", 3,
+			iv(100), sv("do"), iv(300),
+			iv(101), sv("do"), iv(301),
+			iv(102), sv("do"), iv(302),
+		),
+		"ClassDecl": makeRel("ClassDecl", 3,
+			iv(100), sv("A"), iv(999),
+			iv(101), sv("B"), iv(999),
+			iv(102), sv("C"), iv(999),
+		),
+		"NewExpr": makeRel("NewExpr", 2,
+			iv(500), iv(100), // A instantiated
+			iv(501), iv(101), // B instantiated
+			// C NOT instantiated
+		),
+		"CallCalleeSym":  eval.NewRelation("CallCalleeSym", 2),
+		"FunctionSymbol": eval.NewRelation("FunctionSymbol", 2),
+		"Extends":        eval.NewRelation("Extends", 2),
+	}
+
+	// Get CHA targets
+	chaQuery := &datalog.Query{
+		Select: []datalog.Term{v("call"), v("fn")},
+		Body:   []datalog.Literal{pos("CallTarget", v("call"), v("fn"))},
+	}
+	chaRS := planAndEval(t, CallGraphRules(), chaQuery, baseRels)
+
+	// Get RTA targets
+	rtaQuery := &datalog.Query{
+		Select: []datalog.Term{v("call"), v("fn")},
+		Body:   []datalog.Literal{pos("CallTargetRTA", v("call"), v("fn"))},
+	}
+	rtaRS := planAndEval(t, CallGraphRules(), rtaQuery, baseRels)
+
+	// Every RTA target must be in CHA
+	chaSet := make(map[[2]int64]bool)
+	for _, row := range chaRS.Rows {
+		call := row[0].(eval.IntVal).V
+		fn := row[1].(eval.IntVal).V
+		chaSet[[2]int64{call, fn}] = true
+	}
+
+	for _, row := range rtaRS.Rows {
+		call := row[0].(eval.IntVal).V
+		fn := row[1].(eval.IntVal).V
+		if !chaSet[[2]int64{call, fn}] {
+			t.Errorf("RTA target (%d, %d) not in CHA set", call, fn)
+		}
+	}
+
+	// CHA should have 6 targets (2 calls x 3 classes), RTA should have 4 (2 calls x 2 instantiated classes)
+	if len(chaRS.Rows) != 6 {
+		t.Errorf("CHA: expected 6 targets, got %d", len(chaRS.Rows))
+	}
+	if len(rtaRS.Rows) != 4 {
+		t.Errorf("RTA: expected 4 targets, got %d", len(rtaRS.Rows))
+	}
+}
+
+// TestMergeSystemRules tests the merge function.
+func TestMergeSystemRules(t *testing.T) {
+	userProg := &datalog.Program{
+		Rules: []datalog.Rule{
+			{Head: datalog.Atom{Predicate: "UserRule", Args: []datalog.Term{v("x")}}},
+		},
+		Query: &datalog.Query{
+			Select: []datalog.Term{v("x")},
+		},
+	}
+
+	sysRules := []datalog.Rule{
+		{Head: datalog.Atom{Predicate: "SysRule", Args: []datalog.Term{v("y")}}},
+	}
+
+	merged := MergeSystemRules(userProg, sysRules)
+
+	if len(merged.Rules) != 2 {
+		t.Fatalf("expected 2 rules in merged program, got %d", len(merged.Rules))
+	}
+	// System rules first, then user rules.
+	if merged.Rules[0].Head.Predicate != "SysRule" {
+		t.Errorf("expected system rule first, got %s", merged.Rules[0].Head.Predicate)
+	}
+	if merged.Rules[1].Head.Predicate != "UserRule" {
+		t.Errorf("expected user rule second, got %s", merged.Rules[1].Head.Predicate)
+	}
+	// Original should be unmodified.
+	if len(userProg.Rules) != 1 {
+		t.Errorf("original program was modified")
+	}
+	// Query should be preserved.
+	if merged.Query == nil {
+		t.Error("merged query is nil")
+	}
+}
+
+// TestInstantiatedRelation tests rule 6: Instantiated derived from NewExpr.
+func TestInstantiatedRelation(t *testing.T) {
+	baseRels := map[string]*eval.Relation{
+		"NewExpr": makeRel("NewExpr", 2,
+			iv(1), iv(100),
+			iv(2), iv(100), // duplicate class, should deduplicate
+			iv(3), iv(200),
+		),
+		"MethodCall":     eval.NewRelation("MethodCall", 3),
+		"ExprType":       eval.NewRelation("ExprType", 2),
+		"ClassDecl":      eval.NewRelation("ClassDecl", 3),
+		"InterfaceDecl":  eval.NewRelation("InterfaceDecl", 3),
+		"MethodDecl":     eval.NewRelation("MethodDecl", 3),
+		"Implements":     eval.NewRelation("Implements", 2),
+		"Extends":        eval.NewRelation("Extends", 2),
+		"CallCalleeSym":  eval.NewRelation("CallCalleeSym", 2),
+		"FunctionSymbol": eval.NewRelation("FunctionSymbol", 2),
+	}
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("classId")},
+		Body:   []datalog.Literal{pos("Instantiated", v("classId"))},
+	}
+
+	rs := planAndEval(t, CallGraphRules(), query, baseRels)
+	if len(rs.Rows) != 2 {
+		t.Fatalf("expected 2 instantiated classes, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestCallGraphRulesCount verifies we produce exactly 7 rules.
+func TestCallGraphRulesCount(t *testing.T) {
+	rules := CallGraphRules()
+	if len(rules) != 7 {
+		t.Errorf("expected 7 call graph rules, got %d", len(rules))
+	}
+}
+
+// TestCallGraphRulesValidate verifies all rules pass the planner's validation.
+func TestCallGraphRulesValidate(t *testing.T) {
+	for i, r := range CallGraphRules() {
+		errs := plan.ValidateRule(r)
+		if len(errs) > 0 {
+			t.Errorf("rule %d (%s) validation errors: %v", i, r.Head.Predicate, errs)
+		}
+	}
+}
+
+// TestCallGraphRulesStratify verifies the rules can be stratified (no recursive negation).
+func TestCallGraphRulesStratify(t *testing.T) {
+	prog := &datalog.Program{Rules: CallGraphRules()}
+	_, errs := plan.Plan(prog, nil)
+	if len(errs) > 0 {
+		t.Fatalf("call graph rules failed to plan: %v", errs)
+	}
+}

--- a/extract/rules/merge.go
+++ b/extract/rules/merge.go
@@ -1,0 +1,18 @@
+package rules
+
+import (
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// MergeSystemRules returns a new Program that contains both the user-written
+// rules (from prog) and the given system rules. The original program is not
+// modified.
+func MergeSystemRules(prog *datalog.Program, systemRules []datalog.Rule) *datalog.Program {
+	merged := &datalog.Program{
+		Query: prog.Query,
+		Rules: make([]datalog.Rule, 0, len(prog.Rules)+len(systemRules)),
+	}
+	merged.Rules = append(merged.Rules, systemRules...)
+	merged.Rules = append(merged.Rules, prog.Rules...)
+	return merged
+}

--- a/extract/schema/relations.go
+++ b/extract/schema/relations.go
@@ -223,6 +223,29 @@ func init() {
 		{Name: "fnId", Type: TypeEntityRef},
 	}})
 
+	// v2 Phase B: call graph derived relations (computed by system Datalog rules)
+	RegisterRelation(RelationDef{Name: "CallTarget", Version: 2, Columns: []ColumnDef{
+		{Name: "call", Type: TypeEntityRef},
+		{Name: "fn", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "CallTargetRTA", Version: 2, Columns: []ColumnDef{
+		{Name: "call", Type: TypeEntityRef},
+		{Name: "fn", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "Instantiated", Version: 2, Columns: []ColumnDef{
+		{Name: "classId", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "MethodDeclDirect", Version: 2, Columns: []ColumnDef{
+		{Name: "classId", Type: TypeEntityRef},
+		{Name: "name", Type: TypeString},
+		{Name: "fn", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "MethodDeclInherited", Version: 2, Columns: []ColumnDef{
+		{Name: "childId", Type: TypeEntityRef},
+		{Name: "name", Type: TypeString},
+		{Name: "fn", Type: TypeEntityRef},
+	}})
+
 	// Diagnostics
 	RegisterRelation(RelationDef{Name: "ExtractError", Version: 1, Columns: []ColumnDef{
 		{Name: "file", Type: TypeEntityRef},

--- a/extract/schema/relations_test.go
+++ b/extract/schema/relations_test.go
@@ -34,8 +34,8 @@ func TestAllRelationsRegistered(t *testing.T) {
 }
 
 func TestRelationCount(t *testing.T) {
-	if len(Registry) != 45 {
-		t.Fatalf("expected 45 relations in registry, got %d", len(Registry))
+	if len(Registry) != 50 {
+		t.Fatalf("expected 50 relations in registry, got %d", len(Registry))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add 7 Datalog rules for call graph resolution: direct calls, concrete class dispatch, CHA interface dispatch, method inheritance with override blocking, instantiation tracking, and RTA filtering
- New `extract/rules` package with `CallGraphRules()` and `MergeSystemRules()` for injecting system rules alongside user queries
- Bridge classes (`CallTarget`, `CallTargetRTA`, `Instantiated`, `MethodDeclDirect`, `MethodDeclInherited`) with schema registration and manifest updates

## Test plan

- [x] 12 unit tests covering all 7 rules individually and in combination
- [x] Property test: CHA >= RTA (every RTA target is also a CHA target)
- [x] All rules pass `ValidateRule` safety checks
- [x] All rules stratify successfully (no recursive negation)
- [x] Full `go test ./... -count=1` passes (all existing + new tests)