### PR TITLE
feat: CodeQL compatibility phases 1e-1g

### DIFF
--- a/ql/ast/ast.go
+++ b/ql/ast/ast.go
@@ -192,6 +192,26 @@ type Forall struct {
 
 func (Forall) formulaNode() {}
 
+// IfThenElse: if cond then thenBranch else elseBranch
+type IfThenElse struct {
+	BaseFormula
+	Cond Formula
+	Then Formula
+	Else Formula
+}
+
+func (IfThenElse) formulaNode() {}
+
+// ClosureCall: pred+(args...) or pred*(args...)
+type ClosureCall struct {
+	BaseFormula
+	Name string // predicate name
+	Plus bool   // true for +, false for *
+	Args []Expr
+}
+
+func (ClosureCall) formulaNode() {}
+
 // None: none() — always false
 type None struct{ BaseFormula }
 

--- a/ql/desugar/desugar.go
+++ b/ql/desugar/desugar.go
@@ -599,6 +599,16 @@ func (d *desugarer) desugarFormula(f ast.Formula, gen *freshVarGen) []datalog.Li
 		// any() — always true; no constraints.
 		return nil
 
+	case *ast.IfThenElse:
+		// Desugar as: (cond and then) or (not cond and else)
+		thenBranch := &ast.Conjunction{Left: n.Cond, Right: n.Then}
+		elseBranch := &ast.Conjunction{Left: &ast.Negation{Formula: n.Cond}, Right: n.Else}
+		disj := &ast.Disjunction{Left: thenBranch, Right: elseBranch}
+		return d.desugarFormula(disj, gen)
+
+	case *ast.ClosureCall:
+		return d.desugarClosureCall(n, gen)
+
 	default:
 		d.errorf("unknown formula type %T", f)
 		return nil
@@ -608,6 +618,24 @@ func (d *desugarer) desugarFormula(f ast.Formula, gen *freshVarGen) []datalog.Li
 // desugarPredicateCall handles a PredicateCall used as a formula.
 func (d *desugarer) desugarPredicateCall(pc *ast.PredicateCall, gen *freshVarGen) []datalog.Literal {
 	if pc.Recv != nil {
+		// Check if receiver is a string type and method is a builtin.
+		recvType := d.resolveReceiverType(pc.Recv)
+		if recvType == "string" && stringBuiltins[pc.Name] {
+			recvTerm, extraLits := d.desugarExpr(pc.Recv, gen)
+			predName := "__builtin_string_" + pc.Name
+			args := []datalog.Term{recvTerm}
+			for _, arg := range pc.Args {
+				t, lits := d.desugarExpr(arg, gen)
+				extraLits = append(extraLits, lits...)
+				args = append(args, t)
+			}
+			lit := datalog.Literal{
+				Positive: true,
+				Atom:     datalog.Atom{Predicate: predName, Args: args},
+			}
+			return append(extraLits, lit)
+		}
+
 		// Method call as formula (predicate call on receiver — no result).
 		recvTerm, extraLits := d.desugarExpr(pc.Recv, gen)
 		args := []datalog.Term{recvTerm}
@@ -815,6 +843,28 @@ func (d *desugarer) desugarExpr(e ast.Expr, gen *freshVarGen) (datalog.Term, []d
 func (d *desugarer) desugarMethodCallExpr(mc *ast.MethodCall, gen *freshVarGen) (datalog.Term, []datalog.Literal) {
 	recv, lits := d.desugarExpr(mc.Recv, gen)
 
+	// Check if receiver is a string type — if so, emit a builtin predicate.
+	recvType := d.resolveReceiverType(mc.Recv)
+	if recvType == "string" && stringBuiltins[mc.Method] {
+		predName := "__builtin_string_" + mc.Method
+		args := []datalog.Term{recv}
+		for _, arg := range mc.Args {
+			t, argLits := d.desugarExpr(arg, gen)
+			lits = append(lits, argLits...)
+			args = append(args, t)
+		}
+		// matches and regexpMatch are predicates (no result), but when used
+		// as an expression they shouldn't have a result variable.
+		// In expression context, all builtins produce a result.
+		fresh := gen.next()
+		args = append(args, fresh)
+		lits = append(lits, datalog.Literal{
+			Positive: true,
+			Atom:     datalog.Atom{Predicate: predName, Args: args},
+		})
+		return fresh, lits
+	}
+
 	// Determine the predicate name.
 	predName := d.resolveMethodCallPred(mc, mc.Method)
 
@@ -973,6 +1023,86 @@ func (d *desugarer) desugarAggregateExpr(a *ast.Aggregate, gen *freshVarGen) (da
 	}
 
 	return fresh, []datalog.Literal{lit}
+}
+
+// ---- Closure call desugaring ----
+
+// desugarClosureCall handles pred+(args) and pred*(args) transitive closure syntax.
+func (d *desugarer) desugarClosureCall(cc *ast.ClosureCall, gen *freshVarGen) []datalog.Literal {
+	if len(cc.Args) != 2 {
+		d.errorf("closure call %s requires exactly 2 arguments, got %d", cc.Name, len(cc.Args))
+		return nil
+	}
+
+	arg0, lits0 := d.desugarExpr(cc.Args[0], gen)
+	arg1, lits1 := d.desugarExpr(cc.Args[1], gen)
+	extraLits := append(lits0, lits1...)
+
+	if cc.Plus {
+		// pred+(x, y): transitive closure (one or more steps)
+		synthName := d.freshSynthName("_closure")
+		z := gen.next()
+
+		// _closure(x, y) :- pred(x, y).
+		d.syntheticRules = append(d.syntheticRules, datalog.Rule{
+			Head: datalog.Atom{Predicate: synthName, Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "y"}}},
+			Body: []datalog.Literal{{
+				Positive: true,
+				Atom:     datalog.Atom{Predicate: cc.Name, Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "y"}}},
+			}},
+		})
+
+		// _closure(x, y) :- pred(x, z), _closure(z, y).
+		d.syntheticRules = append(d.syntheticRules, datalog.Rule{
+			Head: datalog.Atom{Predicate: synthName, Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "y"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: cc.Name, Args: []datalog.Term{datalog.Var{Name: "x"}, z}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: synthName, Args: []datalog.Term{z, datalog.Var{Name: "y"}}}},
+			},
+		})
+
+		lit := datalog.Literal{
+			Positive: true,
+			Atom:     datalog.Atom{Predicate: synthName, Args: []datalog.Term{arg0, arg1}},
+		}
+		return append(extraLits, lit)
+	}
+
+	// pred*(x, y): reflexive-transitive closure
+	// Desugar as: (x = y) or pred+(x, y)
+	plusCall := &ast.ClosureCall{
+		Name: cc.Name,
+		Plus: true,
+		Args: cc.Args,
+	}
+	eqFormula := &ast.Comparison{
+		Left:  cc.Args[0],
+		Right: cc.Args[1],
+		Op:    "=",
+	}
+	disj := &ast.Disjunction{
+		Left:  eqFormula,
+		Right: plusCall,
+	}
+	return d.desugarFormula(disj, gen)
+}
+
+// ---- String builtin desugaring ----
+
+// isStringBuiltin returns true if the method name is a known string builtin.
+var stringBuiltins = map[string]bool{
+	"length":      true,
+	"indexOf":     true,
+	"substring":   true,
+	"matches":     true,
+	"regexpMatch": true,
+	"toUpperCase": true,
+	"toLowerCase": true,
+	"trim":        true,
+	"replaceAll":  true,
+	"charAt":      true,
+	"toInt":       true,
+	"toString":    true,
 }
 
 // ---- Helpers ----

