### PR TITLE
v2 Phase C1: Intra-procedural dataflow

### DIFF
--- a/bridge/embed.go
+++ b/bridge/embed.go
@@ -2,7 +2,7 @@ package bridge
 
 import "embed"
 
-//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll
+//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll
 var bridgeFS embed.FS
 
 // LoadBridge returns all embedded .qll files as a map from filename to contents.
@@ -19,6 +19,7 @@ func LoadBridge() map[string][]byte {
 		"tsq_types.qll",
 		"tsq_symbols.qll",
 		"tsq_callgraph.qll",
+		"tsq_dataflow.qll",
 	}
 	result := make(map[string][]byte, len(files))
 	for _, name := range files {
@@ -55,6 +56,7 @@ func BridgeImportLoader(bridgeFiles map[string][]byte, parseFn func(src, file st
 		"tsq::types":       "tsq_types.qll",
 		"tsq::symbols":     "tsq_symbols.qll",
 		"tsq::callgraph":   "tsq_callgraph.qll",
+		"tsq::dataflow":    "tsq_dataflow.qll",
 	}
 	return func(path string) (interface{}, bool) {
 		filename, ok := pathToFile[path]

--- a/bridge/embed_test.go
+++ b/bridge/embed_test.go
@@ -18,6 +18,7 @@ func TestLoadBridgeReturnsAllFiles(t *testing.T) {
 		"tsq_types.qll",
 		"tsq_symbols.qll",
 		"tsq_callgraph.qll",
+		"tsq_dataflow.qll",
 	}
 	files := LoadBridge()
 	if len(files) != len(expected) {
@@ -105,7 +106,6 @@ func TestBridgeImportLoaderUnknownPaths(t *testing.T) {
 	loader := BridgeImportLoader(files, stubParse)
 
 	unknownPaths := []string{
-		"tsq::dataflow",
 		"tsq::taint",
 		"javascript",
 		"DataFlow::PathGraph",

--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -95,6 +95,10 @@ func v2Manifest() *CapabilityManifest {
 			{Name: "Instantiated", Relation: "Instantiated", File: "tsq_callgraph.qll"},
 			{Name: "MethodDeclDirect", Relation: "MethodDeclDirect", File: "tsq_callgraph.qll"},
 			{Name: "MethodDeclInherited", Relation: "MethodDeclInherited", File: "tsq_callgraph.qll"},
+			// v2 Phase C1: intra-procedural dataflow
+			{Name: "ReturnSym", Relation: "ReturnSym", File: "tsq_functions.qll"},
+			{Name: "LocalFlow", Relation: "LocalFlow", File: "tsq_dataflow.qll"},
+			{Name: "LocalFlowStar", Relation: "LocalFlowStar", File: "tsq_dataflow.qll"},
 		},
 		Unavailable: []UnavailableClass{
 			{Name: "DataFlow", Reason: "IPA-dependent; requires inter-procedural analysis engine", VersionTarget: "v3"},

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -9,8 +9,8 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	m := V1Manifest()
 	// v2: 28 original + 5 promoted from unavailable + 12 new v2 = 45
 	// But some relations share bridge classes. Count: 28 + 17 = 45
-	if got := len(m.Available); got != 50 {
-		t.Errorf("expected 50 available classes, got %d", got)
+	if got := len(m.Available); got != 53 {
+		t.Errorf("expected 53 available classes, got %d", got)
 	}
 }
 

--- a/bridge/tsq_dataflow.qll
+++ b/bridge/tsq_dataflow.qll
@@ -1,0 +1,46 @@
+/**
+ * Bridge library for intra-procedural dataflow relations (v2 Phase C1).
+ * Maps LocalFlow and LocalFlowStar derived from system Datalog rules
+ * over assignment, VarDecl, return, field, and destructuring facts.
+ */
+
+/**
+ * A local (intra-procedural) data-flow edge within a single function.
+ * Holds when `srcSym` flows to `dstSym` in one step inside function `fnId`.
+ */
+class LocalFlow extends @local_flow {
+    LocalFlow() { LocalFlow(this, _, _) }
+
+    /** Gets the enclosing function. */
+    int getFunction() { result = this }
+
+    /** Gets the source symbol. */
+    int getSource() { LocalFlow(this, result, _) }
+
+    /** Gets the destination symbol. */
+    int getDestination() { LocalFlow(this, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "LocalFlow" }
+}
+
+/**
+ * Transitive closure of local data-flow edges.
+ * Holds when there exists a chain of LocalFlow edges from `srcSym` to `dstSym`
+ * within the same function `fnId`.
+ */
+class LocalFlowStar extends @local_flow_star {
+    LocalFlowStar() { LocalFlowStar(this, _, _) }
+
+    /** Gets the enclosing function. */
+    int getFunction() { result = this }
+
+    /** Gets the source symbol. */
+    int getSource() { LocalFlowStar(this, result, _) }
+
+    /** Gets the destination symbol. */
+    int getDestination() { LocalFlowStar(this, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "LocalFlowStar" }
+}

--- a/extract/ids.go
+++ b/extract/ids.go
@@ -38,6 +38,12 @@ func SymID(filePath, name string, startLine, startCol int) uint32 {
 	return uint32(h.Sum64())
 }
 
+// ReturnSymID returns a deterministic 32-bit ID for the synthetic return symbol
+// of a function. Uses FNV-1a of (filePath, "$return", fnStartLine, fnStartCol).
+func ReturnSymID(filePath string, fnStartLine, fnStartCol int) uint32 {
+	return SymID(filePath, "$return", fnStartLine, fnStartCol)
+}
+
 // FileID returns a deterministic 32-bit ID for a file path.
 func FileID(filePath string) uint32 {
 	h := fnv.New64a()

--- a/extract/rules/localflow.go
+++ b/extract/rules/localflow.go
@@ -41,12 +41,14 @@ func LocalFlowRules() []datalog.Rule {
 		// LocalFlow(fn, retSym, returnSym) :-
 		//   ReturnStmt(fn, _, retExpr),
 		//   ExprMayRef(retExpr, retSym),
-		//   ReturnSym(fn, returnSym).
+		//   ReturnSym(fn, returnSym),
+		//   SymInFunction(retSym, fn).
 		rule("LocalFlow",
 			[]datalog.Term{v("fn"), v("retSym"), v("returnSym")},
 			pos("ReturnStmt", v("fn"), w(), v("retExpr")),
 			pos("ExprMayRef", v("retExpr"), v("retSym")),
 			pos("ReturnSym", v("fn"), v("returnSym")),
+			pos("SymInFunction", v("retSym"), v("fn")),
 		),
 
 		// Rule 4: Destructuring flow (field-insensitive).

--- a/extract/rules/localflow.go
+++ b/extract/rules/localflow.go
@@ -1,0 +1,111 @@
+package rules
+
+import (
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// LocalFlowRules returns the system Datalog rules for intra-procedural dataflow.
+// These compute LocalFlow(fn, srcSym, dstSym) edges within a single function,
+// and LocalFlowStar(fn, srcSym, dstSym) as the transitive closure.
+func LocalFlowRules() []datalog.Rule {
+	return []datalog.Rule{
+		// Rule 1: Assignment flow.
+		// LocalFlow(fn, rhsSym, lhsSym) :-
+		//   Assign(lhsNode, rhsExpr, lhsSym),
+		//   ExprMayRef(rhsExpr, rhsSym),
+		//   SymInFunction(lhsSym, fn),
+		//   SymInFunction(rhsSym, fn).
+		rule("LocalFlow",
+			[]datalog.Term{v("fn"), v("rhsSym"), v("lhsSym")},
+			pos("Assign", w(), v("rhsExpr"), v("lhsSym")),
+			pos("ExprMayRef", v("rhsExpr"), v("rhsSym")),
+			pos("SymInFunction", v("lhsSym"), v("fn")),
+			pos("SymInFunction", v("rhsSym"), v("fn")),
+		),
+
+		// Rule 2: VarDecl init flow.
+		// LocalFlow(fn, initSym, sym) :-
+		//   VarDecl(_, sym, initExpr, _),
+		//   ExprMayRef(initExpr, initSym),
+		//   SymInFunction(sym, fn),
+		//   SymInFunction(initSym, fn).
+		rule("LocalFlow",
+			[]datalog.Term{v("fn"), v("initSym"), v("sym")},
+			pos("VarDecl", w(), v("sym"), v("initExpr"), w()),
+			pos("ExprMayRef", v("initExpr"), v("initSym")),
+			pos("SymInFunction", v("sym"), v("fn")),
+			pos("SymInFunction", v("initSym"), v("fn")),
+		),
+
+		// Rule 3: Return value flow.
+		// LocalFlow(fn, retSym, returnSym) :-
+		//   ReturnStmt(fn, _, retExpr),
+		//   ExprMayRef(retExpr, retSym),
+		//   ReturnSym(fn, returnSym).
+		rule("LocalFlow",
+			[]datalog.Term{v("fn"), v("retSym"), v("returnSym")},
+			pos("ReturnStmt", v("fn"), w(), v("retExpr")),
+			pos("ExprMayRef", v("retExpr"), v("retSym")),
+			pos("ReturnSym", v("fn"), v("returnSym")),
+		),
+
+		// Rule 4: Destructuring flow (field-insensitive).
+		// LocalFlow(fn, parentSym, bindSym) :-
+		//   DestructureField(parent, _, _, bindSym, _),
+		//   VarDecl(parent, parentDeclSym, initExpr, _),
+		//   ExprMayRef(initExpr, parentSym),
+		//   SymInFunction(bindSym, fn),
+		//   SymInFunction(parentSym, fn).
+		rule("LocalFlow",
+			[]datalog.Term{v("fn"), v("parentSym"), v("bindSym")},
+			pos("DestructureField", v("parent"), w(), w(), v("bindSym"), w()),
+			pos("VarDecl", v("parent"), w(), v("initExpr"), w()),
+			pos("ExprMayRef", v("initExpr"), v("parentSym")),
+			pos("SymInFunction", v("bindSym"), v("fn")),
+			pos("SymInFunction", v("parentSym"), v("fn")),
+		),
+
+		// Rule 5: Field read flow (field-insensitive).
+		// LocalFlow(fn, baseSym, exprSym) :-
+		//   FieldRead(expr, baseSym, _),
+		//   ExprMayRef(expr, exprSym),
+		//   SymInFunction(baseSym, fn),
+		//   SymInFunction(exprSym, fn).
+		rule("LocalFlow",
+			[]datalog.Term{v("fn"), v("baseSym"), v("exprSym")},
+			pos("FieldRead", v("expr"), v("baseSym"), w()),
+			pos("ExprMayRef", v("expr"), v("exprSym")),
+			pos("SymInFunction", v("baseSym"), v("fn")),
+			pos("SymInFunction", v("exprSym"), v("fn")),
+		),
+
+		// Rule 6: Field write flow (field-insensitive).
+		// LocalFlow(fn, rhsSym, baseSym) :-
+		//   FieldWrite(_, baseSym, _, rhsExpr),
+		//   ExprMayRef(rhsExpr, rhsSym),
+		//   SymInFunction(baseSym, fn),
+		//   SymInFunction(rhsSym, fn).
+		rule("LocalFlow",
+			[]datalog.Term{v("fn"), v("rhsSym"), v("baseSym")},
+			pos("FieldWrite", w(), v("baseSym"), w(), v("rhsExpr")),
+			pos("ExprMayRef", v("rhsExpr"), v("rhsSym")),
+			pos("SymInFunction", v("baseSym"), v("fn")),
+			pos("SymInFunction", v("rhsSym"), v("fn")),
+		),
+
+		// Rule 7: Transitive closure base case.
+		// LocalFlowStar(fn, src, dst) :- LocalFlow(fn, src, dst).
+		rule("LocalFlowStar",
+			[]datalog.Term{v("fn"), v("src"), v("dst")},
+			pos("LocalFlow", v("fn"), v("src"), v("dst")),
+		),
+
+		// Rule 8: Transitive closure recursive step.
+		// LocalFlowStar(fn, src, dst) :- LocalFlowStar(fn, src, mid), LocalFlow(fn, mid, dst).
+		rule("LocalFlowStar",
+			[]datalog.Term{v("fn"), v("src"), v("dst")},
+			pos("LocalFlowStar", v("fn"), v("src"), v("mid")),
+			pos("LocalFlow", v("fn"), v("mid"), v("dst")),
+		),
+	}
+}

--- a/extract/rules/localflow_test.go
+++ b/extract/rules/localflow_test.go
@@ -78,9 +78,10 @@ func TestVarDeclFlow(t *testing.T) {
 func TestReturnFlow(t *testing.T) {
 	// fn=1, sym_x=10, returnSym=99, stmtNode=50, retExpr=200
 	baseRels := localFlowBaseRels(map[string]*eval.Relation{
-		"ReturnStmt": makeRel("ReturnStmt", 3, iv(1), iv(50), iv(200)),
-		"ExprMayRef": makeRel("ExprMayRef", 2, iv(200), iv(10)),
-		"ReturnSym":  makeRel("ReturnSym", 2, iv(1), iv(99)),
+		"ReturnStmt":    makeRel("ReturnStmt", 3, iv(1), iv(50), iv(200)),
+		"ExprMayRef":    makeRel("ExprMayRef", 2, iv(200), iv(10)),
+		"ReturnSym":     makeRel("ReturnSym", 2, iv(1), iv(99)),
+		"SymInFunction": makeRel("SymInFunction", 2, iv(10), iv(1), iv(99), iv(1)),
 	})
 
 	query := &datalog.Query{

--- a/extract/rules/localflow_test.go
+++ b/extract/rules/localflow_test.go
@@ -1,0 +1,399 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// localFlowBaseRels returns a base relation map with all required relations
+// for LocalFlow rules, populated with the given overrides.
+func localFlowBaseRels(overrides map[string]*eval.Relation) map[string]*eval.Relation {
+	base := map[string]*eval.Relation{
+		"Assign":           eval.NewRelation("Assign", 3),
+		"ExprMayRef":       eval.NewRelation("ExprMayRef", 2),
+		"SymInFunction":    eval.NewRelation("SymInFunction", 2),
+		"VarDecl":          eval.NewRelation("VarDecl", 4),
+		"ReturnStmt":       eval.NewRelation("ReturnStmt", 3),
+		"ReturnSym":        eval.NewRelation("ReturnSym", 2),
+		"DestructureField": eval.NewRelation("DestructureField", 5),
+		"FieldRead":        eval.NewRelation("FieldRead", 3),
+		"FieldWrite":       eval.NewRelation("FieldWrite", 4),
+	}
+	for k, v := range overrides {
+		base[k] = v
+	}
+	return base
+}
+
+// TestAssignmentFlow tests rule 1: x = y → LocalFlow(fn, sym_y, sym_x).
+func TestAssignmentFlow(t *testing.T) {
+	// fn=1, sym_x=10, sym_y=20, lhsNode=100, rhsExpr=200
+	baseRels := localFlowBaseRels(map[string]*eval.Relation{
+		"Assign":        makeRel("Assign", 3, iv(100), iv(200), iv(10)),
+		"ExprMayRef":    makeRel("ExprMayRef", 2, iv(200), iv(20)),
+		"SymInFunction": makeRel("SymInFunction", 2, iv(10), iv(1), iv(20), iv(1)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("LocalFlow", v("fn"), v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, LocalFlowRules(), query, baseRels)
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 LocalFlow row, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(1), iv(20), iv(10)) {
+		t.Errorf("expected LocalFlow(1, 20, 10), got %v", rs.Rows)
+	}
+}
+
+// TestVarDeclFlow tests rule 2: const x = y → LocalFlow(fn, sym_y, sym_x).
+func TestVarDeclFlow(t *testing.T) {
+	// fn=1, sym_x=10, sym_y=20, declId=100, initExpr=200
+	baseRels := localFlowBaseRels(map[string]*eval.Relation{
+		"VarDecl":       makeRel("VarDecl", 4, iv(100), iv(10), iv(200), iv(1)),
+		"ExprMayRef":    makeRel("ExprMayRef", 2, iv(200), iv(20)),
+		"SymInFunction": makeRel("SymInFunction", 2, iv(10), iv(1), iv(20), iv(1)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("LocalFlow", v("fn"), v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, LocalFlowRules(), query, baseRels)
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 LocalFlow row, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(1), iv(20), iv(10)) {
+		t.Errorf("expected LocalFlow(1, 20, 10), got %v", rs.Rows)
+	}
+}
+
+// TestReturnFlow tests rule 3: return x → LocalFlow(fn, sym_x, returnSym).
+func TestReturnFlow(t *testing.T) {
+	// fn=1, sym_x=10, returnSym=99, stmtNode=50, retExpr=200
+	baseRels := localFlowBaseRels(map[string]*eval.Relation{
+		"ReturnStmt": makeRel("ReturnStmt", 3, iv(1), iv(50), iv(200)),
+		"ExprMayRef": makeRel("ExprMayRef", 2, iv(200), iv(10)),
+		"ReturnSym":  makeRel("ReturnSym", 2, iv(1), iv(99)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("LocalFlow", v("fn"), v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, LocalFlowRules(), query, baseRels)
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 LocalFlow row, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(1), iv(10), iv(99)) {
+		t.Errorf("expected LocalFlow(1, 10, 99), got %v", rs.Rows)
+	}
+}
+
+// TestChainFlow tests transitivity: x = y; z = x → LocalFlowStar(fn, sym_y, sym_z).
+func TestChainFlow(t *testing.T) {
+	// fn=1, sym_x=10, sym_y=20, sym_z=30
+	// Assign x = y: lhsNode=100, rhsExpr=200
+	// Assign z = x: lhsNode=101, rhsExpr=201
+	baseRels := localFlowBaseRels(map[string]*eval.Relation{
+		"Assign": makeRel("Assign", 3,
+			iv(100), iv(200), iv(10), // x = y
+			iv(101), iv(201), iv(30), // z = x
+		),
+		"ExprMayRef": makeRel("ExprMayRef", 2,
+			iv(200), iv(20), // rhsExpr for y
+			iv(201), iv(10), // rhsExpr for x
+		),
+		"SymInFunction": makeRel("SymInFunction", 2,
+			iv(10), iv(1),
+			iv(20), iv(1),
+			iv(30), iv(1),
+		),
+	})
+
+	// Check LocalFlowStar for the transitive edge
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("LocalFlowStar", v("fn"), v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, LocalFlowRules(), query, baseRels)
+	// Direct: (1,20,10) and (1,10,30); Transitive: (1,20,30)
+	if !resultContains(rs, iv(1), iv(20), iv(30)) {
+		t.Errorf("expected transitive LocalFlowStar(1, 20, 30), got %v", rs.Rows)
+	}
+	if !resultContains(rs, iv(1), iv(20), iv(10)) {
+		t.Errorf("expected direct LocalFlowStar(1, 20, 10), got %v", rs.Rows)
+	}
+	if !resultContains(rs, iv(1), iv(10), iv(30)) {
+		t.Errorf("expected direct LocalFlowStar(1, 10, 30), got %v", rs.Rows)
+	}
+	if len(rs.Rows) != 3 {
+		t.Errorf("expected 3 LocalFlowStar rows, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestNoCrossFunctionFlow verifies that flow does not cross function boundaries.
+func TestNoCrossFunctionFlow(t *testing.T) {
+	// fn1=1, fn2=2, sym_x=10 in fn1, sym_y=20 in fn2
+	// Assign x = y but they are in different functions → no LocalFlow.
+	baseRels := localFlowBaseRels(map[string]*eval.Relation{
+		"Assign":     makeRel("Assign", 3, iv(100), iv(200), iv(10)),
+		"ExprMayRef": makeRel("ExprMayRef", 2, iv(200), iv(20)),
+		"SymInFunction": makeRel("SymInFunction", 2,
+			iv(10), iv(1), // sym_x in fn1
+			iv(20), iv(2), // sym_y in fn2
+		),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("LocalFlow", v("fn"), v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, LocalFlowRules(), query, baseRels)
+	if len(rs.Rows) != 0 {
+		t.Errorf("expected 0 cross-function LocalFlow rows, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestSelfAssignment tests x = x → LocalFlow(fn, sym_x, sym_x).
+func TestSelfAssignment(t *testing.T) {
+	// fn=1, sym_x=10, lhsNode=100, rhsExpr=200
+	baseRels := localFlowBaseRels(map[string]*eval.Relation{
+		"Assign":        makeRel("Assign", 3, iv(100), iv(200), iv(10)),
+		"ExprMayRef":    makeRel("ExprMayRef", 2, iv(200), iv(10)),
+		"SymInFunction": makeRel("SymInFunction", 2, iv(10), iv(1)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("LocalFlow", v("fn"), v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, LocalFlowRules(), query, baseRels)
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 self-assignment LocalFlow row, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(1), iv(10), iv(10)) {
+		t.Errorf("expected LocalFlow(1, 10, 10), got %v", rs.Rows)
+	}
+}
+
+// TestFieldWriteFlow tests rule 6: obj.f = x → LocalFlow(fn, sym_x, sym_obj).
+func TestFieldWriteFlow(t *testing.T) {
+	// fn=1, sym_obj=10, sym_x=20, assignNode=100, rhsExpr=200
+	baseRels := localFlowBaseRels(map[string]*eval.Relation{
+		"FieldWrite":    makeRel("FieldWrite", 4, iv(100), iv(10), sv("f"), iv(200)),
+		"ExprMayRef":    makeRel("ExprMayRef", 2, iv(200), iv(20)),
+		"SymInFunction": makeRel("SymInFunction", 2, iv(10), iv(1), iv(20), iv(1)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("LocalFlow", v("fn"), v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, LocalFlowRules(), query, baseRels)
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 FieldWrite LocalFlow row, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(1), iv(20), iv(10)) {
+		t.Errorf("expected LocalFlow(1, 20, 10), got %v", rs.Rows)
+	}
+}
+
+// TestFieldReadFlow tests rule 5: y = obj.f → LocalFlow(fn, sym_obj, sym_y).
+func TestFieldReadFlow(t *testing.T) {
+	// fn=1, sym_obj=10, sym_y=20, expr=300
+	// FieldRead(expr=300, baseSym=10, fieldName="f")
+	// ExprMayRef(expr=300, exprSym=20) — the read expression refers to sym_y
+	baseRels := localFlowBaseRels(map[string]*eval.Relation{
+		"FieldRead":     makeRel("FieldRead", 3, iv(300), iv(10), sv("f")),
+		"ExprMayRef":    makeRel("ExprMayRef", 2, iv(300), iv(20)),
+		"SymInFunction": makeRel("SymInFunction", 2, iv(10), iv(1), iv(20), iv(1)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("LocalFlow", v("fn"), v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, LocalFlowRules(), query, baseRels)
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 FieldRead LocalFlow row, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(1), iv(10), iv(20)) {
+		t.Errorf("expected LocalFlow(1, 10, 20), got %v", rs.Rows)
+	}
+}
+
+// TestLocalFlowRulesCount verifies we produce exactly 8 rules.
+func TestLocalFlowRulesCount(t *testing.T) {
+	rules := LocalFlowRules()
+	if len(rules) != 8 {
+		t.Errorf("expected 8 local flow rules, got %d", len(rules))
+	}
+}
+
+// TestLocalFlowRulesValidate verifies all rules pass the planner's validation.
+func TestLocalFlowRulesValidate(t *testing.T) {
+	for i, r := range LocalFlowRules() {
+		errs := plan.ValidateRule(r)
+		if len(errs) > 0 {
+			t.Errorf("rule %d (%s) validation errors: %v", i, r.Head.Predicate, errs)
+		}
+	}
+}
+
+// TestLocalFlowRulesStratify verifies the rules can be stratified (no recursive negation).
+func TestLocalFlowRulesStratify(t *testing.T) {
+	prog := &datalog.Program{Rules: LocalFlowRules()}
+	_, errs := plan.Plan(prog, nil)
+	if len(errs) > 0 {
+		t.Fatalf("local flow rules failed to plan: %v", errs)
+	}
+}
+
+// TestAllSystemRulesStratify verifies call graph + local flow rules together can be stratified.
+func TestAllSystemRulesStratify(t *testing.T) {
+	prog := &datalog.Program{Rules: AllSystemRules()}
+	_, errs := plan.Plan(prog, nil)
+	if len(errs) > 0 {
+		t.Fatalf("all system rules failed to plan: %v", errs)
+	}
+}
+
+// TestAllSystemRulesCount verifies AllSystemRules returns combined count.
+func TestAllSystemRulesCount(t *testing.T) {
+	all := AllSystemRules()
+	cg := CallGraphRules()
+	lf := LocalFlowRules()
+	if len(all) != len(cg)+len(lf) {
+		t.Errorf("expected %d rules, got %d", len(cg)+len(lf), len(all))
+	}
+}
+
+// TestLocalFlowStarTransitivity property: if LocalFlowStar(fn, a, b) and LocalFlow(fn, b, c)
+// then LocalFlowStar(fn, a, c).
+func TestLocalFlowStarTransitivity(t *testing.T) {
+	// Chain: a→b→c→d (all in same fn=1)
+	baseRels := localFlowBaseRels(map[string]*eval.Relation{
+		"Assign": makeRel("Assign", 3,
+			iv(100), iv(200), iv(20), // b = a
+			iv(101), iv(201), iv(30), // c = b
+			iv(102), iv(202), iv(40), // d = c
+		),
+		"ExprMayRef": makeRel("ExprMayRef", 2,
+			iv(200), iv(10), // a
+			iv(201), iv(20), // b
+			iv(202), iv(30), // c
+		),
+		"SymInFunction": makeRel("SymInFunction", 2,
+			iv(10), iv(1),
+			iv(20), iv(1),
+			iv(30), iv(1),
+			iv(40), iv(1),
+		),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("LocalFlowStar", v("fn"), v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, LocalFlowRules(), query, baseRels)
+	// Direct: (10→20), (20→30), (30→40)
+	// Transitive: (10→30), (10→40), (20→40)
+	// Total: 6
+	if len(rs.Rows) != 6 {
+		t.Fatalf("expected 6 LocalFlowStar rows for 4-node chain, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	// Check the longest transitive path
+	if !resultContains(rs, iv(1), iv(10), iv(40)) {
+		t.Errorf("expected transitive LocalFlowStar(1, 10, 40)")
+	}
+}
+
+// TestFunctionScoping verifies that two parallel chains in different functions
+// do not interfere with each other.
+func TestFunctionScoping(t *testing.T) {
+	// fn1=1: a(10)→b(20)
+	// fn2=2: c(30)→d(40)
+	baseRels := localFlowBaseRels(map[string]*eval.Relation{
+		"Assign": makeRel("Assign", 3,
+			iv(100), iv(200), iv(20), // b = a (fn1)
+			iv(101), iv(201), iv(40), // d = c (fn2)
+		),
+		"ExprMayRef": makeRel("ExprMayRef", 2,
+			iv(200), iv(10),
+			iv(201), iv(30),
+		),
+		"SymInFunction": makeRel("SymInFunction", 2,
+			iv(10), iv(1),
+			iv(20), iv(1),
+			iv(30), iv(2),
+			iv(40), iv(2),
+		),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("LocalFlow", v("fn"), v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, LocalFlowRules(), query, baseRels)
+	if len(rs.Rows) != 2 {
+		t.Fatalf("expected 2 LocalFlow rows (one per function), got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(1), iv(10), iv(20)) {
+		t.Errorf("expected LocalFlow(1, 10, 20)")
+	}
+	if !resultContains(rs, iv(2), iv(30), iv(40)) {
+		t.Errorf("expected LocalFlow(2, 30, 40)")
+	}
+}
+
+// TestDestructuringFlow tests rule 4: const {a} = obj → LocalFlow(fn, sym_obj, sym_a).
+func TestDestructuringFlow(t *testing.T) {
+	// fn=1, sym_obj=10, sym_a=20, parent(VarDecl)=100, initExpr=200
+	baseRels := localFlowBaseRels(map[string]*eval.Relation{
+		"DestructureField": makeRel("DestructureField", 5,
+			iv(100), sv("a"), sv("a"), iv(20), iv(0)),
+		"VarDecl":       makeRel("VarDecl", 4, iv(100), iv(99), iv(200), iv(1)),
+		"ExprMayRef":    makeRel("ExprMayRef", 2, iv(200), iv(10)),
+		"SymInFunction": makeRel("SymInFunction", 2, iv(10), iv(1), iv(20), iv(1)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("LocalFlow", v("fn"), v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, LocalFlowRules(), query, baseRels)
+	if !resultContains(rs, iv(1), iv(10), iv(20)) {
+		t.Errorf("expected LocalFlow(1, 10, 20) for destructuring, got %v", rs.Rows)
+	}
+}
+
+// TestEmptyRelationsNoFlow verifies no flow is produced from empty base relations.
+func TestEmptyRelationsNoFlow(t *testing.T) {
+	baseRels := localFlowBaseRels(nil)
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("LocalFlow", v("fn"), v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, LocalFlowRules(), query, baseRels)
+	if len(rs.Rows) != 0 {
+		t.Errorf("expected 0 LocalFlow rows from empty relations, got %d", len(rs.Rows))
+	}
+}

--- a/extract/rules/merge.go
+++ b/extract/rules/merge.go
@@ -4,6 +4,14 @@ import (
 	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
 )
 
+// AllSystemRules returns all system Datalog rules: call graph + local flow.
+func AllSystemRules() []datalog.Rule {
+	var all []datalog.Rule
+	all = append(all, CallGraphRules()...)
+	all = append(all, LocalFlowRules()...)
+	return all
+}
+
 // MergeSystemRules returns a new Program that contains both the user-written
 // rules (from prog) and the given system rules. The original program is not
 // modified. If prog is nil, a program containing only the system rules is returned.

--- a/extract/schema/relations.go
+++ b/extract/schema/relations.go
@@ -223,6 +223,12 @@ func init() {
 		{Name: "fnId", Type: TypeEntityRef},
 	}})
 
+	// v2 Phase C1: Return value symbol (synthetic per-function return symbol)
+	RegisterRelation(RelationDef{Name: "ReturnSym", Version: 2, Columns: []ColumnDef{
+		{Name: "fnId", Type: TypeEntityRef},
+		{Name: "sym", Type: TypeEntityRef},
+	}})
+
 	// v2 Phase B: call graph derived relations (computed by system Datalog rules)
 	RegisterRelation(RelationDef{Name: "CallTarget", Version: 2, Columns: []ColumnDef{
 		{Name: "call", Type: TypeEntityRef},
@@ -244,6 +250,18 @@ func init() {
 		{Name: "childId", Type: TypeEntityRef},
 		{Name: "name", Type: TypeString},
 		{Name: "fn", Type: TypeEntityRef},
+	}})
+
+	// v2 Phase C1: intra-procedural dataflow (computed by system Datalog rules)
+	RegisterRelation(RelationDef{Name: "LocalFlow", Version: 2, Columns: []ColumnDef{
+		{Name: "fnId", Type: TypeEntityRef},
+		{Name: "srcSym", Type: TypeEntityRef},
+		{Name: "dstSym", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "LocalFlowStar", Version: 2, Columns: []ColumnDef{
+		{Name: "fnId", Type: TypeEntityRef},
+		{Name: "srcSym", Type: TypeEntityRef},
+		{Name: "dstSym", Type: TypeEntityRef},
 	}})
 
 	// Diagnostics

--- a/extract/schema/relations_test.go
+++ b/extract/schema/relations_test.go
@@ -34,8 +34,8 @@ func TestAllRelationsRegistered(t *testing.T) {
 }
 
 func TestRelationCount(t *testing.T) {
-	if len(Registry) != 50 {
-		t.Fatalf("expected 50 relations in registry, got %d", len(Registry))
+	if len(Registry) != 53 {
+		t.Fatalf("expected 53 relations in registry, got %d", len(Registry))
 	}
 }
 

--- a/extract/walker_v2.go
+++ b/extract/walker_v2.go
@@ -298,6 +298,14 @@ func (tw *TypeAwareWalker) pushFunction(node ASTNode, id uint32) {
 		}
 	}
 
+	// Emit ReturnSym: synthetic symbol for the function's return value.
+	{
+		retSymID := ReturnSymID(tw.fw.filePath, node.StartLine(), node.StartCol())
+		tw.fw.emit("ReturnSym", id, retSymID)
+		// Also emit the return symbol into SymInFunction so dataflow rules can scope it.
+		tw.fw.emit("SymInFunction", retSymID, id)
+	}
+
 	// MethodDecl: if inside a class or interface
 	if kind == "MethodDefinition" && len(tw.classOrIfaceStack) > 0 {
 		containerID := tw.classOrIfaceStack[len(tw.classOrIfaceStack)-1]

--- a/testdata/ts/v2/localflow/chain_flow.ts
+++ b/testdata/ts/v2/localflow/chain_flow.ts
@@ -1,0 +1,26 @@
+// Multi-step flow chains
+
+function chainFlow() {
+    let a = 1;
+    let b = a;
+    let c = b;
+    let d = c;
+    let e = d;
+    return e;
+}
+
+function branchFlow() {
+    let source = "data";
+    let left = source;
+    let right = source;
+    let leftResult = left;
+    let rightResult = right;
+    return leftResult;
+}
+
+function fieldFlow() {
+    const obj: any = {};
+    obj.field = "value";
+    const read = obj.field;
+    return read;
+}

--- a/testdata/ts/v2/localflow/nested_functions.ts
+++ b/testdata/ts/v2/localflow/nested_functions.ts
@@ -1,0 +1,30 @@
+// Nested function isolation — inner/outer should not share flow
+
+function outer() {
+    let outerVar = 1;
+
+    function inner() {
+        let innerVar = 2;
+        return innerVar;
+    }
+
+    const result = inner();
+    return result;
+}
+
+const arrowOuter = () => {
+    let x = 10;
+
+    const arrowInner = () => {
+        let y = 20;
+        return y;
+    };
+
+    return arrowInner();
+};
+
+function withDestructuring() {
+    const obj = { a: 1, b: 2 };
+    const { a, b } = obj;
+    return a;
+}

--- a/testdata/ts/v2/localflow/simple_flow.ts
+++ b/testdata/ts/v2/localflow/simple_flow.ts
@@ -1,0 +1,20 @@
+// Simple assignment and return flow
+
+function simpleAssign() {
+    let x = 10;
+    let y = x;
+    return y;
+}
+
+function multiAssign() {
+    let a = 1;
+    let b = a;
+    let c = b;
+    a = c;
+    return a;
+}
+
+function withReturn(input: number): number {
+    const result = input;
+    return result;
+}


### PR DESCRIPTION
## Summary

- Add `LocalFlow(fn, srcSym, dstSym)` Datalog rules for intra-procedural data-flow edges: assignment, VarDecl init, return value, destructuring (field-insensitive), field read, and field write
- Add `LocalFlowStar(fn, srcSym, dstSym)` as the transitive closure of LocalFlow
- Add `ReturnSym(fnId, sym)` schema relation and walker emission for synthetic per-function return symbols
- Add `AllSystemRules()` helper in merge.go combining call graph + local flow rules
- Add `tsq_dataflow.qll` bridge file with LocalFlow/LocalFlowStar QL classes

## Schema changes

- 3 new relations: `ReturnSym`, `LocalFlow`, `LocalFlowStar` (registry count 50 -> 53)
- Bridge manifest updated (53 available classes)
- New embed: `tsq_dataflow.qll`, import path `tsq::dataflow`

## Test plan

- [x] 16 new tests in `localflow_test.go`: assignment, VarDecl, return, chain/transitivity, cross-function isolation, self-assignment, field write, field read, destructuring, empty relations, rule count, validation, stratification, combined stratification, AllSystemRules count
- [x] Full test suite passes (`go test ./... -count=1`)
- [x] Test fixtures in `testdata/ts/v2/localflow/`: simple_flow.ts, chain_flow.ts, nested_functions.ts