### PR TITLE
v2 Phase C3: inter-procedural flow composition at call sites

### DIFF
--- a/bridge/embed.go
+++ b/bridge/embed.go
@@ -2,7 +2,7 @@ package bridge
 
 import "embed"
 
-//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll tsq_summaries.qll tsq_taint.qll
+//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll tsq_summaries.qll tsq_composition.qll tsq_taint.qll
 var bridgeFS embed.FS
 
 // LoadBridge returns all embedded .qll files as a map from filename to contents.
@@ -21,6 +21,7 @@ func LoadBridge() map[string][]byte {
 		"tsq_callgraph.qll",
 		"tsq_dataflow.qll",
 		"tsq_summaries.qll",
+		"tsq_composition.qll",
 		"tsq_taint.qll",
 	}
 	result := make(map[string][]byte, len(files))
@@ -60,6 +61,7 @@ func BridgeImportLoader(bridgeFiles map[string][]byte, parseFn func(src, file st
 		"tsq::callgraph":   "tsq_callgraph.qll",
 		"tsq::dataflow":    "tsq_dataflow.qll",
 		"tsq::summaries":   "tsq_summaries.qll",
+		"tsq::composition": "tsq_composition.qll",
 		"tsq::taint":       "tsq_taint.qll",
 	}
 	return func(path string) (interface{}, bool) {

--- a/bridge/embed_test.go
+++ b/bridge/embed_test.go
@@ -20,6 +20,7 @@ func TestLoadBridgeReturnsAllFiles(t *testing.T) {
 		"tsq_callgraph.qll",
 		"tsq_dataflow.qll",
 		"tsq_summaries.qll",
+		"tsq_composition.qll",
 		"tsq_taint.qll",
 	}
 	files := LoadBridge()

--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -106,6 +106,9 @@ func v2Manifest() *CapabilityManifest {
 			{Name: "ParamToSink", Relation: "ParamToSink", File: "tsq_summaries.qll"},
 			{Name: "SourceToReturn", Relation: "SourceToReturn", File: "tsq_summaries.qll"},
 			{Name: "CallReturnToReturn", Relation: "CallReturnToReturn", File: "tsq_summaries.qll"},
+			// v2 Phase C3: inter-procedural composition
+			{Name: "InterFlow", Relation: "InterFlow", File: "tsq_composition.qll"},
+			{Name: "FlowStar", Relation: "FlowStar", File: "tsq_composition.qll"},
 			// v2 Phase D placeholders: taint analysis base relations
 			{Name: "TaintSink", Relation: "TaintSink", File: "tsq_taint.qll"},
 			{Name: "TaintSource", Relation: "TaintSource", File: "tsq_taint.qll"},

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -9,8 +9,8 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	m := V1Manifest()
 	// v2: 28 original + 5 promoted from unavailable + 12 new v2 = 45
 	// But some relations share bridge classes. Count: 28 + 17 = 45
-	if got := len(m.Available); got != 61 {
-		t.Errorf("expected 61 available classes, got %d", got)
+	if got := len(m.Available); got != 63 {
+		t.Errorf("expected 63 available classes, got %d", got)
 	}
 }
 

--- a/bridge/tsq_composition.qll
+++ b/bridge/tsq_composition.qll
@@ -1,0 +1,41 @@
+/**
+ * Bridge library for inter-procedural flow composition relations (v2 Phase C3).
+ * Maps composition relations derived from system Datalog rules that combine
+ * function-level summaries with call graph edges to propagate dataflow
+ * across function boundaries.
+ */
+
+/**
+ * Holds when there is inter-procedural dataflow from `srcSym` to `dstSym`
+ * across a call site — either argument-to-return or argument-to-inner-argument.
+ */
+class InterFlow extends @inter_flow {
+    InterFlow() { InterFlow(this, _) }
+
+    /** Gets the source symbol. */
+    int getSrc() { result = this }
+
+    /** Gets the destination symbol. */
+    int getDst() { InterFlow(this, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "InterFlow" }
+}
+
+/**
+ * Holds when there is whole-program transitive dataflow from `srcSym`
+ * to `dstSym`, composing local intra-procedural flow and inter-procedural
+ * flow across call sites.
+ */
+class FlowStar extends @flow_star {
+    FlowStar() { FlowStar(this, _) }
+
+    /** Gets the source symbol. */
+    int getSrc() { result = this }
+
+    /** Gets the destination symbol. */
+    int getDst() { FlowStar(this, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "FlowStar" }
+}

--- a/extract/rules/composition.go
+++ b/extract/rules/composition.go
@@ -1,0 +1,69 @@
+package rules
+
+import (
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// CompositionRules returns the system Datalog rules for inter-procedural
+// flow composition at call sites (Phase C3). These compose function-level
+// summaries (from Phase C2) with call graph edges (Phase B) to propagate
+// dataflow across function boundaries, and define whole-program FlowStar
+// as the transitive closure of local + inter-procedural flow.
+func CompositionRules() []datalog.Rule {
+	return []datalog.Rule{
+		// Rule 1: Argument flows through callee to return (InterFlow).
+		// InterFlow(argSym, callRetSym) :-
+		//   CallTarget(call, fn), CallArg(call, idx, argExpr),
+		//   ExprMayRef(argExpr, argSym), ParamToReturn(fn, idx),
+		//   CallResultSym(call, callRetSym).
+		rule("InterFlow",
+			[]datalog.Term{v("argSym"), v("callRetSym")},
+			pos("CallTarget", v("call"), v("fn")),
+			pos("CallArg", v("call"), v("idx"), v("argExpr")),
+			pos("ExprMayRef", v("argExpr"), v("argSym")),
+			pos("ParamToReturn", v("fn"), v("idx")),
+			pos("CallResultSym", v("call"), v("callRetSym")),
+		),
+
+		// Rule 2: Argument flows through callee to another callee's argument.
+		// InterFlow(argSym, innerArgSym) :-
+		//   CallTarget(outerCall, fn), CallArg(outerCall, idx, argExpr),
+		//   ExprMayRef(argExpr, argSym), ParamToCallArg(fn, idx, innerCalleeSym, innerIdx),
+		//   FunctionSymbol(innerCalleeSym, innerFn),
+		//   CallTarget(innerCall, innerFn), CallArg(innerCall, innerIdx, innerArgExpr),
+		//   ExprMayRef(innerArgExpr, innerArgSym).
+		rule("InterFlow",
+			[]datalog.Term{v("argSym"), v("innerArgSym")},
+			pos("CallTarget", v("outerCall"), v("fn")),
+			pos("CallArg", v("outerCall"), v("idx"), v("argExpr")),
+			pos("ExprMayRef", v("argExpr"), v("argSym")),
+			pos("ParamToCallArg", v("fn"), v("idx"), v("innerCalleeSym"), v("innerIdx")),
+			pos("FunctionSymbol", v("innerCalleeSym"), v("innerFn")),
+			pos("CallTarget", v("innerCall"), v("innerFn")),
+			pos("CallArg", v("innerCall"), v("innerIdx"), v("innerArgExpr")),
+			pos("ExprMayRef", v("innerArgExpr"), v("innerArgSym")),
+		),
+
+		// Rule 3: FlowStar — lift local to global.
+		// FlowStar(src, dst) :- LocalFlowStar(_, src, dst).
+		rule("FlowStar",
+			[]datalog.Term{v("src"), v("dst")},
+			pos("LocalFlowStar", w(), v("src"), v("dst")),
+		),
+
+		// Rule 4: FlowStar — inter-procedural base.
+		// FlowStar(src, dst) :- InterFlow(src, dst).
+		rule("FlowStar",
+			[]datalog.Term{v("src"), v("dst")},
+			pos("InterFlow", v("src"), v("dst")),
+		),
+
+		// Rule 5: FlowStar — transitivity.
+		// FlowStar(src, dst) :- FlowStar(src, mid), FlowStar(mid, dst).
+		rule("FlowStar",
+			[]datalog.Term{v("src"), v("dst")},
+			pos("FlowStar", v("src"), v("mid")),
+			pos("FlowStar", v("mid"), v("dst")),
+		),
+	}
+}

--- a/extract/rules/composition_test.go
+++ b/extract/rules/composition_test.go
@@ -1,0 +1,393 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// compositionBaseRels returns base relations needed for composition rules,
+// including all relations needed by LocalFlow, Summary, and CallGraph rules.
+func compositionBaseRels(overrides map[string]*eval.Relation) map[string]*eval.Relation {
+	base := map[string]*eval.Relation{
+		// LocalFlow dependencies
+		"Assign":           eval.NewRelation("Assign", 3),
+		"ExprMayRef":       eval.NewRelation("ExprMayRef", 2),
+		"SymInFunction":    eval.NewRelation("SymInFunction", 2),
+		"VarDecl":          eval.NewRelation("VarDecl", 4),
+		"ReturnStmt":       eval.NewRelation("ReturnStmt", 3),
+		"ReturnSym":        eval.NewRelation("ReturnSym", 2),
+		"DestructureField": eval.NewRelation("DestructureField", 5),
+		"FieldRead":        eval.NewRelation("FieldRead", 3),
+		"FieldWrite":       eval.NewRelation("FieldWrite", 4),
+		// Summary dependencies
+		"Parameter":        eval.NewRelation("Parameter", 6),
+		"FunctionContains": eval.NewRelation("FunctionContains", 2),
+		"CallArg":          eval.NewRelation("CallArg", 3),
+		"CallCalleeSym":    eval.NewRelation("CallCalleeSym", 2),
+		"CallResultSym":    eval.NewRelation("CallResultSym", 2),
+		"TaintSink":        eval.NewRelation("TaintSink", 2),
+		"TaintSource":      eval.NewRelation("TaintSource", 2),
+		// CallGraph dependencies
+		"FunctionSymbol": eval.NewRelation("FunctionSymbol", 2),
+		"MethodCall":     eval.NewRelation("MethodCall", 3),
+		"ExprType":       eval.NewRelation("ExprType", 2),
+		"ClassDecl":      eval.NewRelation("ClassDecl", 3),
+		"InterfaceDecl":  eval.NewRelation("InterfaceDecl", 3),
+		"MethodDecl":     eval.NewRelation("MethodDecl", 3),
+		"Implements":     eval.NewRelation("Implements", 2),
+		"Extends":        eval.NewRelation("Extends", 2),
+		"NewExpr":        eval.NewRelation("NewExpr", 2),
+	}
+	for k, v := range overrides {
+		base[k] = v
+	}
+	return base
+}
+
+// allRulesForComposition returns all system rules needed for composition evaluation.
+func allRulesForComposition() []datalog.Rule {
+	return AllSystemRules()
+}
+
+// TestInterFlow_PassThrough tests: f(x) { return x; } called as f(tainted) → InterFlow from arg to call result.
+func TestInterFlow_PassThrough(t *testing.T) {
+	// Function f: fn=1, paramSym=10, retSym=99
+	// Caller: call=300, argExpr=400, argSym=50, callRetSym=60
+	//
+	// Facts needed to derive ParamToReturn(fn=1, idx=0):
+	//   Parameter(fn=1, idx=0, "x", paramNode=80, sym=10, "")
+	//   ReturnStmt(fn=1, stmtNode=81, retExpr=200)
+	//   ExprMayRef(retExpr=200, sym=10)    — return references param
+	//   ReturnSym(fn=1, sym=99)
+	//   SymInFunction(10, 1), SymInFunction(99, 1)
+	//
+	// Call site facts:
+	//   CallCalleeSym(call=300, calleeSym=500)
+	//   FunctionSymbol(calleeSym=500, fn=1)  → CallTarget(300, 1)
+	//   CallArg(call=300, idx=0, argExpr=400)
+	//   ExprMayRef(argExpr=400, argSym=50)
+	//   CallResultSym(call=300, callRetSym=60)
+	baseRels := compositionBaseRels(map[string]*eval.Relation{
+		"Parameter":  makeRel("Parameter", 6, iv(1), iv(0), sv("x"), iv(80), iv(10), sv("")),
+		"ReturnStmt": makeRel("ReturnStmt", 3, iv(1), iv(81), iv(200)),
+		"ExprMayRef": makeRel("ExprMayRef", 2,
+			iv(200), iv(10), // return expr → param sym
+			iv(400), iv(50), // arg expr → arg sym
+		),
+		"ReturnSym": makeRel("ReturnSym", 2, iv(1), iv(99)),
+		"SymInFunction": makeRel("SymInFunction", 2,
+			iv(10), iv(1),
+			iv(99), iv(1),
+		),
+		"CallCalleeSym":  makeRel("CallCalleeSym", 2, iv(300), iv(500)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(500), iv(1)),
+		"CallArg":        makeRel("CallArg", 3, iv(300), iv(0), iv(400)),
+		"CallResultSym":  makeRel("CallResultSym", 2, iv(300), iv(60)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("InterFlow", v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, allRulesForComposition(), query, baseRels)
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 InterFlow row, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(50), iv(60)) {
+		t.Errorf("expected InterFlow(50, 60), got %v", rs.Rows)
+	}
+}
+
+// TestInterFlow_NoFlow tests: f(x) { return 42; } → no InterFlow.
+func TestInterFlow_NoFlow(t *testing.T) {
+	// Function f: fn=1, paramSym=10, retSym=99, literalSym=88
+	// The return expression references a literal, not the parameter → no ParamToReturn → no InterFlow.
+	baseRels := compositionBaseRels(map[string]*eval.Relation{
+		"Parameter":  makeRel("Parameter", 6, iv(1), iv(0), sv("x"), iv(80), iv(10), sv("")),
+		"ReturnStmt": makeRel("ReturnStmt", 3, iv(1), iv(81), iv(200)),
+		"ExprMayRef": makeRel("ExprMayRef", 2,
+			iv(200), iv(88), // return expr → literal sym (not param)
+			iv(400), iv(50), // arg expr → arg sym
+		),
+		"ReturnSym": makeRel("ReturnSym", 2, iv(1), iv(99)),
+		"SymInFunction": makeRel("SymInFunction", 2,
+			iv(10), iv(1),
+			iv(88), iv(1),
+			iv(99), iv(1),
+		),
+		"CallCalleeSym":  makeRel("CallCalleeSym", 2, iv(300), iv(500)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(500), iv(1)),
+		"CallArg":        makeRel("CallArg", 3, iv(300), iv(0), iv(400)),
+		"CallResultSym":  makeRel("CallResultSym", 2, iv(300), iv(60)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("InterFlow", v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, allRulesForComposition(), query, baseRels)
+	if len(rs.Rows) != 0 {
+		t.Errorf("expected 0 InterFlow rows for non-identity function, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestInterFlow_MultiLevel tests: f calls g, g is identity → flow propagates across two levels.
+// g(x) { return x; }    ← ParamToReturn(g, 0)
+// f(a) { return g(a); } ← f has ParamToCallArg(f, 0, gSym, 0) and CallReturnToReturn(f, call_g)
+//
+// At the caller calling f(tainted):
+//   - InterFlow rule 2 (ParamToCallArg): tainted flows through f to g's arg
+//     via ParamToCallArg(f, 0, gSym, 0)
+//   - InterFlow rule 1 on g's call: g's arg flows to g's call result (ParamToReturn(g, 0))
+//   - FlowStar composes these transitively
+func TestInterFlow_MultiLevel(t *testing.T) {
+	// g: fn=2, paramSym_g=20, retSym_g=29
+	// f: fn=1, paramSym_f=10, retSym_f=19, call_g=300, callRetSym_g=40
+	// caller: call_f=600, argExpr_f=700, argSym_f=50, callRetSym_f=60
+
+	baseRels := compositionBaseRels(map[string]*eval.Relation{
+		"Parameter": makeRel("Parameter", 6,
+			iv(2), iv(0), sv("x"), iv(180), iv(20), sv(""), // g's param
+			iv(1), iv(0), sv("a"), iv(80), iv(10), sv(""), // f's param
+		),
+		"ReturnStmt": makeRel("ReturnStmt", 3,
+			iv(2), iv(181), iv(250), // g's return
+			iv(1), iv(81), iv(200), // f's return
+		),
+		"ExprMayRef": makeRel("ExprMayRef", 2,
+			iv(250), iv(20), // g's return expr → g's param sym
+			iv(200), iv(40), // f's return expr → callRetSym of g (f returns g(a))
+			iv(350), iv(10), // f's call arg to g → f's param sym
+			iv(700), iv(50), // caller's call arg to f → tainted sym
+		),
+		"ReturnSym": makeRel("ReturnSym", 2,
+			iv(2), iv(29), // g's return sym
+			iv(1), iv(19), // f's return sym
+		),
+		"SymInFunction": makeRel("SymInFunction", 2,
+			iv(20), iv(2), // g
+			iv(29), iv(2),
+			iv(10), iv(1), // f
+			iv(19), iv(1),
+			iv(40), iv(1), // callRetSym of g is in f
+		),
+		// g is called from f: call_g=300
+		"FunctionContains": makeRel("FunctionContains", 2, iv(1), iv(300)),
+		"CallCalleeSym": makeRel("CallCalleeSym", 2,
+			iv(300), iv(501), // f's call to g
+			iv(600), iv(500), // caller's call to f
+		),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2,
+			iv(500), iv(1), // sym 500 → fn 1 (f)
+			iv(501), iv(2), // sym 501 → fn 2 (g)
+		),
+		"CallArg": makeRel("CallArg", 3,
+			iv(300), iv(0), iv(350), // f calls g(a) — arg is expr 350
+			iv(600), iv(0), iv(700), // caller calls f(tainted) — arg is expr 700
+		),
+		"CallResultSym": makeRel("CallResultSym", 2,
+			iv(300), iv(40), // g call result sym in f
+			iv(600), iv(60), // f call result sym in caller
+		),
+	})
+
+	// Check InterFlow: f→g pass-through should work (g is identity, called with f's param)
+	queryInterFlow := &datalog.Query{
+		Select: []datalog.Term{v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("InterFlow", v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, allRulesForComposition(), queryInterFlow, baseRels)
+
+	// InterFlow(10, 40): f's param flows through g to g's call result in f.
+	// This uses rule 1: CallTarget(300, 2), CallArg(300, 0, 350), ExprMayRef(350, 10),
+	//   ParamToReturn(2, 0), CallResultSym(300, 40).
+	if !resultContains(rs, iv(10), iv(40)) {
+		t.Errorf("expected InterFlow(10, 40) for f→g pass-through, got %v", rs.Rows)
+	}
+
+	// Check FlowStar for end-to-end: tainted(50) → callResult(60)
+	// Path: FlowStar(50, 10) via InterFlow rule 2 (ParamToCallArg),
+	//        then InterFlow(10, 40), LocalFlowStar(1, 40, 19) (local in f),
+	//        then caller gets it.
+	// Actually the full chain is: InterFlow(10,40) + LocalFlow(1,40,19)
+	// which means FlowStar(10, 19) via local lift + inter compose.
+	queryFlowStar := &datalog.Query{
+		Select: []datalog.Term{v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("FlowStar", v("src"), v("dst"))},
+	}
+
+	rsFlow := planAndEval(t, allRulesForComposition(), queryFlowStar, baseRels)
+
+	// FlowStar(10, 40): inter-procedural through g
+	if !resultContains(rsFlow, iv(10), iv(40)) {
+		t.Errorf("expected FlowStar(10, 40), got %v", rsFlow.Rows)
+	}
+	// FlowStar(40, 19): local flow in f (return g(a) → retSym)
+	if !resultContains(rsFlow, iv(40), iv(19)) {
+		t.Errorf("expected FlowStar(40, 19) from local flow in f, got %v", rsFlow.Rows)
+	}
+	// FlowStar(10, 19): transitive through g and back — param flows to f's return
+	if !resultContains(rsFlow, iv(10), iv(19)) {
+		t.Errorf("expected FlowStar(10, 19) transitively, got %v", rsFlow.Rows)
+	}
+}
+
+// TestInterFlow_UnresolvedCall tests: no CallTarget → no crash, no InterFlow.
+func TestInterFlow_UnresolvedCall(t *testing.T) {
+	// Call exists but no CallCalleeSym/FunctionSymbol → no CallTarget → no InterFlow.
+	baseRels := compositionBaseRels(map[string]*eval.Relation{
+		"CallArg":       makeRel("CallArg", 3, iv(300), iv(0), iv(400)),
+		"ExprMayRef":    makeRel("ExprMayRef", 2, iv(400), iv(50)),
+		"CallResultSym": makeRel("CallResultSym", 2, iv(300), iv(60)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("InterFlow", v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, allRulesForComposition(), query, baseRels)
+	if len(rs.Rows) != 0 {
+		t.Errorf("expected 0 InterFlow rows for unresolved call, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestFlowStar_Transitivity tests that FlowStar composes local and inter-procedural flow.
+// Setup: local flow A→B within a function, inter-procedural flow B→C across a call.
+// Expected: FlowStar(A, C) via transitivity.
+func TestFlowStar_Transitivity(t *testing.T) {
+	// Function f: fn=1, sym A=10, sym B=15, retSym=99
+	// let b = a; (local flow A→B)
+	// return b; (local flow B→retSym)
+	// ParamToReturn(f, 0) derived
+	//
+	// Caller: call=300, argExpr=400, argSym=50 (tainted), callRetSym=60
+	// Local flow: sym 50 → sym 50 (reflexive via LocalFlowStar)
+	// InterFlow: 50 → 60
+
+	// For FlowStar transitivity, we also need a local step in the caller.
+	// Setup: caller has let x = tainted; let r = f(x);
+	// localSymX=50, localSymTainted=45
+	// Assign x = tainted → LocalFlow(caller, 45, 50)
+	// Then InterFlow(50, 60) from the pass-through
+	// FlowStar should give us (45, 60) transitively.
+
+	baseRels := compositionBaseRels(map[string]*eval.Relation{
+		"Parameter":  makeRel("Parameter", 6, iv(1), iv(0), sv("b"), iv(80), iv(15), sv("")),
+		"ReturnStmt": makeRel("ReturnStmt", 3, iv(1), iv(81), iv(200)),
+		"ExprMayRef": makeRel("ExprMayRef", 2,
+			iv(200), iv(15), // return expr → B (param sym)
+			iv(400), iv(50), // call arg expr → sym 50
+			iv(450), iv(45), // init expr for let x = tainted → sym 45
+		),
+		"ReturnSym": makeRel("ReturnSym", 2, iv(1), iv(99)),
+		"SymInFunction": makeRel("SymInFunction", 2,
+			iv(15), iv(1),
+			iv(99), iv(1),
+			iv(45), iv(2), // tainted sym in caller fn=2
+			iv(50), iv(2), // x sym in caller fn=2
+		),
+		// let x = tainted in caller (fn=2)
+		"VarDecl":        makeRel("VarDecl", 4, iv(460), iv(50), iv(450), iv(0)),
+		"CallCalleeSym":  makeRel("CallCalleeSym", 2, iv(300), iv(500)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(500), iv(1)),
+		"CallArg":        makeRel("CallArg", 3, iv(300), iv(0), iv(400)),
+		"CallResultSym":  makeRel("CallResultSym", 2, iv(300), iv(60)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("FlowStar", v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, allRulesForComposition(), query, baseRels)
+
+	// FlowStar(45, 50) from local flow in caller
+	if !resultContains(rs, iv(45), iv(50)) {
+		t.Errorf("expected FlowStar(45, 50) from local flow, got %v", rs.Rows)
+	}
+	// FlowStar(50, 60) from inter-procedural flow
+	if !resultContains(rs, iv(50), iv(60)) {
+		t.Errorf("expected FlowStar(50, 60) from inter flow, got %v", rs.Rows)
+	}
+	// FlowStar(45, 60) from transitivity: local(45→50) + inter(50→60)
+	if !resultContains(rs, iv(45), iv(60)) {
+		t.Errorf("expected FlowStar(45, 60) from transitivity, got %v", rs.Rows)
+	}
+}
+
+// TestCompositionRulesValidate verifies all composition rules pass the planner's validation.
+func TestCompositionRulesValidate(t *testing.T) {
+	for i, r := range CompositionRules() {
+		errs := plan.ValidateRule(r)
+		if len(errs) > 0 {
+			t.Errorf("rule %d (%s) validation errors: %v", i, r.Head.Predicate, errs)
+		}
+	}
+}
+
+// TestCompositionRulesStratify verifies composition + summary + localflow + callgraph rules stratify together.
+func TestCompositionRulesStratify(t *testing.T) {
+	prog := &datalog.Program{Rules: AllSystemRules()}
+	_, errs := plan.Plan(prog, nil)
+	if len(errs) > 0 {
+		t.Fatalf("all system rules (including composition) failed to plan: %v", errs)
+	}
+}
+
+// TestCompositionRulesCount verifies we produce exactly 5 composition rules.
+func TestCompositionRulesCount(t *testing.T) {
+	rules := CompositionRules()
+	if len(rules) != 5 {
+		t.Errorf("expected 5 composition rules, got %d", len(rules))
+	}
+}
+
+// TestAllSystemRulesCountWithComposition verifies AllSystemRules returns combined count.
+func TestAllSystemRulesCountWithComposition(t *testing.T) {
+	all := AllSystemRules()
+	cg := CallGraphRules()
+	lf := LocalFlowRules()
+	sm := SummaryRules()
+	co := CompositionRules()
+	expected := len(cg) + len(lf) + len(sm) + len(co)
+	if len(all) != expected {
+		t.Errorf("expected %d rules, got %d", expected, len(all))
+	}
+}
+
+// TestEmptyRelationsNoInterFlow verifies no InterFlow from empty base relations.
+func TestEmptyRelationsNoInterFlow(t *testing.T) {
+	baseRels := compositionBaseRels(nil)
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("InterFlow", v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, allRulesForComposition(), query, baseRels)
+	if len(rs.Rows) != 0 {
+		t.Errorf("expected 0 InterFlow rows from empty relations, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestEmptyRelationsNoFlowStar verifies no FlowStar from empty base relations.
+func TestEmptyRelationsNoFlowStar(t *testing.T) {
+	baseRels := compositionBaseRels(nil)
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("FlowStar", v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, allRulesForComposition(), query, baseRels)
+	if len(rs.Rows) != 0 {
+		t.Errorf("expected 0 FlowStar rows from empty relations, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}

--- a/extract/rules/localflow_test.go
+++ b/extract/rules/localflow_test.go
@@ -278,7 +278,8 @@ func TestAllSystemRulesCount(t *testing.T) {
 	cg := CallGraphRules()
 	lf := LocalFlowRules()
 	sm := SummaryRules()
-	expected := len(cg) + len(lf) + len(sm)
+	co := CompositionRules()
+	expected := len(cg) + len(lf) + len(sm) + len(co)
 	if len(all) != expected {
 		t.Errorf("expected %d rules, got %d", expected, len(all))
 	}

--- a/extract/rules/merge.go
+++ b/extract/rules/merge.go
@@ -4,12 +4,13 @@ import (
 	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
 )
 
-// AllSystemRules returns all system Datalog rules: call graph + local flow + summaries.
+// AllSystemRules returns all system Datalog rules: call graph + local flow + summaries + composition.
 func AllSystemRules() []datalog.Rule {
 	var all []datalog.Rule
 	all = append(all, CallGraphRules()...)
 	all = append(all, LocalFlowRules()...)
 	all = append(all, SummaryRules()...)
+	all = append(all, CompositionRules()...)
 	return all
 }
 

--- a/extract/rules/summaries_test.go
+++ b/extract/rules/summaries_test.go
@@ -307,7 +307,8 @@ func TestAllSystemRulesCountWithSummaries(t *testing.T) {
 	cg := CallGraphRules()
 	lf := LocalFlowRules()
 	sm := SummaryRules()
-	expected := len(cg) + len(lf) + len(sm)
+	co := CompositionRules()
+	expected := len(cg) + len(lf) + len(sm) + len(co)
 	if len(all) != expected {
 		t.Errorf("expected %d rules, got %d", expected, len(all))
 	}

--- a/extract/schema/relations.go
+++ b/extract/schema/relations.go
@@ -294,6 +294,16 @@ func init() {
 		{Name: "callId", Type: TypeEntityRef},
 	}})
 
+	// v2 Phase C3: inter-procedural composition (computed by system Datalog rules)
+	RegisterRelation(RelationDef{Name: "InterFlow", Version: 2, Columns: []ColumnDef{
+		{Name: "srcSym", Type: TypeEntityRef},
+		{Name: "dstSym", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "FlowStar", Version: 2, Columns: []ColumnDef{
+		{Name: "srcSym", Type: TypeEntityRef},
+		{Name: "dstSym", Type: TypeEntityRef},
+	}})
+
 	// v2 Phase D placeholders: taint analysis base relations (empty until Phase D)
 	RegisterRelation(RelationDef{Name: "TaintSink", Version: 2, Columns: []ColumnDef{
 		{Name: "sinkExpr", Type: TypeEntityRef},

--- a/extract/schema/relations_test.go
+++ b/extract/schema/relations_test.go
@@ -34,8 +34,8 @@ func TestAllRelationsRegistered(t *testing.T) {
 }
 
 func TestRelationCount(t *testing.T) {
-	if len(Registry) != 61 {
-		t.Fatalf("expected 61 relations in registry, got %d", len(Registry))
+	if len(Registry) != 63 {
+		t.Fatalf("expected 63 relations in registry, got %d", len(Registry))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `CompositionRules()` with 5 Datalog rules for inter-procedural flow composition: two InterFlow rules (arg-to-return via ParamToReturn, arg-to-inner-arg via ParamToCallArg) and three FlowStar rules (lift local, lift inter, transitivity)
- New schema relations: `InterFlow` (arity 2) and `FlowStar` (arity 2) as derived relations
- Bridge QLL: `tsq_composition.qll` with InterFlow and FlowStar classes, embedded and registered in manifest

## Test plan
- [x] Pass-through identity function: `f(x) { return x; }` called with tainted arg produces InterFlow
- [x] No-flow case: `f(x) { return 42; }` produces no InterFlow
- [x] Multi-level: f calls g (identity), verifies InterFlow through g and FlowStar transitivity across both levels
- [x] Unresolved call (no CallTarget): no crash, no spurious flow
- [x] FlowStar transitivity: local flow + inter-procedural flow compose end-to-end
- [x] All composition rules pass ValidateRule
- [x] All system rules (callgraph + localflow + summaries + composition) stratify together
- [x] Rule count and AllSystemRules count assertions updated
- [x] `go test ./... -count=1` all green