--- a/ql/desugar/desugar.go
+++ b/ql/desugar/desugar.go
@@ -853,9 +853,12 @@ func (d *desugarer) desugarMethodCallExpr(mc *ast.MethodCall, gen *freshVarGen) 
 			lits = append(lits, argLits...)
 			args = append(args, t)
 		}
-		// matches and regexpMatch are predicates (no result), but when used
-		// as an expression they shouldn't have a result variable.
-		// In expression context, all builtins produce a result.
+		// matches and regexpMatch are predicates (no result) — they cannot
+		// be used in expression context. Other builtins produce a result.
+		if mc.Method == "matches" || mc.Method == "regexpMatch" {
+			d.errorf("string method %s() is a predicate and cannot be used as an expression", mc.Method)
+			return datalog.Wildcard{}, lits
+		}
 		fresh := gen.next()
 		args = append(args, fresh)
 		lits = append(lits, datalog.Literal{

--- a/ql/desugar/desugar_test.go
+++ b/ql/desugar/desugar_test.go
@@ -1047,3 +1047,179 @@ module M {
 		t.Error("expected M::Base rule body to contain M::Sub")
 	}
 }
+
+// --- Phase 1e: String builtins ---
+
+func TestDesugarStringBuiltinLength(t *testing.T) {
+	src := `
+class Foo extends @foo {
+	Foo() { any() }
+	string getName() { result = "hi" }
+}
+from string s
+where s.length() > 0
+select s
+`
+	rm := parseAndResolve(t, src)
+	prog := desugarOK(t, rm)
+
+	// The query body should contain __builtin_string_length
+	if prog.Query == nil {
+		t.Fatal("expected query")
+	}
+	found := false
+	for _, lit := range prog.Query.Body {
+		if lit.Atom.Predicate == "__builtin_string_length" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected __builtin_string_length in query body")
+		t.Logf("query body: %v", prog.Query.Body)
+	}
+}
+
+func TestDesugarStringBuiltinToUpperCase(t *testing.T) {
+	src := `
+from string s
+where s = "hello"
+select s.toUpperCase()
+`
+	rm := parseAndResolve(t, src)
+	prog := desugarOK(t, rm)
+
+	if prog.Query == nil {
+		t.Fatal("expected query")
+	}
+	found := false
+	for _, lit := range prog.Query.Body {
+		if lit.Atom.Predicate == "__builtin_string_toUpperCase" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected __builtin_string_toUpperCase in query body")
+	}
+}
+
+// --- Phase 1f: If-then-else ---
+
+func TestDesugarIfThenElse(t *testing.T) {
+	src := `predicate foo(int x) {
+		if x > 0 then x < 100 else x > -100
+	}`
+	rm := parseAndResolve(t, src)
+	prog := desugarOK(t, rm)
+
+	// IfThenElse desugars to a disjunction, which produces synthetic rules
+	rule := findRuleExact(prog, "foo")
+	if rule == nil {
+		t.Fatal("expected rule for foo")
+	}
+
+	// The body should reference a synthetic _disj predicate
+	found := false
+	for _, lit := range rule.Body {
+		if strings.HasPrefix(lit.Atom.Predicate, "_disj") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected synthetic _disj predicate from if-then-else desugaring")
+		t.Logf("body: %v", rule.Body)
+	}
+}
+
+// --- Phase 1g: Transitive closure ---
+
+func TestDesugarClosurePlus(t *testing.T) {
+	src := `predicate foo() { edge+(x, y) }`
+	rm := parseAndResolve(t, src)
+	prog := desugarOK(t, rm)
+
+	rule := findRuleExact(prog, "foo")
+	if rule == nil {
+		t.Fatal("expected rule for foo")
+	}
+
+	// The body should reference a synthetic _closure predicate
+	closurePred := ""
+	for _, lit := range rule.Body {
+		if strings.HasPrefix(lit.Atom.Predicate, "_closure") {
+			closurePred = lit.Atom.Predicate
+			break
+		}
+	}
+	if closurePred == "" {
+		t.Fatal("expected synthetic _closure predicate in body")
+	}
+
+	// There should be synthetic rules for the closure:
+	// _closure(x, y) :- edge(x, y).
+	// _closure(x, y) :- edge(x, z), _closure(z, y).
+	var closureRules []*datalog.Rule
+	for i := range prog.Rules {
+		if prog.Rules[i].Head.Predicate == closurePred {
+			closureRules = append(closureRules, &prog.Rules[i])
+		}
+	}
+	if len(closureRules) != 2 {
+		t.Fatalf("expected 2 closure rules, got %d", len(closureRules))
+	}
+
+	// One should have body with just edge, another with edge + closure
+	baseFound := false
+	recursiveFound := false
+	for _, r := range closureRules {
+		if len(r.Body) == 1 && r.Body[0].Atom.Predicate == "edge" {
+			baseFound = true
+		}
+		if len(r.Body) == 2 {
+			hasEdge := false
+			hasClosure := false
+			for _, lit := range r.Body {
+				if lit.Atom.Predicate == "edge" {
+					hasEdge = true
+				}
+				if lit.Atom.Predicate == closurePred {
+					hasClosure = true
+				}
+			}
+			if hasEdge && hasClosure {
+				recursiveFound = true
+			}
+		}
+	}
+	if !baseFound {
+		t.Error("expected base closure rule: _closure(x,y) :- edge(x,y)")
+	}
+	if !recursiveFound {
+		t.Error("expected recursive closure rule: _closure(x,y) :- edge(x,z), _closure(z,y)")
+	}
+}
+
+func TestDesugarClosureStar(t *testing.T) {
+	src := `predicate foo() { edge*(x, y) }`
+	rm := parseAndResolve(t, src)
+	prog := desugarOK(t, rm)
+
+	rule := findRuleExact(prog, "foo")
+	if rule == nil {
+		t.Fatal("expected rule for foo")
+	}
+
+	// Star closure desugars as (x = y) or edge+(x, y), which means a synthetic _disj
+	found := false
+	for _, lit := range rule.Body {
+		if strings.HasPrefix(lit.Atom.Predicate, "_disj") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected synthetic _disj predicate from star closure desugaring")
+	}
+}

--- a/ql/eval/builtins.go
+++ b/ql/eval/builtins.go
@@ -1,0 +1,377 @@
+package eval
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// builtinFunc evaluates a built-in predicate against a set of bindings.
+// It takes the atom (with args) and current bindings, and returns extended bindings.
+type builtinFunc func(atom datalog.Atom, bindings []binding) []binding
+
+// builtinRegistry maps __builtin_* predicate names to their Go implementations.
+var builtinRegistry = map[string]builtinFunc{
+	"__builtin_string_length":      builtinStringLength,
+	"__builtin_string_toUpperCase": builtinStringToUpperCase,
+	"__builtin_string_toLowerCase": builtinStringToLowerCase,
+	"__builtin_string_trim":        builtinStringTrim,
+	"__builtin_string_indexOf":     builtinStringIndexOf,
+	"__builtin_string_substring":   builtinStringSubstring,
+	"__builtin_string_charAt":      builtinStringCharAt,
+	"__builtin_string_replaceAll":  builtinStringReplaceAll,
+	"__builtin_string_matches":     builtinStringMatches,
+	"__builtin_string_regexpMatch": builtinStringRegexpMatch,
+	"__builtin_string_toInt":       builtinStringToInt,
+	"__builtin_string_toString":    builtinStringToString,
+}
+
+// IsBuiltin returns true if the predicate name is a registered builtin.
+func IsBuiltin(pred string) bool {
+	_, ok := builtinRegistry[pred]
+	return ok
+}
+
+// ApplyBuiltin evaluates a builtin predicate against the given bindings.
+func ApplyBuiltin(atom datalog.Atom, bindings []binding) []binding {
+	fn, ok := builtinRegistry[atom.Predicate]
+	if !ok {
+		return nil
+	}
+	return fn(atom, bindings)
+}
+
+// helper: resolve a string argument from the binding
+func resolveStringArg(arg datalog.Term, b binding) (string, bool) {
+	v, ok := lookupTerm(arg, b)
+	if !ok {
+		return "", false
+	}
+	sv, ok := v.(StrVal)
+	if !ok {
+		return "", false
+	}
+	return sv.V, true
+}
+
+// helper: resolve an int argument from the binding
+func resolveIntArg(arg datalog.Term, b binding) (int64, bool) {
+	v, ok := lookupTerm(arg, b)
+	if !ok {
+		return 0, false
+	}
+	iv, ok := v.(IntVal)
+	if !ok {
+		return 0, false
+	}
+	return iv.V, true
+}
+
+// helper: bind or check the result variable
+func bindResult(arg datalog.Term, b binding, val Value) (binding, bool) {
+	existing, ok := lookupTerm(arg, b)
+	if ok {
+		// Already bound — check equality
+		eq, err := Compare("=", existing, val)
+		if err != nil || !eq {
+			return nil, false
+		}
+		return b, true
+	}
+	// Bind the variable
+	if v, isVar := arg.(datalog.Var); isVar && v.Name != "_" {
+		nb := b.clone()
+		nb[v.Name] = val
+		return nb, true
+	}
+	return b, true
+}
+
+// __builtin_string_length(this, result) — result = len(this)
+func builtinStringLength(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 2 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		result := IntVal{V: int64(len(s))}
+		nb, ok := bindResult(atom.Args[1], b, result)
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_string_toUpperCase(this, result)
+func builtinStringToUpperCase(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 2 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[1], b, StrVal{V: strings.ToUpper(s)})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_string_toLowerCase(this, result)
+func builtinStringToLowerCase(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 2 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[1], b, StrVal{V: strings.ToLower(s)})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_string_trim(this, result)
+func builtinStringTrim(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 2 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[1], b, StrVal{V: strings.TrimSpace(s)})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_string_indexOf(this, arg, result)
+func builtinStringIndexOf(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 3 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		sub, ok := resolveStringArg(atom.Args[1], b)
+		if !ok {
+			continue
+		}
+		idx := strings.Index(s, sub)
+		nb, ok := bindResult(atom.Args[2], b, IntVal{V: int64(idx)})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_string_substring(this, start, end, result)
+func builtinStringSubstring(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 4 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		start, ok := resolveIntArg(atom.Args[1], b)
+		if !ok {
+			continue
+		}
+		end, ok := resolveIntArg(atom.Args[2], b)
+		if !ok {
+			continue
+		}
+		if start < 0 || end < start || int(end) > len(s) {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[3], b, StrVal{V: s[start:end]})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_string_charAt(this, idx, result)
+func builtinStringCharAt(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 3 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		idx, ok := resolveIntArg(atom.Args[1], b)
+		if !ok {
+			continue
+		}
+		if idx < 0 || int(idx) >= len(s) {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[2], b, StrVal{V: string(s[idx])})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_string_replaceAll(this, old, new, result)
+func builtinStringReplaceAll(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 4 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		old, ok := resolveStringArg(atom.Args[1], b)
+		if !ok {
+			continue
+		}
+		newStr, ok := resolveStringArg(atom.Args[2], b)
+		if !ok {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[3], b, StrVal{V: strings.ReplaceAll(s, old, newStr)})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_string_matches(this, pattern) — predicate, no result
+func builtinStringMatches(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 2 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		pattern, ok := resolveStringArg(atom.Args[1], b)
+		if !ok {
+			continue
+		}
+		// CodeQL matches uses glob-like patterns: % = any sequence, _ = any char
+		// Convert to filepath.Match pattern: % → *, _ → ?
+		globPat := strings.ReplaceAll(pattern, "%", "*")
+		globPat = strings.ReplaceAll(globPat, "_", "?")
+		matched, err := filepath.Match(globPat, s)
+		if err != nil || !matched {
+			continue
+		}
+		out = append(out, b)
+	}
+	return out
+}
+
+// __builtin_string_regexpMatch(this, pattern) — predicate, no result
+func builtinStringRegexpMatch(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 2 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		pattern, ok := resolveStringArg(atom.Args[1], b)
+		if !ok {
+			continue
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			continue
+		}
+		if re.MatchString(s) {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// __builtin_string_toInt(this, result)
+func builtinStringToInt(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 2 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		val, err := strconv.Atoi(s)
+		if err != nil {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[1], b, IntVal{V: int64(val)})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_string_toString(this, result)
+func builtinStringToString(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 2 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[1], b, StrVal{V: s})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// FormatBuiltinError formats a diagnostic when a builtin is called with wrong arity.
+func FormatBuiltinError(pred string, got int) string {
+	return fmt.Sprintf("builtin %s called with %d args", pred, got)
+}

--- a/ql/eval/builtins_test.go
+++ b/ql/eval/builtins_test.go
@@ -1,0 +1,407 @@
+package eval
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+func sc(s string) datalog.StringConst { return datalog.StringConst{Value: s} }
+
+// TestBuiltinStringLength evaluates __builtin_string_length.
+func TestBuiltinStringLength(t *testing.T) {
+	// Fact: Data("hello"), Data("ab")
+	data := makeRelation("Data", 1, StrVal{V: "hello"}, StrVal{V: "ab"})
+	baseRels := map[string]*Relation{"Data": data}
+
+	// Rule: Result(s, n) :- Data(s), __builtin_string_length(s, n).
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{{
+			Rules: []plan.PlannedRule{{
+				Head: head("Result", v("s"), v("n")),
+				JoinOrder: []plan.JoinStep{
+					positiveStep("Data", v("s")),
+					positiveStep("__builtin_string_length", v("s"), v("n")),
+				},
+			}},
+		}},
+		Query: &plan.PlannedQuery{
+			Select:    []datalog.Term{v("s"), v("n")},
+			JoinOrder: []plan.JoinStep{positiveStep("Result", v("s"), v("n"))},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(rs.Rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rs.Rows))
+	}
+
+	// Check results
+	for _, row := range rs.Rows {
+		s := row[0].(StrVal).V
+		n := row[1].(IntVal).V
+		if s == "hello" && n != 5 {
+			t.Errorf("len(\"hello\") = %d, want 5", n)
+		}
+		if s == "ab" && n != 2 {
+			t.Errorf("len(\"ab\") = %d, want 2", n)
+		}
+	}
+}
+
+// TestBuiltinStringToUpperCase evaluates __builtin_string_toUpperCase.
+func TestBuiltinStringToUpperCase(t *testing.T) {
+	data := makeRelation("Data", 1, StrVal{V: "hello"})
+	baseRels := map[string]*Relation{"Data": data}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{{
+			Rules: []plan.PlannedRule{{
+				Head: head("Result", v("s"), v("u")),
+				JoinOrder: []plan.JoinStep{
+					positiveStep("Data", v("s")),
+					positiveStep("__builtin_string_toUpperCase", v("s"), v("u")),
+				},
+			}},
+		}},
+		Query: &plan.PlannedQuery{
+			Select:    []datalog.Term{v("u")},
+			JoinOrder: []plan.JoinStep{positiveStep("Result", v("s"), v("u"))},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rs.Rows))
+	}
+	if rs.Rows[0][0].(StrVal).V != "HELLO" {
+		t.Errorf("toUpperCase(\"hello\") = %q, want \"HELLO\"", rs.Rows[0][0].(StrVal).V)
+	}
+}
+
+// TestBuiltinStringToLowerCase evaluates __builtin_string_toLowerCase.
+func TestBuiltinStringToLowerCase(t *testing.T) {
+	data := makeRelation("Data", 1, StrVal{V: "HELLO"})
+	baseRels := map[string]*Relation{"Data": data}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{{
+			Rules: []plan.PlannedRule{{
+				Head: head("Result", v("r")),
+				JoinOrder: []plan.JoinStep{
+					positiveStep("Data", v("s")),
+					positiveStep("__builtin_string_toLowerCase", v("s"), v("r")),
+				},
+			}},
+		}},
+		Query: &plan.PlannedQuery{
+			Select:    []datalog.Term{v("r")},
+			JoinOrder: []plan.JoinStep{positiveStep("Result", v("r"))},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(rs.Rows) != 1 || rs.Rows[0][0].(StrVal).V != "hello" {
+		t.Errorf("expected \"hello\", got %v", rs.Rows)
+	}
+}
+
+// TestBuiltinStringTrim evaluates __builtin_string_trim.
+func TestBuiltinStringTrim(t *testing.T) {
+	data := makeRelation("Data", 1, StrVal{V: "  hello  "})
+	baseRels := map[string]*Relation{"Data": data}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{{
+			Rules: []plan.PlannedRule{{
+				Head: head("Result", v("r")),
+				JoinOrder: []plan.JoinStep{
+					positiveStep("Data", v("s")),
+					positiveStep("__builtin_string_trim", v("s"), v("r")),
+				},
+			}},
+		}},
+		Query: &plan.PlannedQuery{
+			Select:    []datalog.Term{v("r")},
+			JoinOrder: []plan.JoinStep{positiveStep("Result", v("r"))},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(rs.Rows) != 1 || rs.Rows[0][0].(StrVal).V != "hello" {
+		t.Errorf("expected \"hello\", got %v", rs.Rows)
+	}
+}
+
+// TestBuiltinStringIndexOf evaluates __builtin_string_indexOf.
+func TestBuiltinStringIndexOf(t *testing.T) {
+	data := makeRelation("Data", 1, StrVal{V: "hello world"})
+	baseRels := map[string]*Relation{"Data": data}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{{
+			Rules: []plan.PlannedRule{{
+				Head: head("Result", v("idx")),
+				JoinOrder: []plan.JoinStep{
+					positiveStep("Data", v("s")),
+					positiveStep("__builtin_string_indexOf", v("s"), sc("world"), v("idx")),
+				},
+			}},
+		}},
+		Query: &plan.PlannedQuery{
+			Select:    []datalog.Term{v("idx")},
+			JoinOrder: []plan.JoinStep{positiveStep("Result", v("idx"))},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(rs.Rows) != 1 || rs.Rows[0][0].(IntVal).V != 6 {
+		t.Errorf("expected indexOf=6, got %v", rs.Rows)
+	}
+}
+
+// TestBuiltinStringMatches evaluates __builtin_string_matches (glob pattern).
+func TestBuiltinStringMatches(t *testing.T) {
+	data := makeRelation("Data", 1,
+		StrVal{V: "hello"},
+		StrVal{V: "world"},
+		StrVal{V: "help"},
+	)
+	baseRels := map[string]*Relation{"Data": data}
+
+	// Match strings starting with "hel" using glob: hel%
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{{
+			Rules: []plan.PlannedRule{{
+				Head: head("Result", v("s")),
+				JoinOrder: []plan.JoinStep{
+					positiveStep("Data", v("s")),
+					positiveStep("__builtin_string_matches", v("s"), sc("hel%")),
+				},
+			}},
+		}},
+		Query: &plan.PlannedQuery{
+			Select:    []datalog.Term{v("s")},
+			JoinOrder: []plan.JoinStep{positiveStep("Result", v("s"))},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(rs.Rows) != 2 {
+		t.Fatalf("expected 2 matches for hel%%, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestBuiltinStringRegexpMatch evaluates __builtin_string_regexpMatch.
+func TestBuiltinStringRegexpMatch(t *testing.T) {
+	data := makeRelation("Data", 1,
+		StrVal{V: "foo123"},
+		StrVal{V: "bar"},
+		StrVal{V: "baz456"},
+	)
+	baseRels := map[string]*Relation{"Data": data}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{{
+			Rules: []plan.PlannedRule{{
+				Head: head("Result", v("s")),
+				JoinOrder: []plan.JoinStep{
+					positiveStep("Data", v("s")),
+					positiveStep("__builtin_string_regexpMatch", v("s"), sc("[0-9]+")),
+				},
+			}},
+		}},
+		Query: &plan.PlannedQuery{
+			Select:    []datalog.Term{v("s")},
+			JoinOrder: []plan.JoinStep{positiveStep("Result", v("s"))},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(rs.Rows) != 2 {
+		t.Fatalf("expected 2 regex matches, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestBuiltinStringToInt evaluates __builtin_string_toInt.
+func TestBuiltinStringToInt(t *testing.T) {
+	data := makeRelation("Data", 1, StrVal{V: "42"})
+	baseRels := map[string]*Relation{"Data": data}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{{
+			Rules: []plan.PlannedRule{{
+				Head: head("Result", v("n")),
+				JoinOrder: []plan.JoinStep{
+					positiveStep("Data", v("s")),
+					positiveStep("__builtin_string_toInt", v("s"), v("n")),
+				},
+			}},
+		}},
+		Query: &plan.PlannedQuery{
+			Select:    []datalog.Term{v("n")},
+			JoinOrder: []plan.JoinStep{positiveStep("Result", v("n"))},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(rs.Rows) != 1 || rs.Rows[0][0].(IntVal).V != 42 {
+		t.Errorf("expected 42, got %v", rs.Rows)
+	}
+}
+
+// TestBuiltinStringSubstring evaluates __builtin_string_substring.
+func TestBuiltinStringSubstring(t *testing.T) {
+	data := makeRelation("Data", 1, StrVal{V: "hello world"})
+	baseRels := map[string]*Relation{"Data": data}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{{
+			Rules: []plan.PlannedRule{{
+				Head: head("Result", v("r")),
+				JoinOrder: []plan.JoinStep{
+					positiveStep("Data", v("s")),
+					positiveStep("__builtin_string_substring", v("s"), ic(0), ic(5), v("r")),
+				},
+			}},
+		}},
+		Query: &plan.PlannedQuery{
+			Select:    []datalog.Term{v("r")},
+			JoinOrder: []plan.JoinStep{positiveStep("Result", v("r"))},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(rs.Rows) != 1 || rs.Rows[0][0].(StrVal).V != "hello" {
+		t.Errorf("expected \"hello\", got %v", rs.Rows)
+	}
+}
+
+// TestBuiltinStringReplaceAll evaluates __builtin_string_replaceAll.
+func TestBuiltinStringReplaceAll(t *testing.T) {
+	data := makeRelation("Data", 1, StrVal{V: "aabaa"})
+	baseRels := map[string]*Relation{"Data": data}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{{
+			Rules: []plan.PlannedRule{{
+				Head: head("Result", v("r")),
+				JoinOrder: []plan.JoinStep{
+					positiveStep("Data", v("s")),
+					positiveStep("__builtin_string_replaceAll", v("s"), sc("a"), sc("x"), v("r")),
+				},
+			}},
+		}},
+		Query: &plan.PlannedQuery{
+			Select:    []datalog.Term{v("r")},
+			JoinOrder: []plan.JoinStep{positiveStep("Result", v("r"))},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(rs.Rows) != 1 || rs.Rows[0][0].(StrVal).V != "xxbxx" {
+		t.Errorf("expected \"xxbxx\", got %v", rs.Rows)
+	}
+}
+
+// TestBuiltinStringCharAt evaluates __builtin_string_charAt.
+func TestBuiltinStringCharAt(t *testing.T) {
+	data := makeRelation("Data", 1, StrVal{V: "hello"})
+	baseRels := map[string]*Relation{"Data": data}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{{
+			Rules: []plan.PlannedRule{{
+				Head: head("Result", v("r")),
+				JoinOrder: []plan.JoinStep{
+					positiveStep("Data", v("s")),
+					positiveStep("__builtin_string_charAt", v("s"), ic(1), v("r")),
+				},
+			}},
+		}},
+		Query: &plan.PlannedQuery{
+			Select:    []datalog.Term{v("r")},
+			JoinOrder: []plan.JoinStep{positiveStep("Result", v("r"))},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(rs.Rows) != 1 || rs.Rows[0][0].(StrVal).V != "e" {
+		t.Errorf("expected \"e\", got %v", rs.Rows)
+	}
+}
+
+// TestBuiltinStringToString evaluates __builtin_string_toString (identity).
+func TestBuiltinStringToString(t *testing.T) {
+	data := makeRelation("Data", 1, StrVal{V: "hello"})
+	baseRels := map[string]*Relation{"Data": data}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{{
+			Rules: []plan.PlannedRule{{
+				Head: head("Result", v("r")),
+				JoinOrder: []plan.JoinStep{
+					positiveStep("Data", v("s")),
+					positiveStep("__builtin_string_toString", v("s"), v("r")),
+				},
+			}},
+		}},
+		Query: &plan.PlannedQuery{
+			Select:    []datalog.Term{v("r")},
+			JoinOrder: []plan.JoinStep{positiveStep("Result", v("r"))},
+		},
+	}
+
+	rs, err := Evaluate(context.Background(), ep, baseRels)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(rs.Rows) != 1 || rs.Rows[0][0].(StrVal).V != "hello" {
+		t.Errorf("expected \"hello\", got %v", rs.Rows)
+	}
+}
+
+// TestBuiltinIsBuiltin verifies IsBuiltin for known and unknown predicates.
+func TestBuiltinIsBuiltin(t *testing.T) {
+	if !IsBuiltin("__builtin_string_length") {
+		t.Error("expected __builtin_string_length to be a builtin")
+	}
+	if IsBuiltin("notABuiltin") {
+		t.Error("expected notABuiltin to NOT be a builtin")
+	}
+}

--- a/ql/eval/join.go
+++ b/ql/eval/join.go
@@ -149,6 +149,22 @@ func applyStep(step plan.JoinStep, rels map[string]*Relation, bindings []binding
 		return bindings
 	}
 
+	// Builtin predicate — evaluate procedurally.
+	if IsBuiltin(lit.Atom.Predicate) {
+		if lit.Positive {
+			return ApplyBuiltin(lit.Atom, bindings)
+		}
+		// Negated builtin: keep bindings where the builtin produces no results.
+		var out []binding
+		for _, b := range bindings {
+			result := ApplyBuiltin(lit.Atom, []binding{b})
+			if len(result) == 0 {
+				out = append(out, b)
+			}
+		}
+		return out
+	}
+
 	if lit.Positive {
 		return applyPositive(lit.Atom, rels, bindings)
 	}

--- a/ql/parse/lexer.go
+++ b/ql/parse/lexer.go
@@ -69,6 +69,9 @@ const (
 	TokKwMax
 	TokKwSum
 	TokKwAvg
+	TokKwIf
+	TokKwThen
+	TokKwElse
 
 	TokEOF
 	TokError // malformed input
@@ -104,6 +107,9 @@ var keywords = map[string]TokenType{
 	"max":        TokKwMax,
 	"sum":        TokKwSum,
 	"avg":        TokKwAvg,
+	"if":         TokKwIf,
+	"then":       TokKwThen,
+	"else":       TokKwElse,
 }
 
 // Token is a single QL token.

--- a/ql/parse/parse_test.go
+++ b/ql/parse/parse_test.go
@@ -963,3 +963,110 @@ func TestLexerModulePrivateKeywords(t *testing.T) {
 		t.Errorf("expected TokKwPrivate, got %d (lit=%q)", tok.Type, tok.Lit)
 	}
 }
+
+// --- Phase 1e-1g tests ---
+
+func TestLexerIfThenElseKeywords(t *testing.T) {
+	l := parse.NewLexer("if then else", "test.ql")
+	expected := []parse.TokenType{parse.TokKwIf, parse.TokKwThen, parse.TokKwElse, parse.TokEOF}
+	for i, exp := range expected {
+		tok := l.Next()
+		if tok.Type != exp {
+			t.Errorf("token %d: expected type %d, got %d (lit=%q)", i, exp, tok.Type, tok.Lit)
+		}
+	}
+}
+
+func TestIfThenElse(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { if a() then b() else c() }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	ite, ok := body.(*ast.IfThenElse)
+	if !ok {
+		t.Fatalf("expected IfThenElse, got %T", body)
+	}
+	condPC, ok := ite.Cond.(*ast.PredicateCall)
+	if !ok {
+		t.Fatalf("expected PredicateCall for cond, got %T", ite.Cond)
+	}
+	if condPC.Name != "a" {
+		t.Errorf("expected cond name 'a', got %q", condPC.Name)
+	}
+	thenPC, ok := ite.Then.(*ast.PredicateCall)
+	if !ok {
+		t.Fatalf("expected PredicateCall for then, got %T", ite.Then)
+	}
+	if thenPC.Name != "b" {
+		t.Errorf("expected then name 'b', got %q", thenPC.Name)
+	}
+	elsePC, ok := ite.Else.(*ast.PredicateCall)
+	if !ok {
+		t.Fatalf("expected PredicateCall for else, got %T", ite.Else)
+	}
+	if elsePC.Name != "c" {
+		t.Errorf("expected else name 'c', got %q", elsePC.Name)
+	}
+}
+
+func TestIfThenElseComplex(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { if a() and b() then c() else d() }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	ite, ok := body.(*ast.IfThenElse)
+	if !ok {
+		t.Fatalf("expected IfThenElse, got %T", body)
+	}
+	_, ok = ite.Cond.(*ast.Conjunction)
+	if !ok {
+		t.Fatalf("expected Conjunction for cond, got %T", ite.Cond)
+	}
+}
+
+func TestClosureCallPlus(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { reaches+(x, y) }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	cc, ok := body.(*ast.ClosureCall)
+	if !ok {
+		t.Fatalf("expected ClosureCall, got %T", body)
+	}
+	if cc.Name != "reaches" {
+		t.Errorf("expected name 'reaches', got %q", cc.Name)
+	}
+	if !cc.Plus {
+		t.Error("expected Plus=true")
+	}
+	if len(cc.Args) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(cc.Args))
+	}
+}
+
+func TestClosureCallStar(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { reaches*(x, y) }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	cc, ok := body.(*ast.ClosureCall)
+	if !ok {
+		t.Fatalf("expected ClosureCall, got %T", body)
+	}
+	if cc.Name != "reaches" {
+		t.Errorf("expected name 'reaches', got %q", cc.Name)
+	}
+	if cc.Plus {
+		t.Error("expected Plus=false for star closure")
+	}
+}
+
+func TestClosureCallInConjunction(t *testing.T) {
+	mod := mustParse(t, `predicate foo() { reaches+(x, y) and y = 42 }`)
+	pred := mod.Predicates[0]
+	body := *pred.Body
+	conj, ok := body.(*ast.Conjunction)
+	if !ok {
+		t.Fatalf("expected Conjunction, got %T", body)
+	}
+	_, ok = conj.Left.(*ast.ClosureCall)
+	if !ok {
+		t.Fatalf("expected ClosureCall on left, got %T", conj.Left)
+	}
+}

--- a/ql/parse/parser.go
+++ b/ql/parse/parser.go
@@ -45,6 +45,7 @@ type parserState struct {
 	lexPos  int
 	lexLine int
 	lexCol  int
+	lexErr  *Token
 }
 
 func (p *Parser) saveState() parserState {
@@ -53,6 +54,7 @@ func (p *Parser) saveState() parserState {
 		lexPos:  p.lexer.pos,
 		lexLine: p.lexer.line,
 		lexCol:  p.lexer.col,
+		lexErr:  p.lexer.err,
 	}
 }
 
@@ -61,6 +63,7 @@ func (p *Parser) restoreState(s parserState) {
 	p.lexer.pos = s.lexPos
 	p.lexer.line = s.lexLine
 	p.lexer.col = s.lexCol
+	p.lexer.err = s.lexErr
 }
 
 func (p *Parser) at(t TokenType) bool {

--- a/ql/parse/parser.go
+++ b/ql/parse/parser.go
@@ -39,6 +39,30 @@ func (p *Parser) advance() Token {
 	return prev
 }
 
+// parserState captures the parser and lexer state for backtracking.
+type parserState struct {
+	current Token
+	lexPos  int
+	lexLine int
+	lexCol  int
+}
+
+func (p *Parser) saveState() parserState {
+	return parserState{
+		current: p.current,
+		lexPos:  p.lexer.pos,
+		lexLine: p.lexer.line,
+		lexCol:  p.lexer.col,
+	}
+}
+
+func (p *Parser) restoreState(s parserState) {
+	p.current = s.current
+	p.lexer.pos = s.lexPos
+	p.lexer.line = s.lexLine
+	p.lexer.col = s.lexCol
+}
+
 func (p *Parser) at(t TokenType) bool {
 	return p.current.Type == t
 }
@@ -89,6 +113,12 @@ func tokenName(t TokenType) string {
 		return "'='"
 	case TokEOF:
 		return "EOF"
+	case TokKwIf:
+		return "'if'"
+	case TokKwThen:
+		return "'then'"
+	case TokKwElse:
+		return "'else'"
 	default:
 		return fmt.Sprintf("token(%d)", t)
 	}
@@ -692,12 +722,68 @@ func (p *Parser) parseNot() (ast.Formula, error) {
 			Formula:     f,
 		}, nil
 	}
+	if p.at(TokKwIf) {
+		return p.parseIfThenElse()
+	}
 	return p.parseComparisonOrAtom()
+}
+
+func (p *Parser) parseIfThenElse() (ast.Formula, error) {
+	tok := p.advance() // consume 'if'
+	cond, err := p.parseFormula()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(TokKwThen); err != nil {
+		return nil, err
+	}
+	thenF, err := p.parseFormula()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(TokKwElse); err != nil {
+		return nil, err
+	}
+	elseF, err := p.parseFormula()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.IfThenElse{
+		BaseFormula: ast.BaseFormula{Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col}},
+		Cond:        cond,
+		Then:        thenF,
+		Else:        elseF,
+	}, nil
 }
 
 func (p *Parser) parseComparisonOrAtom() (ast.Formula, error) {
 	// Try to parse an expression, and if followed by comparison op or instanceof, make it a comparison/instanceof.
 	// Otherwise, it must be a formula atom (predicate call, exists, forall, etc.)
+
+	// Check for closure call: ident+(args...) or ident*(args...)
+	if p.at(TokIdent) {
+		saved := p.saveState()
+		name := p.advance()
+		if p.at(TokPlus) || p.at(TokStar) {
+			isPlus := p.at(TokPlus)
+			p.advance() // consume + or *
+			if p.at(TokLParen) {
+				// This is a closure call
+				args, err := p.parseArgList()
+				if err != nil {
+					return nil, err
+				}
+				return &ast.ClosureCall{
+					BaseFormula: ast.BaseFormula{Span: ast.Span{File: p.file, StartLine: name.Line, StartCol: name.Col}},
+					Name:        name.Lit,
+					Plus:        isPlus,
+					Args:        args,
+				}, nil
+			}
+		}
+		// Not a closure call — restore state
+		p.restoreState(saved)
+	}
 
 	// Check for formula atoms first
 	switch p.current.Type {


### PR DESCRIPTION
## Summary

- **Phase 1e: String built-in predicates** — Adds a builtin registry to the evaluator with 12 string methods (length, indexOf, substring, matches, regexpMatch, toUpperCase, toLowerCase, trim, replaceAll, charAt, toInt, toString). The desugarer emits `__builtin_string_*` predicates when the receiver type resolves to `string`, and the join evaluator handles these procedurally via `ApplyBuiltin`.

- **Phase 1f: If-then-else expressions** — Adds `IfThenElse` AST node, `if`/`then`/`else` lexer keywords, parser support for `if <formula> then <formula> else <formula>`, and desugaring as `(cond and then) or (not cond and else)` which feeds into the existing disjunction/rule-splitting machinery.

- **Phase 1g: Transitive closure syntax** — Adds `ClosureCall` AST node with `Plus` flag (+ vs *), parser backtracking to distinguish `pred+(x,y)` from arithmetic, desugaring of `pred+` as two recursive synthetic rules, and `pred*` as `(x = y) or pred+(x, y)`.

## Test plan

- [x] Lexer tests for `if`/`then`/`else` keywords
- [x] Parser tests for if-then-else (simple and complex conditions)
- [x] Parser tests for `pred+(x,y)` and `pred*(x,y)` closure calls
- [x] Parser test for closure in conjunction context
- [x] Desugarer tests for string builtins (length, toUpperCase)
- [x] Desugarer test for if-then-else producing synthetic _disj rules
- [x] Desugarer tests for transitive closure (+ and *) producing correct synthetic rules
- [x] Evaluator tests for all 12 string builtins with real fact DBs
- [x] All existing tests pass (`go test ./...` and `go vet ./...` clean)