### PR TITLE
feat: CodeQL compatibility phases 1a-1d

### DIFF
--- a/ql/ast/ast.go
+++ b/ql/ast/ast.go
@@ -15,7 +15,17 @@ type Module struct {
 	Imports    []ImportDecl
 	Classes    []ClassDecl
 	Predicates []PredicateDecl
+	Modules    []ModuleDecl
 	Select     *SelectClause // nil for library modules (.qll)
+	Span       Span
+}
+
+// ModuleDecl represents a QL module declaration.
+type ModuleDecl struct {
+	Name       string
+	Classes    []ClassDecl
+	Predicates []PredicateDecl
+	Modules    []ModuleDecl // nested modules
 	Span       Span
 }
 
@@ -29,6 +39,7 @@ type ImportDecl struct {
 // ClassDecl represents a QL class declaration.
 type ClassDecl struct {
 	Name       string
+	IsAbstract bool      // true for `abstract class`
 	SuperTypes []TypeRef // types listed in `extends` clause
 	CharPred   *Formula  // characteristic predicate body (the Foo() { ... } block)
 	Members    []MemberDecl

--- a/ql/desugar/desugar.go
+++ b/ql/desugar/desugar.go
@@ -94,7 +94,13 @@ func (d *desugarer) buildSubclassMapForModule(md *ast.ModuleDecl, prefix string)
 		qualName := qualPrefix + "::" + cd.Name
 		for _, st := range cd.SuperTypes {
 			stName := st.String()
+			// If the supertype is unqualified and exists within this same module,
+			// register under the qualified name too so abstract class lookup works.
 			d.subClasses[stName] = append(d.subClasses[stName], qualName)
+			qualSuperName := qualPrefix + "::" + stName
+			if qualSuperName != stName {
+				d.subClasses[qualSuperName] = append(d.subClasses[qualSuperName], qualName)
+			}
 		}
 	}
 	for i := range md.Modules {
@@ -218,19 +224,8 @@ func (d *desugarer) desugarClass(cd *ast.ClassDecl) []datalog.Rule {
 			}
 			rules = append(rules, rule)
 		}
-		// If no subclasses, emit a rule with no body (empty extent).
-		if len(subclasses) == 0 {
-			rules = append(rules, datalog.Rule{
-				Head: datalog.Atom{
-					Predicate: cd.Name,
-					Args:      []datalog.Term{datalog.Var{Name: "this"}},
-				},
-				Body: []datalog.Literal{{
-					Positive: false,
-					Atom:     datalog.Atom{Predicate: "_none", Args: nil},
-				}},
-			})
-		}
+		// If no subclasses, emit no rules — the abstract class has an empty extent.
+		// No synthetic "_none" sentinel needed; an underived predicate is naturally empty.
 	} else {
 		// Characteristic predicate: Foo(this) :- SuperTypes(this)..., body.
 		gen := &freshVarGen{}
@@ -507,8 +502,11 @@ func (d *desugarer) desugarFormula(f ast.Formula, gen *freshVarGen) []datalog.Li
 		leftLits := d.desugarFormula(n.Left, gen)
 		rightLits := d.desugarFormula(n.Right, gen)
 
-		// Collect all variables from both branches to use as head args.
-		freeVars := collectVarsFromLiterals(append(leftLits, rightLits...))
+		// Use only variables that appear in BOTH branches as head args.
+		// Variables in only one branch are unsafe in the other rule's head.
+		leftVars := collectVarsFromLiterals(leftLits)
+		rightVars := collectVarsFromLiterals(rightLits)
+		freeVars := intersectVars(leftVars, rightVars)
 
 		synthName := d.freshSynthName("_disj")
 		args := make([]datalog.Term, len(freeVars))
@@ -1011,6 +1009,21 @@ func collectVarFromTerm(t datalog.Term, seen map[string]bool, vars *[]string) {
 			*vars = append(*vars, v.Name)
 		}
 	}
+}
+
+// intersectVars returns variables present in both a and b, preserving order from a.
+func intersectVars(a, b []string) []string {
+	bSet := make(map[string]bool, len(b))
+	for _, v := range b {
+		bSet[v] = true
+	}
+	var result []string
+	for _, v := range a {
+		if bSet[v] {
+			result = append(result, v)
+		}
+	}
+	return result
 }
 
 // allConcreteSubclasses returns all transitive subclass names that are not abstract.

