### PR TITLE
Phase F: Framework models and higher-order flow rules

### DIFF
--- a/bridge/bridge_test.go
+++ b/bridge/bridge_test.go
@@ -22,7 +22,7 @@ func TestBridgeFilesNotEmpty(t *testing.T) {
 // of each .qll file to verify they contain valid-looking QL class declarations.
 func TestBridgeFilesParseBasicStructure(t *testing.T) {
 	classRe := regexp.MustCompile(`(?m)^class\s+(\w+)\s+extends\s+`)
-	predicateRe := regexp.MustCompile(`(?m)^\s+(string|int|predicate|ASTNode|File|Call|JsxElement|Function|Parameter|CallArg|ParameterRest|ParameterOptional|ParamIsFunctionType|CallArgSpread|VarDecl|Assign|ExprMayRef|ExprIsCall|FieldRead|FieldWrite|Await|Cast|DestructureField|ArrayDestructure|DestructureRest|JsxAttribute|ImportBinding|ExportBinding|ExtractError|SchemaVersion|Contains)\s+\w+\(`)
+	predicateRe := regexp.MustCompile(`(?m)^\s+(?:override\s+)?(string|int|predicate|ASTNode|File|Call|JsxElement|Function|Parameter|CallArg|ParameterRest|ParameterOptional|ParamIsFunctionType|CallArgSpread|VarDecl|Assign|ExprMayRef|ExprIsCall|FieldRead|FieldWrite|Await|Cast|DestructureField|ArrayDestructure|DestructureRest|JsxAttribute|ImportBinding|ExportBinding|ExtractError|SchemaVersion|Contains)\s+\w+\(`)
 
 	files := LoadBridge()
 	for name, data := range files {

--- a/bridge/embed.go
+++ b/bridge/embed.go
@@ -2,7 +2,7 @@ package bridge
 
 import "embed"
 
-//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll tsq_summaries.qll tsq_composition.qll tsq_taint.qll
+//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll tsq_summaries.qll tsq_composition.qll tsq_taint.qll tsq_express.qll tsq_react.qll tsq_node.qll
 var bridgeFS embed.FS
 
 // LoadBridge returns all embedded .qll files as a map from filename to contents.
@@ -23,6 +23,9 @@ func LoadBridge() map[string][]byte {
 		"tsq_summaries.qll",
 		"tsq_composition.qll",
 		"tsq_taint.qll",
+		"tsq_express.qll",
+		"tsq_react.qll",
+		"tsq_node.qll",
 	}
 	result := make(map[string][]byte, len(files))
 	for _, name := range files {
@@ -63,6 +66,9 @@ func BridgeImportLoader(bridgeFiles map[string][]byte, parseFn func(src, file st
 		"tsq::summaries":   "tsq_summaries.qll",
 		"tsq::composition": "tsq_composition.qll",
 		"tsq::taint":       "tsq_taint.qll",
+		"tsq::express":     "tsq_express.qll",
+		"tsq::react":       "tsq_react.qll",
+		"tsq::node":        "tsq_node.qll",
 	}
 	return func(path string) (interface{}, bool) {
 		filename, ok := pathToFile[path]

--- a/bridge/embed_test.go
+++ b/bridge/embed_test.go
@@ -22,6 +22,9 @@ func TestLoadBridgeReturnsAllFiles(t *testing.T) {
 		"tsq_summaries.qll",
 		"tsq_composition.qll",
 		"tsq_taint.qll",
+		"tsq_express.qll",
+		"tsq_react.qll",
+		"tsq_node.qll",
 	}
 	files := LoadBridge()
 	if len(files) != len(expected) {

--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -109,6 +109,8 @@ func v2Manifest() *CapabilityManifest {
 			// v2 Phase C3: inter-procedural composition
 			{Name: "InterFlow", Relation: "InterFlow", File: "tsq_composition.qll"},
 			{Name: "FlowStar", Relation: "FlowStar", File: "tsq_composition.qll"},
+			// v2 Phase F: framework models
+			{Name: "ExpressHandler", Relation: "ExpressHandler", File: "tsq_express.qll"},
 			// v2 Phase D: taint analysis
 			{Name: "TaintSink", Relation: "TaintSink", File: "tsq_taint.qll"},
 			{Name: "TaintSource", Relation: "TaintSource", File: "tsq_taint.qll"},

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -9,8 +9,8 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	m := V1Manifest()
 	// v2: 28 original + 5 promoted from unavailable + 12 new v2 = 45
 	// But some relations share bridge classes. Count: 28 + 17 = 45
-	if got := len(m.Available); got != 68 {
-		t.Errorf("expected 68 available classes, got %d", got)
+	if got := len(m.Available); got != 69 {
+		t.Errorf("expected 69 available classes, got %d", got)
 	}
 }
 

--- a/bridge/tsq_express.qll
+++ b/bridge/tsq_express.qll
@@ -1,0 +1,29 @@
+/**
+ * Bridge library for Express.js framework models (v2 Phase F).
+ * Provides QL classes for Express handler detection and HTTP input sources.
+ */
+
+/**
+ * An Express route handler function. Derived from patterns like
+ * `app.get("/path", handler)`, `app.post(...)`, etc.
+ */
+class ExpressHandler extends @express_handler {
+    ExpressHandler() { ExpressHandler(this) }
+
+    /** Gets the handler function ID. */
+    int getFnId() { result = this }
+
+    /** Gets a textual representation. */
+    string toString() { result = "ExpressHandler" }
+}
+
+/**
+ * An Express request source — an expression reading from req.query, req.params,
+ * or req.body in an Express handler. These are TaintSource facts with kind "http_input".
+ */
+class ExpressReqSource extends TaintSource {
+    ExpressReqSource() { this.getSourceKind() = "http_input" }
+
+    /** Gets a textual representation. */
+    override string toString() { result = "ExpressReqSource" }
+}

--- a/bridge/tsq_node.qll
+++ b/bridge/tsq_node.qll
@@ -1,0 +1,17 @@
+/**
+ * Bridge library for Node.js framework models (v2 Phase F).
+ * Provides QL classes for Node.js security-sensitive operations
+ * such as child_process.exec (command injection sinks).
+ */
+
+/**
+ * A command injection sink via child_process.exec or similar.
+ * These are TaintSink facts with kind "command_injection" derived
+ * from calls to functions named "exec".
+ */
+class CommandInjectionSink extends TaintSink {
+    CommandInjectionSink() { this.getSinkKind() = "command_injection" }
+
+    /** Gets a textual representation. */
+    override string toString() { result = "CommandInjectionSink" }
+}

--- a/bridge/tsq_react.qll
+++ b/bridge/tsq_react.qll
@@ -1,0 +1,19 @@
+/**
+ * Bridge library for React framework models (v2 Phase F).
+ * Provides QL classes for React component XSS detection via dangerouslySetInnerHTML.
+ */
+
+/**
+ * A React XSS sink via dangerouslySetInnerHTML. These are TaintSink facts
+ * with kind "xss" derived from JsxAttribute facts matching the attribute name
+ * "dangerouslySetInnerHTML".
+ */
+class DangerouslySetInnerHTML extends TaintSink {
+    DangerouslySetInnerHTML() {
+        this.getSinkKind() = "xss" and
+        exists(int elem | JsxAttribute(elem, "dangerouslySetInnerHTML", this))
+    }
+
+    /** Gets a textual representation. */
+    override string toString() { result = "DangerouslySetInnerHTML" }
+}

--- a/extract/rules/composition_test.go
+++ b/extract/rules/composition_test.go
@@ -357,7 +357,9 @@ func TestAllSystemRulesCountWithComposition(t *testing.T) {
 	sm := SummaryRules()
 	co := CompositionRules()
 	ta := TaintRules()
-	expected := len(cg) + len(lf) + len(sm) + len(co) + len(ta)
+	fw := FrameworkRules()
+	ho := HigherOrderRules()
+	expected := len(cg) + len(lf) + len(sm) + len(co) + len(ta) + len(fw) + len(ho)
 	if len(all) != expected {
 		t.Errorf("expected %d rules, got %d", expected, len(all))
 	}

--- a/extract/rules/frameworks.go
+++ b/extract/rules/frameworks.go
@@ -1,0 +1,110 @@
+package rules
+
+import (
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// s returns a StringConst term.
+func s(val string) datalog.StringConst { return datalog.StringConst{Value: val} }
+
+// FrameworkRules returns the system Datalog rules for framework-specific
+// taint source/sink identification (Phase F). These are pattern-based
+// heuristics that match on function names and method names to populate
+// TaintSource, TaintSink, and ExpressHandler relations.
+func FrameworkRules() []datalog.Rule {
+	return []datalog.Rule{
+		// ─── Express handler detection ───────────────────────────────────
+		// ExpressHandler(fn) :-
+		//   MethodCall(call, recv, "get"), CallArg(call, _, cbExpr),
+		//   ExprMayRef(cbExpr, cbSym), FunctionSymbol(cbSym, fn).
+		// (Also for "post", "put", "delete", "use", "patch")
+		expressHandlerRule("get"),
+		expressHandlerRule("post"),
+		expressHandlerRule("put"),
+		expressHandlerRule("delete"),
+		expressHandlerRule("use"),
+		expressHandlerRule("patch"),
+
+		// ─── Express sources: req.query ──────────────────────────────────
+		// TaintSource(callExpr, "http_input") :-
+		//   MethodCall(call, recv, "query"), ExprMayRef(recv, reqSym),
+		//   Parameter(fn, 0, "req", _, reqSym, _), ExpressHandler(fn),
+		//   ExprMayRef(call, callExpr).
+		// Note: MethodCall here represents property access like req.query.
+		// Since we match on FieldRead instead (req.query is a field read, not method call):
+		// TaintSource(expr, "http_input") :-
+		//   FieldRead(expr, reqSym, "query"),
+		//   Parameter(fn, 0, _, _, reqSym, _), ExpressHandler(fn).
+		rule("TaintSource",
+			[]datalog.Term{v("expr"), s("http_input")},
+			pos("FieldRead", v("expr"), v("reqSym"), s("query")),
+			pos("Parameter", v("fn"), datalog.IntConst{Value: 0}, w(), w(), v("reqSym"), w()),
+			pos("ExpressHandler", v("fn")),
+		),
+
+		// TaintSource(expr, "http_input") :- FieldRead(expr, reqSym, "params"), ...
+		rule("TaintSource",
+			[]datalog.Term{v("expr"), s("http_input")},
+			pos("FieldRead", v("expr"), v("reqSym"), s("params")),
+			pos("Parameter", v("fn"), datalog.IntConst{Value: 0}, w(), w(), v("reqSym"), w()),
+			pos("ExpressHandler", v("fn")),
+		),
+
+		// TaintSource(expr, "http_input") :- FieldRead(expr, reqSym, "body"), ...
+		rule("TaintSource",
+			[]datalog.Term{v("expr"), s("http_input")},
+			pos("FieldRead", v("expr"), v("reqSym"), s("body")),
+			pos("Parameter", v("fn"), datalog.IntConst{Value: 0}, w(), w(), v("reqSym"), w()),
+			pos("ExpressHandler", v("fn")),
+		),
+
+		// ─── Express sinks: res.send ─────────────────────────────────────
+		// TaintSink(argExpr, "xss") :-
+		//   MethodCall(call, recv, "send"), ExprMayRef(recv, resSym),
+		//   Parameter(fn, 1, _, _, resSym, _), ExpressHandler(fn),
+		//   CallArg(call, 0, argExpr).
+		rule("TaintSink",
+			[]datalog.Term{v("argExpr"), s("xss")},
+			pos("MethodCall", v("call"), v("recv"), s("send")),
+			pos("ExprMayRef", v("recv"), v("resSym")),
+			pos("Parameter", v("fn"), datalog.IntConst{Value: 1}, w(), w(), v("resSym"), w()),
+			pos("ExpressHandler", v("fn")),
+			pos("CallArg", v("call"), datalog.IntConst{Value: 0}, v("argExpr")),
+		),
+
+		// ─── Node.js sinks: child_process.exec ──────────────────────────
+		// TaintSink(argExpr, "command_injection") :-
+		//   CallCalleeSym(call, execSym), FunctionSymbol(execSym, execFn),
+		//   Function(execFn, "exec", _, _, _, _), CallArg(call, 0, argExpr).
+		rule("TaintSink",
+			[]datalog.Term{v("argExpr"), s("command_injection")},
+			pos("CallCalleeSym", v("call"), v("execSym")),
+			pos("FunctionSymbol", v("execSym"), v("execFn")),
+			pos("Function", v("execFn"), s("exec"), w(), w(), w(), w()),
+			pos("CallArg", v("call"), datalog.IntConst{Value: 0}, v("argExpr")),
+		),
+
+		// ─── React XSS: dangerouslySetInnerHTML ─────────────────────────
+		// TaintSink(valueExpr, "xss") :-
+		//   JsxAttribute(elem, "dangerouslySetInnerHTML", valueExpr).
+		rule("TaintSink",
+			[]datalog.Term{v("valueExpr"), s("xss")},
+			pos("JsxAttribute", w(), s("dangerouslySetInnerHTML"), v("valueExpr")),
+		),
+	}
+}
+
+// expressHandlerRule generates:
+//
+//	ExpressHandler(fn) :-
+//	  MethodCall(call, _, methodName), CallArg(call, _, cbExpr),
+//	  ExprMayRef(cbExpr, cbSym), FunctionSymbol(cbSym, fn).
+func expressHandlerRule(methodName string) datalog.Rule {
+	return rule("ExpressHandler",
+		[]datalog.Term{v("fn")},
+		pos("MethodCall", v("call"), w(), s(methodName)),
+		pos("CallArg", v("call"), w(), v("cbExpr")),
+		pos("ExprMayRef", v("cbExpr"), v("cbSym")),
+		pos("FunctionSymbol", v("cbSym"), v("fn")),
+	)
+}

--- a/extract/rules/frameworks_test.go
+++ b/extract/rules/frameworks_test.go
@@ -1,0 +1,165 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// frameworkBaseRels returns the base relations needed for framework rules evaluation,
+// including all relations from the full system rule set.
+func frameworkBaseRels(overrides map[string]*eval.Relation) map[string]*eval.Relation {
+	base := taintBaseRels(nil)
+	// Add framework-specific base relations
+	base["FieldRead"] = eval.NewRelation("FieldRead", 3)
+	base["Function"] = eval.NewRelation("Function", 6)
+	base["JsxElement"] = eval.NewRelation("JsxElement", 3)
+	base["JsxAttribute"] = eval.NewRelation("JsxAttribute", 3)
+	for k, v := range overrides {
+		base[k] = v
+	}
+	return base
+}
+
+// TestExpressHandler_FromAppGet tests that ExpressHandler is derived from app.get(path, handler).
+func TestExpressHandler_FromAppGet(t *testing.T) {
+	// app.get("/path", handler) → MethodCall(call=500, recv=_, "get"), CallArg(500, 1, cbExpr=600),
+	// ExprMayRef(600, cbSym=60), FunctionSymbol(60, fn=7).
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		"MethodCall":     makeRel("MethodCall", 3, iv(500), iv(400), sv("get")),
+		"CallArg":        makeRel("CallArg", 3, iv(500), iv(1), iv(600)),
+		"ExprMayRef":     makeRel("ExprMayRef", 2, iv(600), iv(60)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(60), iv(7)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn")},
+		Body:   []datalog.Literal{pos("ExpressHandler", v("fn"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(7)) {
+		t.Errorf("expected ExpressHandler(7), got %v", rs.Rows)
+	}
+}
+
+// TestExpressSource_ReqQuery tests that req.query produces a TaintSource.
+func TestExpressSource_ReqQuery(t *testing.T) {
+	// Express handler fn=7, req param sym=10 at idx 0.
+	// FieldRead(expr=100, reqSym=10, "query")
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		// Handler detection: app.post("/path", handler)
+		"MethodCall":     makeRel("MethodCall", 3, iv(500), iv(400), sv("post")),
+		"CallArg":        makeRel("CallArg", 3, iv(500), iv(1), iv(600)),
+		"ExprMayRef":     makeRel("ExprMayRef", 2, iv(600), iv(60), iv(100), iv(10)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(60), iv(7)),
+		"Parameter":      makeRel("Parameter", 6, iv(7), iv(0), sv("req"), iv(80), iv(10), sv("")),
+		"FieldRead":      makeRel("FieldRead", 3, iv(100), iv(10), sv("query")),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("expr"), v("kind")},
+		Body:   []datalog.Literal{pos("TaintSource", v("expr"), v("kind"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(100), sv("http_input")) {
+		t.Errorf("expected TaintSource(100, http_input) from req.query, got %v", rs.Rows)
+	}
+}
+
+// TestExpressSink_ResSend tests that res.send(data) produces a TaintSink.
+func TestExpressSink_ResSend(t *testing.T) {
+	// Express handler fn=7, res param sym=20 at idx 1.
+	// res.send(data): MethodCall(call=700, recv=750, "send"), ExprMayRef(750, 20),
+	// CallArg(700, 0, argExpr=800).
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		// Handler detection
+		"MethodCall": makeRel("MethodCall", 3,
+			iv(500), iv(400), sv("get"), // app.get
+			iv(700), iv(750), sv("send"), // res.send
+		),
+		"CallArg": makeRel("CallArg", 3,
+			iv(500), iv(1), iv(600), // handler callback
+			iv(700), iv(0), iv(800), // send argument
+		),
+		"ExprMayRef": makeRel("ExprMayRef", 2,
+			iv(600), iv(60), // callback expr → cbSym
+			iv(750), iv(20), // recv expr → resSym
+		),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(60), iv(7)),
+		"Parameter":      makeRel("Parameter", 6, iv(7), iv(1), sv("res"), iv(81), iv(20), sv("")),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("expr"), v("kind")},
+		Body:   []datalog.Literal{pos("TaintSink", v("expr"), v("kind"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(800), sv("xss")) {
+		t.Errorf("expected TaintSink(800, xss) from res.send, got %v", rs.Rows)
+	}
+}
+
+// TestNodeSink_ChildProcessExec tests that child_process.exec(cmd) produces a command_injection sink.
+func TestNodeSink_ChildProcessExec(t *testing.T) {
+	// exec(cmd): CallCalleeSym(call=900, execSym=90), FunctionSymbol(90, execFn=9),
+	// Function(9, "exec", 0, 0, 0, 0), CallArg(900, 0, argExpr=950).
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		"CallCalleeSym":  makeRel("CallCalleeSym", 2, iv(900), iv(90)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(90), iv(9)),
+		"Function":       makeRel("Function", 6, iv(9), sv("exec"), iv(0), iv(0), iv(0), iv(0)),
+		"CallArg":        makeRel("CallArg", 3, iv(900), iv(0), iv(950)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("expr"), v("kind")},
+		Body:   []datalog.Literal{pos("TaintSink", v("expr"), v("kind"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(950), sv("command_injection")) {
+		t.Errorf("expected TaintSink(950, command_injection) from exec(), got %v", rs.Rows)
+	}
+}
+
+// TestReactSink_DangerouslySetInnerHTML tests that dangerouslySetInnerHTML produces an XSS sink.
+func TestReactSink_DangerouslySetInnerHTML(t *testing.T) {
+	// <div dangerouslySetInnerHTML={expr} />
+	// JsxAttribute(elem=1000, "dangerouslySetInnerHTML", valueExpr=1050)
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		"JsxAttribute": makeRel("JsxAttribute", 3, iv(1000), sv("dangerouslySetInnerHTML"), iv(1050)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("expr"), v("kind")},
+		Body:   []datalog.Literal{pos("TaintSink", v("expr"), v("kind"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(1050), sv("xss")) {
+		t.Errorf("expected TaintSink(1050, xss) from dangerouslySetInnerHTML, got %v", rs.Rows)
+	}
+}
+
+// TestFrameworkRulesValidate verifies all framework rules pass validation.
+func TestFrameworkRulesValidate(t *testing.T) {
+	for i, r := range FrameworkRules() {
+		errs := plan.ValidateRule(r)
+		if len(errs) > 0 {
+			t.Errorf("rule %d (%s) validation errors: %v", i, r.Head.Predicate, errs)
+		}
+	}
+}
+
+// TestFrameworkRulesStratify verifies framework rules stratify with all system rules.
+func TestFrameworkRulesStratify(t *testing.T) {
+	prog := &datalog.Program{Rules: AllSystemRules()}
+	_, errs := plan.Plan(prog, nil)
+	if len(errs) > 0 {
+		t.Fatalf("all system rules (including frameworks) failed to plan: %v", errs)
+	}
+}

--- a/extract/rules/higherorder.go
+++ b/extract/rules/higherorder.go
@@ -1,0 +1,79 @@
+package rules
+
+import (
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// HigherOrderRules returns the system Datalog rules for higher-order function
+// flow models (Phase F). These model dataflow through common higher-order
+// patterns: Array.map/forEach/filter/reduce and Promise.then.
+func HigherOrderRules() []datalog.Rule {
+	return []datalog.Rule{
+		// ─── Array.map callback flow ─────────────────────────────────────
+		// InterFlow(arraySym, paramSym) :-
+		//   MethodCall(call, arrayExpr, "map"),
+		//   ExprMayRef(arrayExpr, arraySym),
+		//   CallArg(call, 0, callbackExpr),
+		//   ExprMayRef(callbackExpr, callbackSym),
+		//   FunctionSymbol(callbackSym, callbackFn),
+		//   Parameter(callbackFn, 0, _, _, paramSym, _).
+		higherOrderArrayRule("map"),
+
+		// ─── Array.forEach callback flow ─────────────────────────────────
+		higherOrderArrayRule("forEach"),
+
+		// ─── Array.filter callback flow ──────────────────────────────────
+		higherOrderArrayRule("filter"),
+
+		// ─── Array.reduce callback flow ──────────────────────────────────
+		// For reduce, the current element is param index 1 (param 0 is the accumulator).
+		// InterFlow(arraySym, paramSym) :-
+		//   MethodCall(call, arrayExpr, "reduce"),
+		//   ExprMayRef(arrayExpr, arraySym),
+		//   CallArg(call, 0, callbackExpr),
+		//   ExprMayRef(callbackExpr, callbackSym),
+		//   FunctionSymbol(callbackSym, callbackFn),
+		//   Parameter(callbackFn, 1, _, _, paramSym, _).
+		rule("InterFlow",
+			[]datalog.Term{v("arraySym"), v("paramSym")},
+			pos("MethodCall", v("call"), v("arrayExpr"), s("reduce")),
+			pos("ExprMayRef", v("arrayExpr"), v("arraySym")),
+			pos("CallArg", v("call"), datalog.IntConst{Value: 0}, v("callbackExpr")),
+			pos("ExprMayRef", v("callbackExpr"), v("callbackSym")),
+			pos("FunctionSymbol", v("callbackSym"), v("callbackFn")),
+			pos("Parameter", v("callbackFn"), datalog.IntConst{Value: 1}, w(), w(), v("paramSym"), w()),
+		),
+
+		// ─── Promise.then callback flow ──────────────────────────────────
+		// InterFlow(promiseSym, paramSym) :-
+		//   MethodCall(call, promiseExpr, "then"),
+		//   ExprMayRef(promiseExpr, promiseSym),
+		//   CallArg(call, 0, callbackExpr),
+		//   ExprMayRef(callbackExpr, callbackSym),
+		//   FunctionSymbol(callbackSym, callbackFn),
+		//   Parameter(callbackFn, 0, _, _, paramSym, _).
+		rule("InterFlow",
+			[]datalog.Term{v("promiseSym"), v("paramSym")},
+			pos("MethodCall", v("call"), v("promiseExpr"), s("then")),
+			pos("ExprMayRef", v("promiseExpr"), v("promiseSym")),
+			pos("CallArg", v("call"), datalog.IntConst{Value: 0}, v("callbackExpr")),
+			pos("ExprMayRef", v("callbackExpr"), v("callbackSym")),
+			pos("FunctionSymbol", v("callbackSym"), v("callbackFn")),
+			pos("Parameter", v("callbackFn"), datalog.IntConst{Value: 0}, w(), w(), v("paramSym"), w()),
+		),
+	}
+}
+
+// higherOrderArrayRule generates an InterFlow rule for array methods where
+// the element is passed as the first parameter (index 0) of the callback.
+func higherOrderArrayRule(methodName string) datalog.Rule {
+	return rule("InterFlow",
+		[]datalog.Term{v("arraySym"), v("paramSym")},
+		pos("MethodCall", v("call"), v("arrayExpr"), s(methodName)),
+		pos("ExprMayRef", v("arrayExpr"), v("arraySym")),
+		pos("CallArg", v("call"), datalog.IntConst{Value: 0}, v("callbackExpr")),
+		pos("ExprMayRef", v("callbackExpr"), v("callbackSym")),
+		pos("FunctionSymbol", v("callbackSym"), v("callbackFn")),
+		pos("Parameter", v("callbackFn"), datalog.IntConst{Value: 0}, w(), w(), v("paramSym"), w()),
+	)
+}

--- a/extract/rules/higherorder_test.go
+++ b/extract/rules/higherorder_test.go
@@ -1,0 +1,114 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// higherOrderBaseRels returns the base relations needed for higher-order rules evaluation.
+func higherOrderBaseRels(overrides map[string]*eval.Relation) map[string]*eval.Relation {
+	base := taintBaseRels(nil)
+	base["FieldRead"] = eval.NewRelation("FieldRead", 3)
+	base["Function"] = eval.NewRelation("Function", 6)
+	base["JsxElement"] = eval.NewRelation("JsxElement", 3)
+	base["JsxAttribute"] = eval.NewRelation("JsxAttribute", 3)
+	for k, v := range overrides {
+		base[k] = v
+	}
+	return base
+}
+
+// TestArrayMap_FlowToCallback tests that array.map(cb) flows array elements to callback param.
+func TestArrayMap_FlowToCallback(t *testing.T) {
+	// arr.map(callback): MethodCall(call=500, arrayExpr=400, "map"),
+	// ExprMayRef(400, arraySym=40), CallArg(500, 0, cbExpr=600),
+	// ExprMayRef(600, cbSym=60), FunctionSymbol(60, cbFn=7),
+	// Parameter(7, 0, "item", _, paramSym=70, _).
+	baseRels := higherOrderBaseRels(map[string]*eval.Relation{
+		"MethodCall":     makeRel("MethodCall", 3, iv(500), iv(400), sv("map")),
+		"ExprMayRef":     makeRel("ExprMayRef", 2, iv(400), iv(40), iv(600), iv(60)),
+		"CallArg":        makeRel("CallArg", 3, iv(500), iv(0), iv(600)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(60), iv(7)),
+		"Parameter":      makeRel("Parameter", 6, iv(7), iv(0), sv("item"), iv(80), iv(70), sv("")),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("InterFlow", v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(40), iv(70)) {
+		t.Errorf("expected InterFlow(40, 70) from array.map, got %v", rs.Rows)
+	}
+}
+
+// TestPromiseThen_FlowToCallback tests that promise.then(cb) flows promise value to callback param.
+func TestPromiseThen_FlowToCallback(t *testing.T) {
+	// promise.then(callback): MethodCall(call=500, promiseExpr=400, "then"),
+	// ExprMayRef(400, promiseSym=40), CallArg(500, 0, cbExpr=600),
+	// ExprMayRef(600, cbSym=60), FunctionSymbol(60, cbFn=7),
+	// Parameter(7, 0, "value", _, paramSym=70, _).
+	baseRels := higherOrderBaseRels(map[string]*eval.Relation{
+		"MethodCall":     makeRel("MethodCall", 3, iv(500), iv(400), sv("then")),
+		"ExprMayRef":     makeRel("ExprMayRef", 2, iv(400), iv(40), iv(600), iv(60)),
+		"CallArg":        makeRel("CallArg", 3, iv(500), iv(0), iv(600)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(60), iv(7)),
+		"Parameter":      makeRel("Parameter", 6, iv(7), iv(0), sv("value"), iv(80), iv(70), sv("")),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("InterFlow", v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(40), iv(70)) {
+		t.Errorf("expected InterFlow(40, 70) from promise.then, got %v", rs.Rows)
+	}
+}
+
+// TestNoFlow_WrongMethodName tests that no InterFlow is produced for non-matching method names.
+func TestNoFlow_WrongMethodName(t *testing.T) {
+	// arr.slice(callback) — should NOT produce InterFlow.
+	baseRels := higherOrderBaseRels(map[string]*eval.Relation{
+		"MethodCall":     makeRel("MethodCall", 3, iv(500), iv(400), sv("slice")),
+		"ExprMayRef":     makeRel("ExprMayRef", 2, iv(400), iv(40), iv(600), iv(60)),
+		"CallArg":        makeRel("CallArg", 3, iv(500), iv(0), iv(600)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(60), iv(7)),
+		"Parameter":      makeRel("Parameter", 6, iv(7), iv(0), sv("item"), iv(80), iv(70), sv("")),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("InterFlow", v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	// InterFlow from higher-order rules should not include (40, 70)
+	if resultContains(rs, iv(40), iv(70)) {
+		t.Errorf("expected no InterFlow(40, 70) for slice, got %v", rs.Rows)
+	}
+}
+
+// TestHigherOrderRulesValidate verifies all higher-order rules pass validation.
+func TestHigherOrderRulesValidate(t *testing.T) {
+	for i, r := range HigherOrderRules() {
+		errs := plan.ValidateRule(r)
+		if len(errs) > 0 {
+			t.Errorf("rule %d (%s) validation errors: %v", i, r.Head.Predicate, errs)
+		}
+	}
+}
+
+// TestHigherOrderRulesStratify verifies higher-order rules stratify with all system rules.
+func TestHigherOrderRulesStratify(t *testing.T) {
+	prog := &datalog.Program{Rules: AllSystemRules()}
+	_, errs := plan.Plan(prog, nil)
+	if len(errs) > 0 {
+		t.Fatalf("all system rules (including higher-order) failed to plan: %v", errs)
+	}
+}

--- a/extract/rules/localflow_test.go
+++ b/extract/rules/localflow_test.go
@@ -280,7 +280,9 @@ func TestAllSystemRulesCount(t *testing.T) {
 	sm := SummaryRules()
 	co := CompositionRules()
 	ta := TaintRules()
-	expected := len(cg) + len(lf) + len(sm) + len(co) + len(ta)
+	fw := FrameworkRules()
+	ho := HigherOrderRules()
+	expected := len(cg) + len(lf) + len(sm) + len(co) + len(ta) + len(fw) + len(ho)
 	if len(all) != expected {
 		t.Errorf("expected %d rules, got %d", expected, len(all))
 	}

--- a/extract/rules/merge.go
+++ b/extract/rules/merge.go
@@ -4,7 +4,7 @@ import (
 	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
 )
 
-// AllSystemRules returns all system Datalog rules: call graph + local flow + summaries + composition + taint.
+// AllSystemRules returns all system Datalog rules: call graph + local flow + summaries + composition + taint + frameworks + higher-order.
 func AllSystemRules() []datalog.Rule {
 	var all []datalog.Rule
 	all = append(all, CallGraphRules()...)
@@ -12,6 +12,8 @@ func AllSystemRules() []datalog.Rule {
 	all = append(all, SummaryRules()...)
 	all = append(all, CompositionRules()...)
 	all = append(all, TaintRules()...)
+	all = append(all, FrameworkRules()...)
+	all = append(all, HigherOrderRules()...)
 	return all
 }
 

--- a/extract/rules/summaries_test.go
+++ b/extract/rules/summaries_test.go
@@ -309,7 +309,9 @@ func TestAllSystemRulesCountWithSummaries(t *testing.T) {
 	sm := SummaryRules()
 	co := CompositionRules()
 	ta := TaintRules()
-	expected := len(cg) + len(lf) + len(sm) + len(co) + len(ta)
+	fw := FrameworkRules()
+	ho := HigherOrderRules()
+	expected := len(cg) + len(lf) + len(sm) + len(co) + len(ta) + len(fw) + len(ho)
 	if len(all) != expected {
 		t.Errorf("expected %d rules, got %d", expected, len(all))
 	}

--- a/extract/rules/taint_test.go
+++ b/extract/rules/taint_test.go
@@ -391,7 +391,9 @@ func TestAllSystemRulesCountWithTaint(t *testing.T) {
 	sm := SummaryRules()
 	co := CompositionRules()
 	ta := TaintRules()
-	expected := len(cg) + len(lf) + len(sm) + len(co) + len(ta)
+	fw := FrameworkRules()
+	ho := HigherOrderRules()
+	expected := len(cg) + len(lf) + len(sm) + len(co) + len(ta) + len(fw) + len(ho)
 	if len(all) != expected {
 		t.Errorf("expected %d rules, got %d", expected, len(all))
 	}

--- a/extract/schema/relations.go
+++ b/extract/schema/relations.go
@@ -340,6 +340,11 @@ func init() {
 		{Name: "sinkKind", Type: TypeString},
 	}})
 
+	// v2 Phase F: framework-derived relations
+	RegisterRelation(RelationDef{Name: "ExpressHandler", Version: 2, Columns: []ColumnDef{
+		{Name: "fnId", Type: TypeEntityRef},
+	}})
+
 	// Diagnostics
 	RegisterRelation(RelationDef{Name: "ExtractError", Version: 1, Columns: []ColumnDef{
 		{Name: "file", Type: TypeEntityRef},

--- a/extract/schema/relations_test.go
+++ b/extract/schema/relations_test.go
@@ -34,8 +34,8 @@ func TestAllRelationsRegistered(t *testing.T) {
 }
 
 func TestRelationCount(t *testing.T) {
-	if len(Registry) != 68 {
-		t.Fatalf("expected 68 relations in registry, got %d", len(Registry))
+	if len(Registry) != 69 {
+		t.Fatalf("expected 69 relations in registry, got %d", len(Registry))
 	}
 }
 

--- a/testdata/ts/v2/frameworks/express_app.ts
+++ b/testdata/ts/v2/frameworks/express_app.ts
@@ -1,0 +1,23 @@
+import express from "express";
+
+const app = express();
+
+// GET handler — req.query is a taint source, res.send is a taint sink
+app.get("/search", (req, res) => {
+  const query = req.query.q;  // source: http_input
+  res.send(query);            // sink: xss
+});
+
+// POST handler — req.body is a taint source
+app.post("/submit", (req, res) => {
+  const data = req.body;      // source: http_input
+  res.send(data);             // sink: xss
+});
+
+// req.params source
+app.get("/user/:id", (req, res) => {
+  const id = req.params.id;   // source: http_input
+  res.send(`User ${id}`);     // sink: xss
+});
+
+app.listen(3000);

--- a/testdata/ts/v2/frameworks/higher_order.ts
+++ b/testdata/ts/v2/frameworks/higher_order.ts
@@ -1,0 +1,27 @@
+// Array.map — array elements flow to callback parameter
+const items = [1, 2, 3];
+const doubled = items.map((item) => item * 2);
+
+// Array.forEach — array elements flow to callback parameter
+items.forEach((item) => {
+  console.log(item);
+});
+
+// Array.filter — array elements flow to callback parameter
+const evens = items.filter((item) => item % 2 === 0);
+
+// Array.reduce — array elements flow to callback second parameter
+const sum = items.reduce((acc, item) => acc + item, 0);
+
+// Promise.then — resolved value flows to callback parameter
+const promise = fetch("/api/data");
+promise.then((response) => {
+  return response.json();
+});
+
+// Chained promises
+fetch("/api/data")
+  .then((response) => response.json())
+  .then((data) => {
+    console.log(data);
+  });

--- a/testdata/ts/v2/frameworks/node_fs.ts
+++ b/testdata/ts/v2/frameworks/node_fs.ts
@@ -1,0 +1,16 @@
+import { exec } from "child_process";
+import * as fs from "fs";
+
+// Command injection sink — exec with user input
+function runCommand(userInput: string) {
+  exec(userInput);  // sink: command_injection
+}
+
+// File system operations
+function readFile(path: string) {
+  return fs.readFileSync(path, "utf-8");
+}
+
+function writeFile(path: string, content: string) {
+  fs.writeFileSync(path, content);
+}

--- a/testdata/ts/v2/frameworks/react_component.tsx
+++ b/testdata/ts/v2/frameworks/react_component.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+interface Props {
+  userContent: string;
+}
+
+// XSS via dangerouslySetInnerHTML
+function UnsafeComponent({ userContent }: Props) {
+  return (
+    <div dangerouslySetInnerHTML={{ __html: userContent }} />
+  );
+}
+
+// Safe component — no dangerouslySetInnerHTML
+function SafeComponent({ userContent }: Props) {
+  return <div>{userContent}</div>;
+}
+
+export { UnsafeComponent, SafeComponent };


### PR DESCRIPTION
## Summary

- Add Express.js framework models: `ExpressHandler` detection from `app.get/post/put/delete/use/patch`, taint sources from `req.query/params/body`, taint sink from `res.send`
- Add Node.js sink: `child_process.exec` as command injection sink
- Add React XSS sink: `dangerouslySetInnerHTML` JSX attribute
- Add higher-order function flow models: `Array.map/forEach/filter/reduce` and `Promise.then` callback parameter flow via `InterFlow` rules
- New `ExpressHandler` schema relation (arity 1, derived)
- Bridge QLL files: `tsq_express.qll`, `tsq_react.qll`, `tsq_node.qll`
- Test fixtures in `testdata/ts/v2/frameworks/`

All rules are pattern-based heuristics matching on function/method names — the right trade-off for v2.

## Test plan

- [x] Express handler detected from `app.get` pattern
- [x] `req.query` produces `TaintSource("http_input")`
- [x] `res.send` produces `TaintSink("xss")`
- [x] `child_process.exec` produces `TaintSink("command_injection")`
- [x] `dangerouslySetInnerHTML` produces `TaintSink("xss")`
- [x] `Array.map` flows array elements to callback param via `InterFlow`
- [x] `Promise.then` flows promise value to callback param via `InterFlow`
- [x] No flow produced for non-matching method names (e.g. `slice`)
- [x] All rules pass validation and stratification
- [x] Full test suite passes (`go test ./... -count=1`)