### PR TITLE
v2 Phase C2: function-level summary computation rules

### DIFF
--- a/bridge/embed.go
+++ b/bridge/embed.go
@@ -2,7 +2,7 @@ package bridge
 
 import "embed"
 
-//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll
+//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll tsq_summaries.qll tsq_taint.qll
 var bridgeFS embed.FS
 
 // LoadBridge returns all embedded .qll files as a map from filename to contents.
@@ -20,6 +20,8 @@ func LoadBridge() map[string][]byte {
 		"tsq_symbols.qll",
 		"tsq_callgraph.qll",
 		"tsq_dataflow.qll",
+		"tsq_summaries.qll",
+		"tsq_taint.qll",
 	}
 	result := make(map[string][]byte, len(files))
 	for _, name := range files {
@@ -57,6 +59,8 @@ func BridgeImportLoader(bridgeFiles map[string][]byte, parseFn func(src, file st
 		"tsq::symbols":     "tsq_symbols.qll",
 		"tsq::callgraph":   "tsq_callgraph.qll",
 		"tsq::dataflow":    "tsq_dataflow.qll",
+		"tsq::summaries":   "tsq_summaries.qll",
+		"tsq::taint":       "tsq_taint.qll",
 	}
 	return func(path string) (interface{}, bool) {
 		filename, ok := pathToFile[path]

--- a/bridge/embed_test.go
+++ b/bridge/embed_test.go
@@ -19,6 +19,8 @@ func TestLoadBridgeReturnsAllFiles(t *testing.T) {
 		"tsq_symbols.qll",
 		"tsq_callgraph.qll",
 		"tsq_dataflow.qll",
+		"tsq_summaries.qll",
+		"tsq_taint.qll",
 	}
 	files := LoadBridge()
 	if len(files) != len(expected) {
@@ -106,7 +108,6 @@ func TestBridgeImportLoaderUnknownPaths(t *testing.T) {
 	loader := BridgeImportLoader(files, stubParse)
 
 	unknownPaths := []string{
-		"tsq::taint",
 		"javascript",
 		"DataFlow::PathGraph",
 		"",

--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -99,6 +99,16 @@ func v2Manifest() *CapabilityManifest {
 			{Name: "ReturnSym", Relation: "ReturnSym", File: "tsq_functions.qll"},
 			{Name: "LocalFlow", Relation: "LocalFlow", File: "tsq_dataflow.qll"},
 			{Name: "LocalFlowStar", Relation: "LocalFlowStar", File: "tsq_dataflow.qll"},
+			// v2 Phase C2: function-level summaries
+			{Name: "ParamToReturn", Relation: "ParamToReturn", File: "tsq_summaries.qll"},
+			{Name: "ParamToCallArg", Relation: "ParamToCallArg", File: "tsq_summaries.qll"},
+			{Name: "ParamToFieldWrite", Relation: "ParamToFieldWrite", File: "tsq_summaries.qll"},
+			{Name: "ParamToSink", Relation: "ParamToSink", File: "tsq_summaries.qll"},
+			{Name: "SourceToReturn", Relation: "SourceToReturn", File: "tsq_summaries.qll"},
+			{Name: "CallReturnToReturn", Relation: "CallReturnToReturn", File: "tsq_summaries.qll"},
+			// v2 Phase D placeholders: taint analysis base relations
+			{Name: "TaintSink", Relation: "TaintSink", File: "tsq_taint.qll"},
+			{Name: "TaintSource", Relation: "TaintSource", File: "tsq_taint.qll"},
 		},
 		Unavailable: []UnavailableClass{
 			{Name: "DataFlow", Reason: "IPA-dependent; requires inter-procedural analysis engine", VersionTarget: "v3"},

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -9,8 +9,8 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	m := V1Manifest()
 	// v2: 28 original + 5 promoted from unavailable + 12 new v2 = 45
 	// But some relations share bridge classes. Count: 28 + 17 = 45
-	if got := len(m.Available); got != 53 {
-		t.Errorf("expected 53 available classes, got %d", got)
+	if got := len(m.Available); got != 61 {
+		t.Errorf("expected 61 available classes, got %d", got)
 	}
 }
 

--- a/bridge/tsq_summaries.qll
+++ b/bridge/tsq_summaries.qll
@@ -1,0 +1,121 @@
+/**
+ * Bridge library for function-level summary relations (v2 Phase C2).
+ * Maps summary relations derived from system Datalog rules that combine
+ * intra-procedural LocalFlowStar with function boundary facts.
+ */
+
+/**
+ * Holds when parameter at index `paramIdx` of function `fnId` flows
+ * to the function's return value.
+ */
+class ParamToReturn extends @param_to_return {
+    ParamToReturn() { ParamToReturn(this, _) }
+
+    /** Gets the enclosing function. */
+    int getFunction() { result = this }
+
+    /** Gets the parameter index. */
+    int getParamIdx() { ParamToReturn(this, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "ParamToReturn" }
+}
+
+/**
+ * Holds when parameter at index `paramIdx` of function `fnId` flows
+ * to argument at index `argIdx` of a callee identified by `calleeSym`.
+ */
+class ParamToCallArg extends @param_to_call_arg {
+    ParamToCallArg() { ParamToCallArg(this, _, _, _) }
+
+    /** Gets the enclosing function. */
+    int getFunction() { result = this }
+
+    /** Gets the parameter index. */
+    int getParamIdx() { ParamToCallArg(this, result, _, _) }
+
+    /** Gets the callee symbol. */
+    int getCalleeSym() { ParamToCallArg(this, _, result, _) }
+
+    /** Gets the argument index. */
+    int getArgIdx() { ParamToCallArg(this, _, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "ParamToCallArg" }
+}
+
+/**
+ * Holds when parameter at index `paramIdx` of function `fnId` flows
+ * to a field write with the given `fieldName`.
+ */
+class ParamToFieldWrite extends @param_to_field_write {
+    ParamToFieldWrite() { ParamToFieldWrite(this, _, _) }
+
+    /** Gets the enclosing function. */
+    int getFunction() { result = this }
+
+    /** Gets the parameter index. */
+    int getParamIdx() { ParamToFieldWrite(this, result, _) }
+
+    /** Gets the field name. */
+    string getFieldName() { ParamToFieldWrite(this, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "ParamToFieldWrite" }
+}
+
+/**
+ * Holds when parameter at index `paramIdx` of function `fnId` reaches
+ * a taint sink of the given `sinkKind`.
+ * Inactive until Phase D populates TaintSink.
+ */
+class ParamToSink extends @param_to_sink {
+    ParamToSink() { ParamToSink(this, _, _) }
+
+    /** Gets the enclosing function. */
+    int getFunction() { result = this }
+
+    /** Gets the parameter index. */
+    int getParamIdx() { ParamToSink(this, result, _) }
+
+    /** Gets the sink kind. */
+    string getSinkKind() { ParamToSink(this, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "ParamToSink" }
+}
+
+/**
+ * Holds when a taint source of the given `sourceKind` within function `fnId`
+ * flows to the function's return value.
+ * Inactive until Phase D populates TaintSource.
+ */
+class SourceToReturn extends @source_to_return {
+    SourceToReturn() { SourceToReturn(this, _) }
+
+    /** Gets the enclosing function. */
+    int getFunction() { result = this }
+
+    /** Gets the source kind. */
+    string getSourceKind() { SourceToReturn(this, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "SourceToReturn" }
+}
+
+/**
+ * Holds when the return value of a call within function `fnId` flows
+ * to the function's own return value.
+ */
+class CallReturnToReturn extends @call_return_to_return {
+    CallReturnToReturn() { CallReturnToReturn(this, _) }
+
+    /** Gets the enclosing function. */
+    int getFunction() { result = this }
+
+    /** Gets the call node. */
+    int getCall() { CallReturnToReturn(this, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "CallReturnToReturn" }
+}

--- a/bridge/tsq_taint.qll
+++ b/bridge/tsq_taint.qll
@@ -1,0 +1,39 @@
+/**
+ * Bridge library for taint analysis base relations (v2 Phase D placeholder).
+ * These relations are empty until Phase D populates them with taint source
+ * and sink definitions.
+ */
+
+/**
+ * A taint sink expression. Holds when `sinkExpr` is a sink of the given `sinkKind`.
+ * Empty until Phase D.
+ */
+class TaintSink extends @taint_sink {
+    TaintSink() { TaintSink(this, _) }
+
+    /** Gets the sink expression. */
+    int getExpr() { result = this }
+
+    /** Gets the sink kind. */
+    string getSinkKind() { TaintSink(this, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "TaintSink" }
+}
+
+/**
+ * A taint source expression. Holds when `srcExpr` is a source of the given `sourceKind`.
+ * Empty until Phase D.
+ */
+class TaintSource extends @taint_source {
+    TaintSource() { TaintSource(this, _) }
+
+    /** Gets the source expression. */
+    int getExpr() { result = this }
+
+    /** Gets the source kind. */
+    string getSourceKind() { TaintSource(this, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "TaintSource" }
+}

--- a/extract/rules/localflow_test.go
+++ b/extract/rules/localflow_test.go
@@ -277,8 +277,10 @@ func TestAllSystemRulesCount(t *testing.T) {
 	all := AllSystemRules()
 	cg := CallGraphRules()
 	lf := LocalFlowRules()
-	if len(all) != len(cg)+len(lf) {
-		t.Errorf("expected %d rules, got %d", len(cg)+len(lf), len(all))
+	sm := SummaryRules()
+	expected := len(cg) + len(lf) + len(sm)
+	if len(all) != expected {
+		t.Errorf("expected %d rules, got %d", expected, len(all))
 	}
 }
 

--- a/extract/rules/merge.go
+++ b/extract/rules/merge.go
@@ -4,11 +4,12 @@ import (
 	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
 )
 
-// AllSystemRules returns all system Datalog rules: call graph + local flow.
+// AllSystemRules returns all system Datalog rules: call graph + local flow + summaries.
 func AllSystemRules() []datalog.Rule {
 	var all []datalog.Rule
 	all = append(all, CallGraphRules()...)
 	all = append(all, LocalFlowRules()...)
+	all = append(all, SummaryRules()...)
 	return all
 }
 

--- a/extract/rules/summaries.go
+++ b/extract/rules/summaries.go
@@ -1,0 +1,104 @@
+package rules
+
+import (
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// SummaryRules returns the system Datalog rules for function-level summaries.
+// These compute inter-procedural flow summaries by combining intra-procedural
+// LocalFlowStar with function boundary facts (parameters, return values, calls).
+func SummaryRules() []datalog.Rule {
+	return []datalog.Rule{
+		// 1. ParamToReturn(fn, idx) — parameter flows to return value.
+		// ParamToReturn(fn, idx) :-
+		//   Parameter(fn, idx, _, _, paramSym, _),
+		//   ReturnSym(fn, retSym),
+		//   LocalFlowStar(fn, paramSym, retSym).
+		rule("ParamToReturn",
+			[]datalog.Term{v("fn"), v("idx")},
+			pos("Parameter", v("fn"), v("idx"), w(), w(), v("paramSym"), w()),
+			pos("ReturnSym", v("fn"), v("retSym")),
+			pos("LocalFlowStar", v("fn"), v("paramSym"), v("retSym")),
+		),
+
+		// 2. ParamToCallArg(fn, paramIdx, calleeSym, argIdx) — parameter flows to callee argument.
+		// ParamToCallArg(fn, paramIdx, calleeSym, argIdx) :-
+		//   Parameter(fn, paramIdx, _, _, paramSym, _),
+		//   FunctionContains(fn, call),
+		//   CallArg(call, argIdx, argExpr),
+		//   ExprMayRef(argExpr, argSym),
+		//   LocalFlowStar(fn, paramSym, argSym),
+		//   CallCalleeSym(call, calleeSym).
+		rule("ParamToCallArg",
+			[]datalog.Term{v("fn"), v("paramIdx"), v("calleeSym"), v("argIdx")},
+			pos("Parameter", v("fn"), v("paramIdx"), w(), w(), v("paramSym"), w()),
+			pos("FunctionContains", v("fn"), v("call")),
+			pos("CallArg", v("call"), v("argIdx"), v("argExpr")),
+			pos("ExprMayRef", v("argExpr"), v("argSym")),
+			pos("LocalFlowStar", v("fn"), v("paramSym"), v("argSym")),
+			pos("CallCalleeSym", v("call"), v("calleeSym")),
+		),
+
+		// 3. ParamToFieldWrite(fn, paramIdx, fieldName) — parameter flows to field write.
+		// ParamToFieldWrite(fn, paramIdx, fieldName) :-
+		//   Parameter(fn, paramIdx, _, _, paramSym, _),
+		//   FunctionContains(fn, assignNode),
+		//   FieldWrite(assignNode, _, fieldName, rhsExpr),
+		//   ExprMayRef(rhsExpr, rhsSym),
+		//   LocalFlowStar(fn, paramSym, rhsSym).
+		rule("ParamToFieldWrite",
+			[]datalog.Term{v("fn"), v("paramIdx"), v("fieldName")},
+			pos("Parameter", v("fn"), v("paramIdx"), w(), w(), v("paramSym"), w()),
+			pos("FunctionContains", v("fn"), v("assignNode")),
+			pos("FieldWrite", v("assignNode"), w(), v("fieldName"), v("rhsExpr")),
+			pos("ExprMayRef", v("rhsExpr"), v("rhsSym")),
+			pos("LocalFlowStar", v("fn"), v("paramSym"), v("rhsSym")),
+		),
+
+		// 4. ParamToSink(fn, paramIdx, sinkKind) — parameter reaches a taint sink.
+		// Inactive until Phase D populates TaintSink.
+		// ParamToSink(fn, paramIdx, sinkKind) :-
+		//   Parameter(fn, paramIdx, _, _, paramSym, _),
+		//   TaintSink(sinkExpr, sinkKind),
+		//   ExprMayRef(sinkExpr, sinkSym),
+		//   LocalFlowStar(fn, paramSym, sinkSym).
+		rule("ParamToSink",
+			[]datalog.Term{v("fn"), v("paramIdx"), v("sinkKind")},
+			pos("Parameter", v("fn"), v("paramIdx"), w(), w(), v("paramSym"), w()),
+			pos("TaintSink", v("sinkExpr"), v("sinkKind")),
+			pos("ExprMayRef", v("sinkExpr"), v("sinkSym")),
+			pos("LocalFlowStar", v("fn"), v("paramSym"), v("sinkSym")),
+		),
+
+		// 5. SourceToReturn(fn, sourceKind) — taint source flows to return.
+		// Inactive until Phase D populates TaintSource.
+		// SourceToReturn(fn, sourceKind) :-
+		//   TaintSource(srcExpr, sourceKind),
+		//   FunctionContains(fn, srcExpr),
+		//   ExprMayRef(srcExpr, srcSym),
+		//   ReturnSym(fn, retSym),
+		//   LocalFlowStar(fn, srcSym, retSym).
+		rule("SourceToReturn",
+			[]datalog.Term{v("fn"), v("sourceKind")},
+			pos("TaintSource", v("srcExpr"), v("sourceKind")),
+			pos("FunctionContains", v("fn"), v("srcExpr")),
+			pos("ExprMayRef", v("srcExpr"), v("srcSym")),
+			pos("ReturnSym", v("fn"), v("retSym")),
+			pos("LocalFlowStar", v("fn"), v("srcSym"), v("retSym")),
+		),
+
+		// 6. CallReturnToReturn(fn, call) — callee's return value flows to this function's return.
+		// CallReturnToReturn(fn, call) :-
+		//   FunctionContains(fn, call),
+		//   CallResultSym(call, callRetSym),
+		//   ReturnSym(fn, retSym),
+		//   LocalFlowStar(fn, callRetSym, retSym).
+		rule("CallReturnToReturn",
+			[]datalog.Term{v("fn"), v("call")},
+			pos("FunctionContains", v("fn"), v("call")),
+			pos("CallResultSym", v("call"), v("callRetSym")),
+			pos("ReturnSym", v("fn"), v("retSym")),
+			pos("LocalFlowStar", v("fn"), v("callRetSym"), v("retSym")),
+		),
+	}
+}

--- a/extract/rules/summaries_test.go
+++ b/extract/rules/summaries_test.go
@@ -1,0 +1,360 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// summaryBaseRels returns base relations needed for summary rules evaluation,
+// including all relations needed by LocalFlow rules (which summaries depend on).
+func summaryBaseRels(overrides map[string]*eval.Relation) map[string]*eval.Relation {
+	base := map[string]*eval.Relation{
+		// LocalFlow dependencies
+		"Assign":           eval.NewRelation("Assign", 3),
+		"ExprMayRef":       eval.NewRelation("ExprMayRef", 2),
+		"SymInFunction":    eval.NewRelation("SymInFunction", 2),
+		"VarDecl":          eval.NewRelation("VarDecl", 4),
+		"ReturnStmt":       eval.NewRelation("ReturnStmt", 3),
+		"ReturnSym":        eval.NewRelation("ReturnSym", 2),
+		"DestructureField": eval.NewRelation("DestructureField", 5),
+		"FieldRead":        eval.NewRelation("FieldRead", 3),
+		"FieldWrite":       eval.NewRelation("FieldWrite", 4),
+		// Summary-specific dependencies
+		"Parameter":        eval.NewRelation("Parameter", 6),
+		"FunctionContains": eval.NewRelation("FunctionContains", 2),
+		"CallArg":          eval.NewRelation("CallArg", 3),
+		"CallCalleeSym":    eval.NewRelation("CallCalleeSym", 2),
+		"CallResultSym":    eval.NewRelation("CallResultSym", 2),
+		"TaintSink":        eval.NewRelation("TaintSink", 2),
+		"TaintSource":      eval.NewRelation("TaintSource", 2),
+	}
+	for k, v := range overrides {
+		base[k] = v
+	}
+	return base
+}
+
+// summaryAndFlowRules returns LocalFlow + Summary rules combined.
+func summaryAndFlowRules() []datalog.Rule {
+	var all []datalog.Rule
+	all = append(all, LocalFlowRules()...)
+	all = append(all, SummaryRules()...)
+	return all
+}
+
+// TestParamToReturn_Identity tests identity function: id(x) { return x; } → ParamToReturn(id, 0).
+func TestParamToReturn_Identity(t *testing.T) {
+	// fn=1, paramSym=10, retSym=99
+	// Parameter(fn=1, idx=0, name="x", paramNode=50, sym=10, type="")
+	// ReturnStmt(fn=1, stmtNode=60, retExpr=200)
+	// ExprMayRef(retExpr=200, sym=10) — return expression references param symbol
+	// ReturnSym(fn=1, sym=99)
+	// SymInFunction(10, 1), SymInFunction(99, 1)
+	baseRels := summaryBaseRels(map[string]*eval.Relation{
+		"Parameter":     makeRel("Parameter", 6, iv(1), iv(0), sv("x"), iv(50), iv(10), sv("")),
+		"ReturnStmt":    makeRel("ReturnStmt", 3, iv(1), iv(60), iv(200)),
+		"ExprMayRef":    makeRel("ExprMayRef", 2, iv(200), iv(10)),
+		"ReturnSym":     makeRel("ReturnSym", 2, iv(1), iv(99)),
+		"SymInFunction": makeRel("SymInFunction", 2, iv(10), iv(1), iv(99), iv(1)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("idx")},
+		Body:   []datalog.Literal{pos("ParamToReturn", v("fn"), v("idx"))},
+	}
+
+	rs := planAndEval(t, summaryAndFlowRules(), query, baseRels)
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 ParamToReturn row, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(1), iv(0)) {
+		t.Errorf("expected ParamToReturn(1, 0), got %v", rs.Rows)
+	}
+}
+
+// TestParamToReturn_NoFlow tests f(x) { return 42; } → no ParamToReturn.
+func TestParamToReturn_NoFlow(t *testing.T) {
+	// fn=1, paramSym=10, retSym=99, literalSym=88
+	// The return expression references a literal symbol, not the parameter.
+	baseRels := summaryBaseRels(map[string]*eval.Relation{
+		"Parameter":  makeRel("Parameter", 6, iv(1), iv(0), sv("x"), iv(50), iv(10), sv("")),
+		"ReturnStmt": makeRel("ReturnStmt", 3, iv(1), iv(60), iv(200)),
+		"ExprMayRef": makeRel("ExprMayRef", 2, iv(200), iv(88)), // references literal, not param
+		"ReturnSym":  makeRel("ReturnSym", 2, iv(1), iv(99)),
+		"SymInFunction": makeRel("SymInFunction", 2,
+			iv(10), iv(1),
+			iv(88), iv(1),
+			iv(99), iv(1),
+		),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("idx")},
+		Body:   []datalog.Literal{pos("ParamToReturn", v("fn"), v("idx"))},
+	}
+
+	rs := planAndEval(t, summaryAndFlowRules(), query, baseRels)
+	if len(rs.Rows) != 0 {
+		t.Errorf("expected 0 ParamToReturn rows for non-identity, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestParamToReturn_MultiParam tests f(a, b) { return a; } → only ParamToReturn(f, 0).
+func TestParamToReturn_MultiParam(t *testing.T) {
+	// fn=1, paramSym_a=10, paramSym_b=20, retSym=99
+	baseRels := summaryBaseRels(map[string]*eval.Relation{
+		"Parameter": makeRel("Parameter", 6,
+			iv(1), iv(0), sv("a"), iv(50), iv(10), sv(""),
+			iv(1), iv(1), sv("b"), iv(51), iv(20), sv(""),
+		),
+		"ReturnStmt": makeRel("ReturnStmt", 3, iv(1), iv(60), iv(200)),
+		"ExprMayRef": makeRel("ExprMayRef", 2, iv(200), iv(10)), // only 'a' flows to return
+		"ReturnSym":  makeRel("ReturnSym", 2, iv(1), iv(99)),
+		"SymInFunction": makeRel("SymInFunction", 2,
+			iv(10), iv(1),
+			iv(20), iv(1),
+			iv(99), iv(1),
+		),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("idx")},
+		Body:   []datalog.Literal{pos("ParamToReturn", v("fn"), v("idx"))},
+	}
+
+	rs := planAndEval(t, summaryAndFlowRules(), query, baseRels)
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 ParamToReturn row, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(1), iv(0)) {
+		t.Errorf("expected ParamToReturn(1, 0), got %v", rs.Rows)
+	}
+}
+
+// TestParamToCallArg tests f(x) { let y = x; g(y); } → ParamToCallArg(f, 0, g_sym, 0).
+func TestParamToCallArg(t *testing.T) {
+	// fn=1, paramSym=10, ySym=15, call=300, argExpr=400, calleeSym=500
+	// VarDecl y = x creates LocalFlow(fn, paramSym, ySym)
+	// g(y) passes ySym to callee
+	baseRels := summaryBaseRels(map[string]*eval.Relation{
+		"Parameter":        makeRel("Parameter", 6, iv(1), iv(0), sv("x"), iv(50), iv(10), sv("")),
+		"FunctionContains": makeRel("FunctionContains", 2, iv(1), iv(300)),
+		"CallArg":          makeRel("CallArg", 3, iv(300), iv(0), iv(400)),
+		"ExprMayRef": makeRel("ExprMayRef", 2,
+			iv(400), iv(15), // arg references ySym
+			iv(600), iv(10), // initExpr references paramSym
+		),
+		"CallCalleeSym": makeRel("CallCalleeSym", 2, iv(300), iv(500)),
+		"VarDecl":       makeRel("VarDecl", 4, iv(700), iv(15), iv(600), iv(0)), // let y = x
+		"SymInFunction": makeRel("SymInFunction", 2,
+			iv(10), iv(1),
+			iv(15), iv(1),
+		),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("paramIdx"), v("calleeSym"), v("argIdx")},
+		Body:   []datalog.Literal{pos("ParamToCallArg", v("fn"), v("paramIdx"), v("calleeSym"), v("argIdx"))},
+	}
+
+	rs := planAndEval(t, summaryAndFlowRules(), query, baseRels)
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 ParamToCallArg row, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(1), iv(0), iv(500), iv(0)) {
+		t.Errorf("expected ParamToCallArg(1, 0, 500, 0), got %v", rs.Rows)
+	}
+}
+
+// TestParamToFieldWrite tests f(obj, val) { let v = val; obj.x = v; } → ParamToFieldWrite(f, 1, "x").
+func TestParamToFieldWrite(t *testing.T) {
+	// fn=1, paramSym_obj=10, paramSym_val=20, vSym=25, assignNode=300, rhsExpr=400
+	// VarDecl v = val creates LocalFlow(fn, paramSym_val, vSym)
+	// FieldWrite obj.x = v references vSym
+	baseRels := summaryBaseRels(map[string]*eval.Relation{
+		"Parameter": makeRel("Parameter", 6,
+			iv(1), iv(0), sv("obj"), iv(50), iv(10), sv(""),
+			iv(1), iv(1), sv("val"), iv(51), iv(20), sv(""),
+		),
+		"FunctionContains": makeRel("FunctionContains", 2, iv(1), iv(300)),
+		"FieldWrite":       makeRel("FieldWrite", 4, iv(300), iv(10), sv("x"), iv(400)),
+		"ExprMayRef": makeRel("ExprMayRef", 2,
+			iv(400), iv(25), // rhs references vSym
+			iv(600), iv(20), // initExpr references val param
+		),
+		"VarDecl": makeRel("VarDecl", 4, iv(700), iv(25), iv(600), iv(0)), // let v = val
+		"SymInFunction": makeRel("SymInFunction", 2,
+			iv(10), iv(1),
+			iv(20), iv(1),
+			iv(25), iv(1),
+		),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("paramIdx"), v("fieldName")},
+		Body:   []datalog.Literal{pos("ParamToFieldWrite", v("fn"), v("paramIdx"), v("fieldName"))},
+	}
+
+	rs := planAndEval(t, summaryAndFlowRules(), query, baseRels)
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 ParamToFieldWrite row, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(1), iv(1), sv("x")) {
+		t.Errorf("expected ParamToFieldWrite(1, 1, 'x'), got %v", rs.Rows)
+	}
+}
+
+// TestCallReturnToReturn tests f(x) { return g(x); } → CallReturnToReturn(f, call).
+func TestCallReturnToReturn(t *testing.T) {
+	// fn=1, call=300, callRetSym=40, retSym=99
+	// g(x) is called, result sym is callRetSym=40
+	// return stmt references callRetSym, which flows to retSym
+	baseRels := summaryBaseRels(map[string]*eval.Relation{
+		"FunctionContains": makeRel("FunctionContains", 2, iv(1), iv(300)),
+		"CallResultSym":    makeRel("CallResultSym", 2, iv(300), iv(40)),
+		"ReturnSym":        makeRel("ReturnSym", 2, iv(1), iv(99)),
+		"ReturnStmt":       makeRel("ReturnStmt", 3, iv(1), iv(60), iv(200)),
+		"ExprMayRef":       makeRel("ExprMayRef", 2, iv(200), iv(40)), // return expr references callRetSym
+		"SymInFunction": makeRel("SymInFunction", 2,
+			iv(40), iv(1),
+			iv(99), iv(1),
+		),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("call")},
+		Body:   []datalog.Literal{pos("CallReturnToReturn", v("fn"), v("call"))},
+	}
+
+	rs := planAndEval(t, summaryAndFlowRules(), query, baseRels)
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 CallReturnToReturn row, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(1), iv(300)) {
+		t.Errorf("expected CallReturnToReturn(1, 300), got %v", rs.Rows)
+	}
+}
+
+// TestTaintSinkEmpty tests that ParamToSink produces nothing when TaintSink is empty.
+func TestTaintSinkEmpty(t *testing.T) {
+	baseRels := summaryBaseRels(map[string]*eval.Relation{
+		"Parameter":     makeRel("Parameter", 6, iv(1), iv(0), sv("x"), iv(50), iv(10), sv("")),
+		"SymInFunction": makeRel("SymInFunction", 2, iv(10), iv(1)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("paramIdx"), v("sinkKind")},
+		Body:   []datalog.Literal{pos("ParamToSink", v("fn"), v("paramIdx"), v("sinkKind"))},
+	}
+
+	rs := planAndEval(t, summaryAndFlowRules(), query, baseRels)
+	if len(rs.Rows) != 0 {
+		t.Errorf("expected 0 ParamToSink rows with empty TaintSink, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestTaintSourceEmpty tests that SourceToReturn produces nothing when TaintSource is empty.
+func TestTaintSourceEmpty(t *testing.T) {
+	baseRels := summaryBaseRels(map[string]*eval.Relation{
+		"ReturnSym":     makeRel("ReturnSym", 2, iv(1), iv(99)),
+		"SymInFunction": makeRel("SymInFunction", 2, iv(99), iv(1)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("sourceKind")},
+		Body:   []datalog.Literal{pos("SourceToReturn", v("fn"), v("sourceKind"))},
+	}
+
+	rs := planAndEval(t, summaryAndFlowRules(), query, baseRels)
+	if len(rs.Rows) != 0 {
+		t.Errorf("expected 0 SourceToReturn rows with empty TaintSource, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestSummaryRulesValidate verifies all summary rules pass the planner's validation.
+func TestSummaryRulesValidate(t *testing.T) {
+	for i, r := range SummaryRules() {
+		errs := plan.ValidateRule(r)
+		if len(errs) > 0 {
+			t.Errorf("rule %d (%s) validation errors: %v", i, r.Head.Predicate, errs)
+		}
+	}
+}
+
+// TestSummaryRulesStratify verifies summary rules can be stratified with all other system rules.
+func TestSummaryRulesStratify(t *testing.T) {
+	prog := &datalog.Program{Rules: AllSystemRules()}
+	_, errs := plan.Plan(prog, nil)
+	if len(errs) > 0 {
+		t.Fatalf("all system rules (including summaries) failed to plan: %v", errs)
+	}
+}
+
+// TestSummaryRulesCount verifies we produce exactly 6 summary rules.
+func TestSummaryRulesCount(t *testing.T) {
+	rules := SummaryRules()
+	if len(rules) != 6 {
+		t.Errorf("expected 6 summary rules, got %d", len(rules))
+	}
+}
+
+// TestAllSystemRulesCountWithSummaries verifies AllSystemRules returns combined count.
+func TestAllSystemRulesCountWithSummaries(t *testing.T) {
+	all := AllSystemRules()
+	cg := CallGraphRules()
+	lf := LocalFlowRules()
+	sm := SummaryRules()
+	expected := len(cg) + len(lf) + len(sm)
+	if len(all) != expected {
+		t.Errorf("expected %d rules, got %d", expected, len(all))
+	}
+}
+
+// TestEmptyRelationsNoSummaries verifies no summaries are produced from empty base relations.
+func TestEmptyRelationsNoSummaries(t *testing.T) {
+	baseRels := summaryBaseRels(nil)
+
+	for _, tc := range []struct {
+		name  string
+		query *datalog.Query
+	}{
+		{
+			"ParamToReturn",
+			&datalog.Query{
+				Select: []datalog.Term{v("fn"), v("idx")},
+				Body:   []datalog.Literal{pos("ParamToReturn", v("fn"), v("idx"))},
+			},
+		},
+		{
+			"ParamToCallArg",
+			&datalog.Query{
+				Select: []datalog.Term{v("fn"), v("pi"), v("cs"), v("ai")},
+				Body:   []datalog.Literal{pos("ParamToCallArg", v("fn"), v("pi"), v("cs"), v("ai"))},
+			},
+		},
+		{
+			"ParamToFieldWrite",
+			&datalog.Query{
+				Select: []datalog.Term{v("fn"), v("pi"), v("f")},
+				Body:   []datalog.Literal{pos("ParamToFieldWrite", v("fn"), v("pi"), v("f"))},
+			},
+		},
+		{
+			"CallReturnToReturn",
+			&datalog.Query{
+				Select: []datalog.Term{v("fn"), v("call")},
+				Body:   []datalog.Literal{pos("CallReturnToReturn", v("fn"), v("call"))},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rs := planAndEval(t, summaryAndFlowRules(), tc.query, baseRels)
+			if len(rs.Rows) != 0 {
+				t.Errorf("expected 0 %s rows from empty relations, got %d", tc.name, len(rs.Rows))
+			}
+		})
+	}
+}

--- a/extract/schema/relations.go
+++ b/extract/schema/relations.go
@@ -264,6 +264,46 @@ func init() {
 		{Name: "dstSym", Type: TypeEntityRef},
 	}})
 
+	// v2 Phase C2: function-level summaries (computed by system Datalog rules)
+	RegisterRelation(RelationDef{Name: "ParamToReturn", Version: 2, Columns: []ColumnDef{
+		{Name: "fnId", Type: TypeEntityRef},
+		{Name: "paramIdx", Type: TypeInt32},
+	}})
+	RegisterRelation(RelationDef{Name: "ParamToCallArg", Version: 2, Columns: []ColumnDef{
+		{Name: "fnId", Type: TypeEntityRef},
+		{Name: "paramIdx", Type: TypeInt32},
+		{Name: "calleeSym", Type: TypeEntityRef},
+		{Name: "argIdx", Type: TypeInt32},
+	}})
+	RegisterRelation(RelationDef{Name: "ParamToFieldWrite", Version: 2, Columns: []ColumnDef{
+		{Name: "fnId", Type: TypeEntityRef},
+		{Name: "paramIdx", Type: TypeInt32},
+		{Name: "fieldName", Type: TypeString},
+	}})
+	RegisterRelation(RelationDef{Name: "ParamToSink", Version: 2, Columns: []ColumnDef{
+		{Name: "fnId", Type: TypeEntityRef},
+		{Name: "paramIdx", Type: TypeInt32},
+		{Name: "sinkKind", Type: TypeString},
+	}})
+	RegisterRelation(RelationDef{Name: "SourceToReturn", Version: 2, Columns: []ColumnDef{
+		{Name: "fnId", Type: TypeEntityRef},
+		{Name: "sourceKind", Type: TypeString},
+	}})
+	RegisterRelation(RelationDef{Name: "CallReturnToReturn", Version: 2, Columns: []ColumnDef{
+		{Name: "fnId", Type: TypeEntityRef},
+		{Name: "callId", Type: TypeEntityRef},
+	}})
+
+	// v2 Phase D placeholders: taint analysis base relations (empty until Phase D)
+	RegisterRelation(RelationDef{Name: "TaintSink", Version: 2, Columns: []ColumnDef{
+		{Name: "sinkExpr", Type: TypeEntityRef},
+		{Name: "sinkKind", Type: TypeString},
+	}})
+	RegisterRelation(RelationDef{Name: "TaintSource", Version: 2, Columns: []ColumnDef{
+		{Name: "srcExpr", Type: TypeEntityRef},
+		{Name: "sourceKind", Type: TypeString},
+	}})
+
 	// Diagnostics
 	RegisterRelation(RelationDef{Name: "ExtractError", Version: 1, Columns: []ColumnDef{
 		{Name: "file", Type: TypeEntityRef},

--- a/extract/schema/relations_test.go
+++ b/extract/schema/relations_test.go
@@ -34,8 +34,8 @@ func TestAllRelationsRegistered(t *testing.T) {
 }
 
 func TestRelationCount(t *testing.T) {
-	if len(Registry) != 53 {
-		t.Fatalf("expected 53 relations in registry, got %d", len(Registry))
+	if len(Registry) != 61 {
+		t.Fatalf("expected 61 relations in registry, got %d", len(Registry))
 	}
 }
 

--- a/ql/eval/seminaive.go
+++ b/ql/eval/seminaive.go
@@ -3,9 +3,15 @@ package eval
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/Gjdoalfnrxu/tsq/ql/plan"
 )
+
+// DefaultMaxIterations is the default maximum number of fixpoint iterations
+// per stratum. If exceeded, a warning is logged but evaluation continues
+// with the results computed so far.
+const DefaultMaxIterations = 100
 
 // ResultSet holds the query results.
 type ResultSet struct {
@@ -13,8 +19,27 @@ type ResultSet struct {
 	Rows    [][]Value
 }
 
+// EvalOption configures the evaluator.
+type EvalOption func(*evalConfig)
+
+type evalConfig struct {
+	maxIterations int
+}
+
+// WithMaxIterations sets the maximum number of fixpoint iterations per stratum.
+// If the limit is reached, a warning is logged and evaluation proceeds with
+// the results computed so far. A value of 0 means no limit.
+func WithMaxIterations(n int) EvalOption {
+	return func(c *evalConfig) { c.maxIterations = n }
+}
+
 // Evaluate executes an ExecutionPlan over base facts and returns results.
-func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[string]*Relation) (*ResultSet, error) {
+func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[string]*Relation, opts ...EvalOption) (*ResultSet, error) {
+	cfg := evalConfig{maxIterations: DefaultMaxIterations}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	// allRels starts with base facts; derived relations are added as we go.
 	allRels := make(map[string]*Relation, len(baseRels))
 	for k, v := range baseRels {
@@ -54,10 +79,18 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 		}
 
 		// Semi-naive fixpoint.
+		iteration := 0
 		for {
 			if err := ctx.Err(); err != nil {
 				return nil, fmt.Errorf("cancelled in fixpoint stratum %d: %w", si, err)
 			}
+
+			// Check iteration limit.
+			if cfg.maxIterations > 0 && iteration >= cfg.maxIterations {
+				log.Printf("WARNING: stratum %d reached max iteration limit (%d); results may be incomplete", si, cfg.maxIterations)
+				break
+			}
+			iteration++
 
 			// Check if any delta is non-empty.
 			anyDelta := false

--- a/ql/eval/seminaive_test.go
+++ b/ql/eval/seminaive_test.go
@@ -333,6 +333,79 @@ func TestSeminaiveSelfRecursivePath(t *testing.T) {
 	}
 }
 
+// TestSeminaiveMaxIterations verifies that the iteration limit prevents infinite loops
+// and emits a warning rather than silently truncating.
+func TestSeminaiveMaxIterations(t *testing.T) {
+	// Create a cycle: Edge(1,2), Edge(2,1) with self-recursive Path rule.
+	// This will produce Path(1,2), Path(2,1), Path(1,1), Path(2,2) — finite,
+	// but to test the limit, set maxIterations=1 so it terminates early.
+	edge := makeRelation("Edge", 2,
+		IntVal{1}, IntVal{2},
+		IntVal{2}, IntVal{3},
+		IntVal{3}, IntVal{4},
+		IntVal{4}, IntVal{5},
+		IntVal{5}, IntVal{6},
+	)
+	baseRels := map[string]*Relation{"Edge": edge}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{
+			{
+				Rules: []plan.PlannedRule{
+					// Path(x,y) :- Edge(x,y).
+					{
+						Head: datalog.Atom{Predicate: "Path", Args: []datalog.Term{v("x"), v("y")}},
+						JoinOrder: []plan.JoinStep{
+							positiveStep("Edge", v("x"), v("y")),
+						},
+					},
+					// Path(x,z) :- Edge(x,y), Path(y,z).
+					{
+						Head: datalog.Atom{Predicate: "Path", Args: []datalog.Term{v("x"), v("z")}},
+						JoinOrder: []plan.JoinStep{
+							positiveStep("Edge", v("x"), v("y")),
+							positiveStep("Path", v("y"), v("z")),
+						},
+					},
+				},
+			},
+		},
+		Query: &plan.PlannedQuery{
+			Select: []datalog.Term{v("a"), v("b")},
+			JoinOrder: []plan.JoinStep{
+				positiveStep("Path", v("a"), v("b")),
+			},
+		},
+	}
+
+	// With maxIterations=1, the fixpoint should stop early (not compute all transitive pairs).
+	rs, err := Evaluate(context.Background(), ep, baseRels, WithMaxIterations(1))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	// With limit=1, we get bootstrap results + 1 iteration of delta.
+	// Should have fewer than the full 15 pairs for a 6-node chain.
+	if len(rs.Rows) >= 15 {
+		t.Errorf("expected fewer than 15 rows with maxIterations=1, got %d", len(rs.Rows))
+	}
+
+	// With maxIterations=0 (unlimited), should get all 15 pairs.
+	rsUnlimited, err := Evaluate(context.Background(), ep, baseRels, WithMaxIterations(0))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(rsUnlimited.Rows) != 15 {
+		t.Errorf("expected 15 rows with unlimited iterations, got %d", len(rsUnlimited.Rows))
+	}
+}
+
+// TestSeminaiveDefaultMaxIterations verifies the default limit is 100.
+func TestSeminaiveDefaultMaxIterations(t *testing.T) {
+	if DefaultMaxIterations != 100 {
+		t.Errorf("expected DefaultMaxIterations=100, got %d", DefaultMaxIterations)
+	}
+}
+
 // TestSeminaiveCancellation verifies context cancellation is respected.
 func TestSeminaiveCancellation(t *testing.T) {
 	// Build a trivial plan that would otherwise succeed.


### PR DESCRIPTION
## Summary

- Add 6 Datalog rules computing inter-procedural flow summaries (ParamToReturn, ParamToCallArg, ParamToFieldWrite, ParamToSink, SourceToReturn, CallReturnToReturn) that combine intra-procedural LocalFlowStar with function boundary facts
- Add TaintSink/TaintSource base relations as Phase D placeholders (empty until taint sources/sinks are populated)
- Add configurable max iteration limit (default 100) to semi-naive fixpoint evaluator with log.Printf warning on limit hit, preventing infinite loops on pathological inputs
- Add bridge .qll files (tsq_summaries.qll, tsq_taint.qll) and update schema, manifest, and embed to include all 8 new relations

## Test plan

- [x] Identity function produces ParamToReturn(fn, 0)
- [x] Non-identity function (return 42) produces no ParamToReturn
- [x] Multi-param function only produces ParamToReturn for the flowing param
- [x] Parameter pass-through produces ParamToCallArg
- [x] Field write produces ParamToFieldWrite
- [x] Call return flow produces CallReturnToReturn
- [x] Empty TaintSink/TaintSource produce no ParamToSink/SourceToReturn
- [x] All 6 rules pass ValidateRule
- [x] All system rules (callgraph + localflow + summaries) stratify together
- [x] Empty relations produce no summary facts
- [x] Iteration limit test: maxIterations=1 truncates early; maxIterations=0 computes full closure
- [x] Full test suite passes: `go test ./... -count=1`