--- a/ql/desugar/desugar.go
+++ b/ql/desugar/desugar.go
@@ -38,10 +38,20 @@ type desugarer struct {
 	errors []error
 	// subClasses maps class name → names of classes that directly extend it.
 	subClasses map[string][]string
+	// syntheticRules accumulates rules generated for disjunction/negation.
+	syntheticRules []datalog.Rule
+	// synthCounter generates unique names for synthetic predicates.
+	synthCounter int
 }
 
 func (d *desugarer) errorf(format string, args ...interface{}) {
 	d.errors = append(d.errors, fmt.Errorf(format, args...))
+}
+
+// freshSynthName generates a unique synthetic predicate name with the given prefix.
+func (d *desugarer) freshSynthName(prefix string) string {
+	d.synthCounter++
+	return fmt.Sprintf("%s_%d", prefix, d.synthCounter)
 }
 
 // buildSubclassMap builds the direct subclass relationship from the AST.
@@ -67,6 +77,28 @@ func (d *desugarer) buildSubclassMap() {
 			stName := st.String()
 			d.subClasses[stName] = append(d.subClasses[stName], cd.Name)
 		}
+	}
+	// Include module-scoped classes in the subclass map.
+	for i := range d.mod.AST.Modules {
+		d.buildSubclassMapForModule(&d.mod.AST.Modules[i], "")
+	}
+}
+
+func (d *desugarer) buildSubclassMapForModule(md *ast.ModuleDecl, prefix string) {
+	qualPrefix := md.Name
+	if prefix != "" {
+		qualPrefix = prefix + "::" + md.Name
+	}
+	for i := range md.Classes {
+		cd := &md.Classes[i]
+		qualName := qualPrefix + "::" + cd.Name
+		for _, st := range cd.SuperTypes {
+			stName := st.String()
+			d.subClasses[stName] = append(d.subClasses[stName], qualName)
+		}
+	}
+	for i := range md.Modules {
+		d.buildSubclassMapForModule(&md.Modules[i], qualPrefix)
 	}
 }
 
@@ -108,13 +140,56 @@ func (d *desugarer) run() (*datalog.Program, []error) {
 		prog.Rules = append(prog.Rules, rules...)
 	}
 
+	// Desugar module declarations.
+	for i := range d.mod.AST.Modules {
+		rules := d.desugarModuleDecl(&d.mod.AST.Modules[i], "")
+		prog.Rules = append(prog.Rules, rules...)
+	}
+
 	// Desugar select clause.
 	if d.mod.AST.Select != nil {
 		q := d.desugarSelect(d.mod.AST.Select)
 		prog.Query = q
 	}
 
+	// Append synthetic rules generated during desugaring (disjunction/negation).
+	prog.Rules = append(prog.Rules, d.syntheticRules...)
+
 	return prog, d.errors
+}
+
+// desugarModuleDecl desugars all classes and predicates inside a module declaration.
+func (d *desugarer) desugarModuleDecl(md *ast.ModuleDecl, prefix string) []datalog.Rule {
+	var rules []datalog.Rule
+	qualPrefix := md.Name
+	if prefix != "" {
+		qualPrefix = prefix + "::" + md.Name
+	}
+
+	for i := range md.Classes {
+		cd := &md.Classes[i]
+		// Temporarily set the class name to the qualified name for desugaring.
+		origName := cd.Name
+		cd.Name = qualPrefix + "::" + origName
+		classRules := d.desugarClass(cd)
+		cd.Name = origName
+		rules = append(rules, classRules...)
+	}
+
+	for i := range md.Predicates {
+		pd := &md.Predicates[i]
+		origName := pd.Name
+		pd.Name = qualPrefix + "::" + origName
+		predRules := d.desugarTopLevelPredicate(pd)
+		pd.Name = origName
+		rules = append(rules, predRules...)
+	}
+
+	for i := range md.Modules {
+		rules = append(rules, d.desugarModuleDecl(&md.Modules[i], qualPrefix)...)
+	}
+
+	return rules
 }
 
 // ---- Class desugaring ----
@@ -123,8 +198,41 @@ func (d *desugarer) run() (*datalog.Program, []error) {
 func (d *desugarer) desugarClass(cd *ast.ClassDecl) []datalog.Rule {
 	var rules []datalog.Rule
 
-	// Characteristic predicate: Foo(this) :- SuperTypes(this)..., body.
-	{
+	if cd.IsAbstract {
+		// Abstract class: emit one rule per concrete subclass.
+		// AbstractClass(this) :- ConcreteSubclass(this) for each subclass.
+		subclasses := d.allConcreteSubclasses(cd.Name)
+		for _, subName := range subclasses {
+			rule := datalog.Rule{
+				Head: datalog.Atom{
+					Predicate: cd.Name,
+					Args:      []datalog.Term{datalog.Var{Name: "this"}},
+				},
+				Body: []datalog.Literal{{
+					Positive: true,
+					Atom: datalog.Atom{
+						Predicate: subName,
+						Args:      []datalog.Term{datalog.Var{Name: "this"}},
+					},
+				}},
+			}
+			rules = append(rules, rule)
+		}
+		// If no subclasses, emit a rule with no body (empty extent).
+		if len(subclasses) == 0 {
+			rules = append(rules, datalog.Rule{
+				Head: datalog.Atom{
+					Predicate: cd.Name,
+					Args:      []datalog.Term{datalog.Var{Name: "this"}},
+				},
+				Body: []datalog.Literal{{
+					Positive: false,
+					Atom:     datalog.Atom{Predicate: "_none", Args: nil},
+				}},
+			})
+		}
+	} else {
+		// Characteristic predicate: Foo(this) :- SuperTypes(this)..., body.
 		gen := &freshVarGen{}
 		body := d.superTypeConstraints(cd, gen)
 		if cd.CharPred != nil {
@@ -395,12 +503,31 @@ func (d *desugarer) desugarFormula(f ast.Formula, gen *freshVarGen) []datalog.Li
 		return append(left, right...)
 
 	case *ast.Disjunction:
-		// Datalog doesn't natively support disjunction in rule bodies without rule
-		// splitting.  Emit an error rather than silently evaluating only the left branch.
-		d.errorf("disjunction (or) is not yet supported in v1 — only the left branch will be evaluated")
-		left := d.desugarFormula(n.Left, gen)
-		_ = n.Right
-		return left
+		// Rule splitting: create a synthetic predicate with both branches as separate rules.
+		leftLits := d.desugarFormula(n.Left, gen)
+		rightLits := d.desugarFormula(n.Right, gen)
+
+		// Collect all variables from both branches to use as head args.
+		freeVars := collectVarsFromLiterals(append(leftLits, rightLits...))
+
+		synthName := d.freshSynthName("_disj")
+		args := make([]datalog.Term, len(freeVars))
+		for i, v := range freeVars {
+			args[i] = datalog.Var{Name: v}
+		}
+
+		// Create two rules: one for left branch, one for right branch.
+		head := datalog.Atom{Predicate: synthName, Args: args}
+		d.syntheticRules = append(d.syntheticRules,
+			datalog.Rule{Head: head, Body: leftLits},
+			datalog.Rule{Head: head, Body: rightLits},
+		)
+
+		// Return a call to the synthetic predicate.
+		return []datalog.Literal{{
+			Positive: true,
+			Atom:     datalog.Atom{Predicate: synthName, Args: args},
+		}}
 
 	case *ast.Negation:
 		inner := d.desugarFormula(n.Formula, gen)
@@ -409,11 +536,25 @@ func (d *desugarer) desugarFormula(f ast.Formula, gen *freshVarGen) []datalog.Li
 			lit.Positive = !lit.Positive
 			return []datalog.Literal{lit}
 		}
-		// Multiple literals: negating a conjunction requires De Morgan / rule splitting,
-		// which is not supported in v1.  Emit an error rather than silently producing
-		// wrong results (not A, not B instead of the correct not A or not B).
-		d.errorf("negation of conjunction not yet supported — only single-literal negation is supported in v1")
-		return nil
+		// Multiple literals: create a helper predicate and negate it.
+		freeVars := collectVarsFromLiterals(inner)
+
+		synthName := d.freshSynthName("_neg")
+		args := make([]datalog.Term, len(freeVars))
+		for i, v := range freeVars {
+			args[i] = datalog.Var{Name: v}
+		}
+
+		head := datalog.Atom{Predicate: synthName, Args: args}
+		d.syntheticRules = append(d.syntheticRules,
+			datalog.Rule{Head: head, Body: inner},
+		)
+
+		// Return negated call to the helper.
+		return []datalog.Literal{{
+			Positive: false,
+			Atom:     datalog.Atom{Predicate: synthName, Args: args},
+		}}
 
 	case *ast.Comparison:
 		left, leftLits := d.desugarExpr(n.Left, gen)
@@ -837,6 +978,64 @@ func (d *desugarer) desugarAggregateExpr(a *ast.Aggregate, gen *freshVarGen) (da
 }
 
 // ---- Helpers ----
+
+// collectVarsFromLiterals collects all unique Var names from a slice of literals.
+func collectVarsFromLiterals(lits []datalog.Literal) []string {
+	seen := make(map[string]bool)
+	var vars []string
+	for _, lit := range lits {
+		collectVarsFromAtom(lit.Atom, seen, &vars)
+		if lit.Cmp != nil {
+			collectVarFromTerm(lit.Cmp.Left, seen, &vars)
+			collectVarFromTerm(lit.Cmp.Right, seen, &vars)
+		}
+		if lit.Agg != nil {
+			for _, innerLit := range lit.Agg.Body {
+				collectVarsFromAtom(innerLit.Atom, seen, &vars)
+			}
+		}
+	}
+	return vars
+}
+
+func collectVarsFromAtom(a datalog.Atom, seen map[string]bool, vars *[]string) {
+	for _, arg := range a.Args {
+		collectVarFromTerm(arg, seen, vars)
+	}
+}
+
+func collectVarFromTerm(t datalog.Term, seen map[string]bool, vars *[]string) {
+	if v, ok := t.(datalog.Var); ok && v.Name != "" {
+		if !seen[v.Name] {
+			seen[v.Name] = true
+			*vars = append(*vars, v.Name)
+		}
+	}
+}
+
+// allConcreteSubclasses returns all transitive subclass names that are not abstract.
+func (d *desugarer) allConcreteSubclasses(className string) []string {
+	var result []string
+	visited := make(map[string]bool)
+	d.collectConcreteSubclasses(className, &result, visited)
+	return result
+}
+
+func (d *desugarer) collectConcreteSubclasses(className string, out *[]string, visited map[string]bool) {
+	for _, subName := range d.subClasses[className] {
+		if visited[subName] {
+			continue
+		}
+		visited[subName] = true
+		// Check if subclass is abstract.
+		if cd, ok := d.env.Classes[subName]; ok && cd.IsAbstract {
+			// Recurse into abstract subclass to find its concrete subclasses.
+			d.collectConcreteSubclasses(subName, out, visited)
+		} else {
+			*out = append(*out, subName)
+		}
+	}
+}
 
 // isPrimitive returns true for built-in scalar types that don't have class predicates.
 func isPrimitive(typeName string) bool {

--- a/ql/desugar/desugar_test.go
+++ b/ql/desugar/desugar_test.go
@@ -766,6 +766,205 @@ int countFoos(Foo f) { result = 0 }
 	}
 }
 
+// --- Phase 1b: Disjunction via rule splitting ---
+
+func TestDesugarDisjunction(t *testing.T) {
+	src := `
+class Foo { Foo() { any() } }
+predicate test(Foo x) { a(x) or b(x) }
+`
+	rm := parseAndResolve(t, src)
+	prog, errs := desugar.Desugar(rm)
+	// Should NOT produce "disjunction not supported" error anymore.
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "disjunction") {
+			t.Fatalf("unexpected disjunction error: %v", e)
+		}
+	}
+
+	// Should have synthetic _disj rules.
+	var disjRules []*datalog.Rule
+	for i := range prog.Rules {
+		if strings.HasPrefix(prog.Rules[i].Head.Predicate, "_disj") {
+			disjRules = append(disjRules, &prog.Rules[i])
+		}
+	}
+	if len(disjRules) != 2 {
+		t.Fatalf("expected 2 synthetic disjunction rules, got %d", len(disjRules))
+	}
+
+	// The test predicate's body should reference the synthetic predicate.
+	r := findRuleExact(prog, "test")
+	if r == nil {
+		t.Fatal("expected rule 'test'")
+	}
+	hasDisjCall := false
+	for _, lit := range r.Body {
+		if strings.HasPrefix(lit.Atom.Predicate, "_disj") {
+			hasDisjCall = true
+		}
+	}
+	if !hasDisjCall {
+		t.Errorf("test rule body should call _disj synthetic predicate, body: %v", r.Body)
+	}
+}
+
+func TestDesugarDisjunctionInClass(t *testing.T) {
+	src := `
+class Foo {
+	Foo() { any() }
+	predicate isAorB() { a(this) or b(this) }
+}
+`
+	rm := parseAndResolve(t, src)
+	prog, errs := desugar.Desugar(rm)
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "disjunction") {
+			t.Fatalf("unexpected disjunction error: %v", e)
+		}
+	}
+
+	// Should have synthetic rules.
+	hasSynth := false
+	for i := range prog.Rules {
+		if strings.HasPrefix(prog.Rules[i].Head.Predicate, "_disj") {
+			hasSynth = true
+			break
+		}
+	}
+	if !hasSynth {
+		t.Error("expected synthetic _disj rules")
+	}
+}
+
+// --- Phase 1c: Negation of conjunctions ---
+
+func TestDesugarNegationOfConjunction(t *testing.T) {
+	src := `
+class Foo { Foo() { any() } }
+predicate test(Foo x) { not (a(x) and b(x)) }
+`
+	rm := parseAndResolve(t, src)
+	prog, errs := desugar.Desugar(rm)
+	// Should NOT produce "negation of conjunction not supported" error.
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "negation of conjunction") {
+			t.Fatalf("unexpected negation error: %v", e)
+		}
+	}
+
+	// Should have a synthetic _neg rule.
+	var negRules []*datalog.Rule
+	for i := range prog.Rules {
+		if strings.HasPrefix(prog.Rules[i].Head.Predicate, "_neg") {
+			negRules = append(negRules, &prog.Rules[i])
+		}
+	}
+	if len(negRules) != 1 {
+		t.Fatalf("expected 1 synthetic _neg rule, got %d", len(negRules))
+	}
+
+	// The test predicate's body should have a negated reference to _neg.
+	r := findRuleExact(prog, "test")
+	if r == nil {
+		t.Fatal("expected rule 'test'")
+	}
+	hasNegCall := false
+	for _, lit := range r.Body {
+		if !lit.Positive && strings.HasPrefix(lit.Atom.Predicate, "_neg") {
+			hasNegCall = true
+		}
+	}
+	if !hasNegCall {
+		t.Errorf("test rule body should have negated _neg call, body: %v", r.Body)
+	}
+}
+
+// --- Phase 1d: Abstract classes ---
+
+func TestDesugarAbstractClass(t *testing.T) {
+	src := `
+abstract class Base { Base() { any() } }
+class ConcreteA extends Base { ConcreteA() { any() } }
+class ConcreteB extends Base { ConcreteB() { any() } }
+`
+	rm := parseAndResolve(t, src)
+	prog := desugarOK(t, rm)
+
+	// Base should have rules: Base(this) :- ConcreteA(this). and Base(this) :- ConcreteB(this).
+	var baseRules []*datalog.Rule
+	for i := range prog.Rules {
+		if prog.Rules[i].Head.Predicate == "Base" {
+			baseRules = append(baseRules, &prog.Rules[i])
+		}
+	}
+	if len(baseRules) != 2 {
+		t.Fatalf("expected 2 rules for abstract class Base (one per subclass), got %d", len(baseRules))
+	}
+
+	hasA := false
+	hasB := false
+	for _, r := range baseRules {
+		if bodyContainsPred(r.Body, "ConcreteA") {
+			hasA = true
+		}
+		if bodyContainsPred(r.Body, "ConcreteB") {
+			hasB = true
+		}
+	}
+	if !hasA {
+		t.Error("expected Base rule with ConcreteA(this)")
+	}
+	if !hasB {
+		t.Error("expected Base rule with ConcreteB(this)")
+	}
+}
+
+func TestDesugarAbstractClassNoSubclasses(t *testing.T) {
+	src := `abstract class Lonely { Lonely() { any() } }`
+	rm := parseAndResolve(t, src)
+	prog := desugarOK(t, rm)
+
+	// Should still produce a rule for Lonely (empty extent).
+	r := findRuleExact(prog, "Lonely")
+	if r == nil {
+		t.Fatal("expected rule for abstract class Lonely even with no subclasses")
+	}
+}
+
+func TestDesugarAbstractClassMethodsStillWork(t *testing.T) {
+	src := `
+abstract class Base { Base() { any() } int getX() { result = 1 } }
+class Sub extends Base { Sub() { any() } }
+`
+	rm := parseAndResolve(t, src)
+	prog := desugarOK(t, rm)
+
+	// Method rule should still be emitted.
+	r := findRule(prog, "Base_getX")
+	if r == nil {
+		t.Fatal("expected Base_getX method rule for abstract class")
+	}
+}
+
+// --- Phase 1a: Module desugaring ---
+
+func TestDesugarModuleClass(t *testing.T) {
+	src := `
+module DataFlow {
+	class Node extends @node { Node() { any() } }
+}
+`
+	rm := parseAndResolve(t, src)
+	prog := desugarOK(t, rm)
+
+	// Should produce a rule with qualified name DataFlow::Node.
+	r := findRuleExact(prog, "DataFlow::Node")
+	if r == nil {
+		t.Fatal("expected rule for DataFlow::Node")
+	}
+}
+
 // 25. Program.String() roundtrip: output is non-empty and contains predicate names.
 func TestDesugarProgramString(t *testing.T) {
 	src := `

--- a/ql/desugar/desugar_test.go
+++ b/ql/desugar/desugar_test.go
@@ -925,10 +925,11 @@ func TestDesugarAbstractClassNoSubclasses(t *testing.T) {
 	rm := parseAndResolve(t, src)
 	prog := desugarOK(t, rm)
 
-	// Should still produce a rule for Lonely (empty extent).
+	// With no concrete subclasses, the abstract class has no derivation rules
+	// and its extent is naturally empty (no rules = empty relation).
 	r := findRuleExact(prog, "Lonely")
-	if r == nil {
-		t.Fatal("expected rule for abstract class Lonely even with no subclasses")
+	if r != nil {
+		t.Fatal("expected no rule for abstract class with no subclasses")
 	}
 }
 
@@ -986,5 +987,63 @@ class Bar extends Foo {
 	}
 	if !strings.Contains(str, "Bar") {
 		t.Errorf("String() should contain 'Bar': %q", str)
+	}
+}
+
+// --- Adversarial regression tests ---
+
+// Disjunction with asymmetric variables: only shared vars go in the head.
+func TestDesugarDisjunctionAsymmetricVars(t *testing.T) {
+	src := `
+predicate a(int x, int y) { any() }
+predicate b(int x) { any() }
+predicate test(int x) { a(x, _) or b(x) }
+`
+	rm := parseAndResolve(t, src)
+	prog := desugarOK(t, rm)
+
+	// Find the synthetic disjunction rule.
+	var synthRules []*datalog.Rule
+	for i := range prog.Rules {
+		if strings.HasPrefix(prog.Rules[i].Head.Predicate, "_disj") {
+			synthRules = append(synthRules, &prog.Rules[i])
+		}
+	}
+	if len(synthRules) != 2 {
+		t.Fatalf("expected 2 synthetic disjunction rules, got %d", len(synthRules))
+	}
+	// Head args should only contain x (the shared variable), not y or _.
+	for _, r := range synthRules {
+		for _, arg := range r.Head.Args {
+			if v, ok := arg.(datalog.Var); ok && v.Name != "x" {
+				t.Errorf("synthetic disjunction head should only have shared var x, got %q", v.Name)
+			}
+		}
+	}
+}
+
+// Abstract class in module: subclass lookup uses qualified names.
+func TestDesugarAbstractClassInModule(t *testing.T) {
+	src := `
+module M {
+	abstract class Base { Base() { any() } }
+	class Sub extends Base { Sub() { any() } }
+}
+`
+	rm := parseAndResolve(t, src)
+	prog := desugarOK(t, rm)
+
+	// M::Base should have a rule: M::Base(this) :- M::Sub(this).
+	var baseRules []*datalog.Rule
+	for i := range prog.Rules {
+		if prog.Rules[i].Head.Predicate == "M::Base" {
+			baseRules = append(baseRules, &prog.Rules[i])
+		}
+	}
+	if len(baseRules) != 1 {
+		t.Fatalf("expected 1 rule for M::Base (from M::Sub), got %d", len(baseRules))
+	}
+	if !bodyContainsPred(baseRules[0].Body, "M::Sub") {
+		t.Error("expected M::Base rule body to contain M::Sub")
 	}
 }

--- a/ql/parse/lexer.go
+++ b/ql/parse/lexer.go
@@ -62,6 +62,8 @@ const (
 	TokKwFalse
 	TokKwOverride
 	TokKwAbstract
+	TokKwModule
+	TokKwPrivate
 	TokKwCount
 	TokKwMin
 	TokKwMax
@@ -95,6 +97,8 @@ var keywords = map[string]TokenType{
 	"false":      TokKwFalse,
 	"override":   TokKwOverride,
 	"abstract":   TokKwAbstract,
+	"module":     TokKwModule,
+	"private":    TokKwPrivate,
 	"count":      TokKwCount,
 	"min":        TokKwMin,
 	"max":        TokKwMax,

--- a/ql/parse/parse_test.go
+++ b/ql/parse/parse_test.go
@@ -839,3 +839,127 @@ func TestAtTypeWithOtherKeywords(t *testing.T) {
 		})
 	}
 }
+
+// --- Phase 1a: Module declarations ---
+
+func TestModuleDeclaration(t *testing.T) {
+	src := `module DataFlow {
+		class Node extends @node {
+			Node() { any() }
+		}
+		predicate isSource(Node n) { any() }
+	}`
+	mod := mustParse(t, src)
+	if len(mod.Modules) != 1 {
+		t.Fatalf("expected 1 module, got %d", len(mod.Modules))
+	}
+	m := mod.Modules[0]
+	if m.Name != "DataFlow" {
+		t.Errorf("expected module name 'DataFlow', got %q", m.Name)
+	}
+	if len(m.Classes) != 1 {
+		t.Fatalf("expected 1 class in module, got %d", len(m.Classes))
+	}
+	if m.Classes[0].Name != "Node" {
+		t.Errorf("expected class name 'Node', got %q", m.Classes[0].Name)
+	}
+	if len(m.Predicates) != 1 {
+		t.Fatalf("expected 1 predicate in module, got %d", len(m.Predicates))
+	}
+	if m.Predicates[0].Name != "isSource" {
+		t.Errorf("expected predicate name 'isSource', got %q", m.Predicates[0].Name)
+	}
+}
+
+func TestNestedModuleDeclaration(t *testing.T) {
+	src := `module Outer {
+		module Inner {
+			class Foo extends @foo { Foo() { any() } }
+		}
+	}`
+	mod := mustParse(t, src)
+	if len(mod.Modules) != 1 {
+		t.Fatalf("expected 1 module, got %d", len(mod.Modules))
+	}
+	outer := mod.Modules[0]
+	if len(outer.Modules) != 1 {
+		t.Fatalf("expected 1 nested module, got %d", len(outer.Modules))
+	}
+	inner := outer.Modules[0]
+	if inner.Name != "Inner" {
+		t.Errorf("expected nested module name 'Inner', got %q", inner.Name)
+	}
+	if len(inner.Classes) != 1 {
+		t.Fatalf("expected 1 class in nested module, got %d", len(inner.Classes))
+	}
+}
+
+func TestQualifiedAccessInQuery(t *testing.T) {
+	src := `module DataFlow {
+		class Node extends @node { Node() { any() } }
+	}
+	from DataFlow::Node n
+	select n`
+	mod := mustParse(t, src)
+	if mod.Select == nil {
+		t.Fatal("expected select clause")
+	}
+	if len(mod.Select.Decls) != 1 {
+		t.Fatalf("expected 1 decl, got %d", len(mod.Select.Decls))
+	}
+	if mod.Select.Decls[0].Type.String() != "DataFlow::Node" {
+		t.Errorf("expected type DataFlow::Node, got %q", mod.Select.Decls[0].Type.String())
+	}
+}
+
+// --- Phase 1d: Abstract classes ---
+
+func TestAbstractClass(t *testing.T) {
+	src := `abstract class Foo extends Bar { Foo() { any() } }`
+	mod := mustParse(t, src)
+	if len(mod.Classes) != 1 {
+		t.Fatalf("expected 1 class, got %d", len(mod.Classes))
+	}
+	cls := mod.Classes[0]
+	if !cls.IsAbstract {
+		t.Error("expected IsAbstract=true")
+	}
+	if cls.Name != "Foo" {
+		t.Errorf("expected name 'Foo', got %q", cls.Name)
+	}
+}
+
+func TestAbstractClassInModule(t *testing.T) {
+	src := `module M {
+		abstract class Base extends @base { Base() { any() } }
+		class Concrete extends Base { Concrete() { any() } }
+	}`
+	mod := mustParse(t, src)
+	if len(mod.Modules) != 1 {
+		t.Fatalf("expected 1 module, got %d", len(mod.Modules))
+	}
+	m := mod.Modules[0]
+	if len(m.Classes) != 2 {
+		t.Fatalf("expected 2 classes in module, got %d", len(m.Classes))
+	}
+	if !m.Classes[0].IsAbstract {
+		t.Error("expected first class to be abstract")
+	}
+	if m.Classes[1].IsAbstract {
+		t.Error("expected second class to NOT be abstract")
+	}
+}
+
+// --- Lexer: module and private keywords ---
+
+func TestLexerModulePrivateKeywords(t *testing.T) {
+	l := parse.NewLexer("module private", "test.ql")
+	tok := l.Next()
+	if tok.Type != parse.TokKwModule {
+		t.Errorf("expected TokKwModule, got %d (lit=%q)", tok.Type, tok.Lit)
+	}
+	tok = l.Next()
+	if tok.Type != parse.TokKwPrivate {
+		t.Errorf("expected TokKwPrivate, got %d (lit=%q)", tok.Type, tok.Lit)
+	}
+}

--- a/ql/parse/parser.go
+++ b/ql/parse/parser.go
@@ -108,12 +108,25 @@ func (p *Parser) Parse() (*ast.Module, error) {
 				return nil, err
 			}
 			mod.Imports = append(mod.Imports, *imp)
+		case TokKwAbstract:
+			// abstract class ...
+			cls, err := p.parseAbstractClass()
+			if err != nil {
+				return nil, err
+			}
+			mod.Classes = append(mod.Classes, *cls)
 		case TokKwClass:
 			cls, err := p.parseClass()
 			if err != nil {
 				return nil, err
 			}
 			mod.Classes = append(mod.Classes, *cls)
+		case TokKwModule:
+			m, err := p.parseModule()
+			if err != nil {
+				return nil, err
+			}
+			mod.Modules = append(mod.Modules, *m)
 		case TokKwPredicate:
 			pred, err := p.parsePredicate()
 			if err != nil {
@@ -242,6 +255,83 @@ func (p *Parser) parseClass() (*ast.ClassDecl, error) {
 	cls.Span.EndLine = end.Line
 	cls.Span.EndCol = end.Col
 	return cls, nil
+}
+
+// parseAbstractClass parses: abstract class Name extends ... { ... }
+func (p *Parser) parseAbstractClass() (*ast.ClassDecl, error) {
+	p.advance() // consume 'abstract'
+	if !p.at(TokKwClass) {
+		return nil, p.errorf("expected 'class' after 'abstract', got %q", p.current.Lit)
+	}
+	cls, err := p.parseClass()
+	if err != nil {
+		return nil, err
+	}
+	cls.IsAbstract = true
+	return cls, nil
+}
+
+// parseModule parses: module Name { <classes, predicates, nested modules> }
+func (p *Parser) parseModule() (*ast.ModuleDecl, error) {
+	tok, _ := p.expect(TokKwModule)
+	m := &ast.ModuleDecl{
+		Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col},
+	}
+
+	name, err := p.expect(TokIdent)
+	if err != nil {
+		return nil, err
+	}
+	m.Name = name.Lit
+
+	if _, err := p.expect(TokLBrace); err != nil {
+		return nil, err
+	}
+
+	for !p.at(TokRBrace) && !p.at(TokEOF) {
+		switch p.current.Type {
+		case TokKwAbstract:
+			cls, err := p.parseAbstractClass()
+			if err != nil {
+				return nil, err
+			}
+			m.Classes = append(m.Classes, *cls)
+		case TokKwClass:
+			cls, err := p.parseClass()
+			if err != nil {
+				return nil, err
+			}
+			m.Classes = append(m.Classes, *cls)
+		case TokKwPredicate:
+			pred, err := p.parsePredicate()
+			if err != nil {
+				return nil, err
+			}
+			m.Predicates = append(m.Predicates, *pred)
+		case TokKwModule:
+			nested, err := p.parseModule()
+			if err != nil {
+				return nil, err
+			}
+			m.Modules = append(m.Modules, *nested)
+		case TokIdent:
+			pred, err := p.parseTypedPredicate()
+			if err != nil {
+				return nil, err
+			}
+			m.Predicates = append(m.Predicates, *pred)
+		default:
+			return nil, p.errorf("unexpected token %q in module body", p.current.Lit)
+		}
+	}
+
+	end, err := p.expect(TokRBrace)
+	if err != nil {
+		return nil, err
+	}
+	m.Span.EndLine = end.Line
+	m.Span.EndCol = end.Col
+	return m, nil
 }
 
 func (p *Parser) parseClassMember(className string) (*ast.MemberDecl, bool, error) {

--- a/ql/resolve/resolve.go
+++ b/ql/resolve/resolve.go
@@ -21,6 +21,7 @@ type Environment struct {
 	Predicates map[string]*ast.PredicateDecl
 	Classes    map[string]*ast.ClassDecl
 	Imports    map[string]*ResolvedModule
+	Modules    map[string]*ast.ModuleDecl
 }
 
 // Error describes a name resolution failure.
@@ -80,6 +81,7 @@ func Resolve(mod *ast.Module, importLoader func(path string) (*ast.Module, error
 		Predicates: make(map[string]*ast.PredicateDecl),
 		Classes:    make(map[string]*ast.ClassDecl),
 		Imports:    make(map[string]*ResolvedModule),
+		Modules:    make(map[string]*ast.ModuleDecl),
 	}
 	ann := &Annotations{
 		ExprResolutions: make(map[ast.Expr]*Resolution),
@@ -170,6 +172,41 @@ func (r *resolver) firstPass(mod *ast.Module) {
 		} else {
 			r.env.Predicates[pd.Name] = pd
 		}
+	}
+	// Register module declarations and their members with qualified names.
+	for i := range mod.Modules {
+		md := &mod.Modules[i]
+		r.registerModule(md, "")
+	}
+}
+
+// registerModule registers a module and its contents with qualified names.
+func (r *resolver) registerModule(md *ast.ModuleDecl, prefix string) {
+	qualName := md.Name
+	if prefix != "" {
+		qualName = prefix + "::" + md.Name
+	}
+	r.env.Modules[qualName] = md
+
+	// Register classes with qualified names.
+	for i := range md.Classes {
+		cd := &md.Classes[i]
+		qn := qualName + "::" + cd.Name
+		if _, dup := r.env.Classes[qn]; !dup {
+			r.env.Classes[qn] = cd
+		}
+	}
+	// Register predicates with qualified names.
+	for i := range md.Predicates {
+		pd := &md.Predicates[i]
+		qn := qualName + "::" + pd.Name
+		if _, dup := r.env.Predicates[qn]; !dup {
+			r.env.Predicates[qn] = pd
+		}
+	}
+	// Recurse for nested modules.
+	for i := range md.Modules {
+		r.registerModule(&md.Modules[i], qualName)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **1a. Module declarations**: `module Name { ... }` syntax with nested modules, qualified name resolution (`DataFlow::Node`), and desugaring to qualified predicate names
- **1b. Disjunction via rule splitting**: `(a(x) or b(x))` desugars to synthetic `_disj_N` predicates with two rules (one per branch) — eliminates the previous left-branch-only behavior
- **1c. Negation of conjunctions**: `not (a(x) and b(x))` desugars to synthetic `_neg_N` helper predicates — eliminates the previous error
- **1d. Abstract classes**: `abstract class Foo extends Bar { }` emits union-of-subclasses semantics instead of normal characteristic predicate

## Test plan

- [x] All existing tests pass (`go test ./...` green)
- [x] `go vet ./...` clean
- [x] New parser tests: module declarations, nested modules, qualified access, abstract class parsing
- [x] New desugarer tests: disjunction rule splitting, negation of conjunctions, abstract class union semantics, module class desugaring