### PR TITLE
feat: CodeQL compatibility layer (Phase 2a/2e)

### DIFF
--- a/bridge/compat_javascript.qll
+++ b/bridge/compat_javascript.qll
@@ -1,0 +1,376 @@
+/**
+ * CodeQL-compatible JavaScript/TypeScript standard library.
+ * Clean-room implementation providing CodeQL API surface
+ * backed by tsq's fact relations.
+ *
+ * This file is NOT derived from CodeQL source code.
+ * API surface documented from public CodeQL documentation at
+ * https://codeql.github.com/docs/ and public query examples.
+ */
+
+// ---- Core AST ----
+
+/** An AST node in the source code. */
+class ASTNode extends @node {
+    ASTNode() { Node(this, _, _, _, _, _, _) }
+
+    /** Gets the file containing this node. */
+    File getFile() { Node(this, result, _, _, _, _, _) }
+
+    /** Gets the syntactic kind of this node (e.g. "CallExpression"). */
+    string getKind() { Node(this, _, result, _, _, _, _) }
+
+    /** Gets the start line (1-based). */
+    int getStartLine() { Node(this, _, _, result, _, _, _) }
+
+    /** Gets the start column (0-based). */
+    int getStartCol() { Node(this, _, _, _, result, _, _) }
+
+    /** Gets the end line (1-based). */
+    int getEndLine() { Node(this, _, _, _, _, result, _) }
+
+    /** Gets the end column (0-based). */
+    int getEndCol() { Node(this, _, _, _, _, _, result) }
+
+    /** Gets a textual representation of this node. */
+    string toString() { result = this.getKind() }
+}
+
+/** A source file in the extraction database. */
+class File extends @file {
+    File() { File(this, _, _) }
+
+    /** Gets the file path. */
+    string getPath() { File(this, result, _) }
+
+    /** Gets the content hash. */
+    string getContentHash() { File(this, _, result) }
+
+    /** Gets a textual representation of this file. */
+    string toString() { result = this.getPath() }
+}
+
+// ---- Functions ----
+
+/** A function declaration or expression. */
+class Function extends @function {
+    Function() { Function(this, _, _, _, _, _) }
+
+    /** Gets the function name (may be empty for anonymous functions). */
+    string getName() { Function(this, result, _, _, _, _) }
+
+    /** Holds if this is an arrow function. */
+    predicate isArrow() { Function(this, _, 1, _, _, _) }
+
+    /** Holds if this is an async function. */
+    predicate isAsync() { Function(this, _, _, 1, _, _) }
+
+    /** Holds if this is a generator function. */
+    predicate isGenerator() { Function(this, _, _, _, 1, _) }
+
+    /** Holds if this is a method. */
+    predicate isMethod() { Function(this, _, _, _, _, 1) }
+
+    /** Gets a textual representation of this function. */
+    string toString() { result = this.getName() }
+}
+
+// ---- Calls (CodeQL-compatible names) ----
+
+/** A function call expression. */
+class CallExpr extends @call {
+    CallExpr() { Call(this, _, _) }
+
+    /** Gets the callee expression node. */
+    ASTNode getCallee() { Call(this, result, _) }
+
+    /** Gets the number of arguments. */
+    int getNumArgument() { Call(this, _, result) }
+
+    /** Gets the i-th argument expression node. */
+    ASTNode getArgument(int i) { CallArg(this, i, result) }
+
+    /** Gets an argument expression node. */
+    ASTNode getAnArgument() { CallArg(this, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "call" }
+}
+
+/** A method call expression (e.g., `obj.method(args)`). */
+class MethodCallExpr extends @method_call {
+    MethodCallExpr() { MethodCall(this, _, _) }
+
+    /** Gets the method name. */
+    string getMethodName() { MethodCall(this, _, result) }
+
+    /** Gets the receiver expression. */
+    ASTNode getReceiver() { MethodCall(this, result, _) }
+
+    /** Gets a textual representation. */
+    string toString() { result = this.getMethodName() }
+}
+
+/** A `new` expression. */
+class NewExpr extends @new_expr {
+    NewExpr() { NewExpr(this, _) }
+
+    /** Gets the class being instantiated. */
+    int getCallee() { NewExpr(this, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "new" }
+}
+
+// ---- Variables ----
+
+/** A variable declaration. */
+class VarDef extends @var_decl {
+    VarDef() { VarDecl(this, _, _, _) }
+
+    /** Gets the symbol for this variable. */
+    int getSym() { VarDecl(this, result, _, _) }
+
+    /** Gets the initializer expression, if any. */
+    ASTNode getInit() { VarDecl(this, _, result, _) }
+
+    /** Holds if this is a const declaration. */
+    predicate isConst() { VarDecl(this, _, _, 1) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "var_decl" }
+}
+
+/** A variable access expression (an expression that may reference a symbol). */
+class VarAccess extends @expr_may_ref {
+    VarAccess() { ExprMayRef(this, _) }
+
+    /** Gets the symbol this expression may reference. */
+    int getSym() { ExprMayRef(this, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "var_access" }
+}
+
+/** An assignment expression. */
+class AssignExpr extends @assign {
+    AssignExpr() { Assign(this, _, _) }
+
+    /** Gets the left-hand side node. */
+    ASTNode getLhs() { result = this }
+
+    /** Gets the right-hand side expression. */
+    ASTNode getRhs() { Assign(this, result, _) }
+
+    /** Gets the symbol being assigned to. */
+    int getLhsSym() { Assign(this, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "assign" }
+}
+
+// ---- Expressions ----
+
+/** A property access expression (e.g., `obj.prop`). */
+class PropAccess extends @field_read {
+    PropAccess() { FieldRead(this, _, _) }
+
+    /** Gets the base symbol. */
+    int getBaseSym() { FieldRead(this, result, _) }
+
+    /** Gets the property name. */
+    string getPropertyName() { FieldRead(this, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "." + this.getPropertyName() }
+}
+
+/** A field write expression (e.g., `obj.field = value`). */
+class PropWrite extends @field_write {
+    PropWrite() { FieldWrite(this, _, _, _) }
+
+    /** Gets the base symbol. */
+    int getBaseSym() { FieldWrite(this, result, _, _) }
+
+    /** Gets the property name. */
+    string getPropertyName() { FieldWrite(this, _, result, _) }
+
+    /** Gets the right-hand side expression. */
+    ASTNode getRhs() { FieldWrite(this, _, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "." + this.getPropertyName() + " =" }
+}
+
+/** An await expression. */
+class AwaitExpr extends @await {
+    AwaitExpr() { Await(this, _) }
+
+    /** Gets the inner (awaited) expression. */
+    ASTNode getOperand() { Await(this, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "await" }
+}
+
+// ---- Types ----
+
+/** A class definition. */
+class ClassDefinition extends @class_decl {
+    ClassDefinition() { ClassDecl(this, _, _) }
+
+    /** Gets the class name. */
+    string getName() { ClassDecl(this, result, _) }
+
+    /** Gets the file containing this class. */
+    File getFile() { ClassDecl(this, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = this.getName() }
+}
+
+/** An interface declaration. */
+class InterfaceDefinition extends @interface_decl {
+    InterfaceDefinition() { InterfaceDecl(this, _, _) }
+
+    /** Gets the interface name. */
+    string getName() { InterfaceDecl(this, result, _) }
+
+    /** Gets the file containing this interface. */
+    File getFile() { InterfaceDecl(this, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = this.getName() }
+}
+
+/** A type declaration (type alias, enum, etc.). */
+class TypeDefinition extends @type_decl {
+    TypeDefinition() { TypeDecl(this, _, _, _) }
+
+    /** Gets the type name. */
+    string getName() { TypeDecl(this, result, _, _) }
+
+    /** Gets the kind of type (e.g. "alias"). */
+    string getTypeKind() { TypeDecl(this, _, result, _) }
+
+    /** Gets the file containing this type. */
+    File getFile() { TypeDecl(this, _, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = this.getName() }
+}
+
+// ---- Imports ----
+
+/** An import declaration. */
+class ImportDeclaration extends @import_binding {
+    ImportDeclaration() { ImportBinding(this, _, _) }
+
+    /** Gets the import path/source. */
+    string getImportPath() { ImportBinding(this, result, _) }
+
+    /** Gets the imported name (or "default" / "*"). */
+    string getImportedName() { ImportBinding(this, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = this.getImportedName() + " from " + this.getImportPath() }
+}
+
+/** An export declaration. */
+class ExportDeclaration extends @export_binding {
+    ExportDeclaration() { ExportBinding(this, _, _) }
+
+    /** Gets the exported name. */
+    string getExportedName() { result = this }
+
+    /** Gets the file containing this export. */
+    File getFile() { ExportBinding(this, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = this.getExportedName() }
+}
+
+// ---- Parameters ----
+
+/** A parameter of a function. */
+class Parameter extends @parameter {
+    Parameter() { Parameter(this, _, _, _, _, _) }
+
+    /** Gets the function this parameter belongs to. */
+    Function getFunction() { result = this }
+
+    /** Gets the parameter index (0-based). */
+    int getIndex() { Parameter(this, result, _, _, _, _) }
+
+    /** Gets the parameter name. */
+    string getName() { Parameter(this, _, result, _, _, _) }
+
+    /** Gets the parameter node. */
+    ASTNode getNode() { Parameter(this, _, _, result, _, _) }
+
+    /** Gets the type annotation text. */
+    string getTypeText() { Parameter(this, _, _, _, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = this.getName() }
+}
+
+// ---- Symbols ----
+
+/** A symbol declaration. */
+class Symbol extends @symbol {
+    Symbol() { Symbol(this, _, _, _) }
+
+    /** Gets the symbol name. */
+    string getName() { Symbol(this, result, _, _) }
+
+    /** Gets the declaration node. */
+    ASTNode getDeclNode() { Symbol(this, _, result, _) }
+
+    /** Gets the file containing the declaration. */
+    File getDeclFile() { Symbol(this, _, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = this.getName() }
+}
+
+// ---- Taint ----
+
+/** A taint source expression. */
+class TaintSource extends @taint_source {
+    TaintSource() { TaintSource(this, _) }
+
+    /** Gets the source kind. */
+    string getSourceKind() { TaintSource(this, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "TaintSource" }
+}
+
+/** A taint sink expression. */
+class TaintSink extends @taint_sink {
+    TaintSink() { TaintSink(this, _) }
+
+    /** Gets the sink kind. */
+    string getSinkKind() { TaintSink(this, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "TaintSink" }
+}
+
+/** A taint alert — tainted data from source reaches sink. */
+class TaintAlert extends @taint_alert {
+    TaintAlert() { TaintAlert(this, _, _, _) }
+
+    /** Gets the sink expression. */
+    int getSinkExpr() { TaintAlert(this, result, _, _) }
+
+    /** Gets the source taint kind. */
+    string getSrcKind() { TaintAlert(this, _, result, _) }
+
+    /** Gets the sink kind. */
+    string getSinkKind() { TaintAlert(this, _, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "TaintAlert" }
+}

--- a/bridge/compat_test.go
+++ b/bridge/compat_test.go
@@ -1,0 +1,305 @@
+package bridge
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/ast"
+	"github.com/Gjdoalfnrxu/tsq/ql/desugar"
+	"github.com/Gjdoalfnrxu/tsq/ql/parse"
+	"github.com/Gjdoalfnrxu/tsq/ql/resolve"
+)
+
+// makeCompatImportLoader creates an import loader that resolves "javascript"
+// (and all tsq:: paths) to the appropriate bridge file.
+func makeCompatImportLoader() func(string) (*ast.Module, error) {
+	bridgeFiles := LoadBridge()
+	pathToFile := map[string]string{
+		"javascript":       "compat_javascript.qll",
+		"tsq::base":        "tsq_base.qll",
+		"tsq::functions":   "tsq_functions.qll",
+		"tsq::calls":       "tsq_calls.qll",
+		"tsq::variables":   "tsq_variables.qll",
+		"tsq::expressions": "tsq_expressions.qll",
+		"tsq::types":       "tsq_types.qll",
+		"tsq::imports":     "tsq_imports.qll",
+		"tsq::symbols":     "tsq_symbols.qll",
+		"tsq::taint":       "tsq_taint.qll",
+	}
+	return func(path string) (*ast.Module, error) {
+		filename, ok := pathToFile[path]
+		if !ok {
+			return nil, fmt.Errorf("unknown import: %s", path)
+		}
+		data, ok := bridgeFiles[filename]
+		if !ok {
+			return nil, fmt.Errorf("missing bridge file: %s", filename)
+		}
+		p := parse.NewParser(string(data), filename)
+		return p.Parse()
+	}
+}
+
+// TestCompatJavascriptParses verifies the compat file parses without errors.
+func TestCompatJavascriptParses(t *testing.T) {
+	files := LoadBridge()
+	data, ok := files["compat_javascript.qll"]
+	if !ok {
+		t.Fatal("compat_javascript.qll not found in embedded bridge files")
+	}
+	p := parse.NewParser(string(data), "compat_javascript.qll")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(mod.Classes) == 0 {
+		t.Error("compat file parsed but contains no class declarations")
+	}
+}
+
+// TestCompatJavascriptRegistersClasses verifies that even though the compat
+// file has resolve warnings about raw relation predicates (expected for bridge
+// files), all expected class declarations are registered in the environment.
+func TestCompatJavascriptRegistersClasses(t *testing.T) {
+	files := LoadBridge()
+	data, ok := files["compat_javascript.qll"]
+	if !ok {
+		t.Fatal("compat_javascript.qll not found")
+	}
+	p := parse.NewParser(string(data), "compat_javascript.qll")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	// Resolve standalone (will have expected errors for DB relation references).
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("resolve returned fatal error: %v", err)
+	}
+
+	expectedClasses := []string{
+		"ASTNode",
+		"File",
+		"Function",
+		"CallExpr",
+		"MethodCallExpr",
+		"NewExpr",
+		"VarDef",
+		"VarAccess",
+		"AssignExpr",
+		"PropAccess",
+		"PropWrite",
+		"AwaitExpr",
+		"ClassDefinition",
+		"InterfaceDefinition",
+		"TypeDefinition",
+		"ImportDeclaration",
+		"ExportDeclaration",
+		"Parameter",
+		"Symbol",
+		"TaintSource",
+		"TaintSink",
+		"TaintAlert",
+	}
+
+	for _, name := range expectedClasses {
+		if _, ok := rm.Env.Classes[name]; !ok {
+			t.Errorf("compat file missing expected class %q", name)
+		}
+	}
+
+	// Verify we got the right count.
+	if got := len(rm.Env.Classes); got != len(expectedClasses) {
+		t.Errorf("expected %d classes, got %d", len(expectedClasses), got)
+	}
+}
+
+// TestImportJavascriptQueryParseResolveDesugar verifies that a query using
+// `import javascript` with CodeQL-style class names parses, resolves, and
+// desugars without errors end-to-end.
+func TestImportJavascriptQueryParseResolveDesugar(t *testing.T) {
+	query := `import javascript
+
+from CallExpr call
+select call
+`
+	p := parse.NewParser(query, "test_import_js.ql")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	// Verify the import was parsed correctly.
+	if len(mod.Imports) != 1 {
+		t.Fatalf("expected 1 import, got %d", len(mod.Imports))
+	}
+	if mod.Imports[0].Path != "javascript" {
+		t.Fatalf("expected import path 'javascript', got %q", mod.Imports[0].Path)
+	}
+
+	// Resolve with the javascript import loader.
+	loader := makeCompatImportLoader()
+	rm, err := resolve.Resolve(mod, loader)
+	if err != nil {
+		t.Fatalf("resolve error: %v", err)
+	}
+	// The query itself should have zero resolve errors (imported bridge
+	// module errors are internal and not propagated to the importing module).
+	if len(rm.Errors) > 0 {
+		for _, e := range rm.Errors {
+			t.Errorf("resolve error: %v", e)
+		}
+		t.FailNow()
+	}
+
+	// Verify CallExpr class is available in the resolved environment.
+	if _, ok := rm.Env.Classes["CallExpr"]; !ok {
+		t.Error("CallExpr class not available after import javascript")
+	}
+
+	// Desugar.
+	_, dsErrors := desugar.Desugar(rm)
+	if len(dsErrors) > 0 {
+		for _, e := range dsErrors {
+			t.Errorf("desugar error: %v", e)
+		}
+	}
+}
+
+// TestImportJavascriptMethodCallQuery tests a query using MethodCallExpr
+// with a predicate filter to verify member access on compat classes works.
+func TestImportJavascriptMethodCallQuery(t *testing.T) {
+	query := `import javascript
+
+from MethodCallExpr mc
+where mc.getMethodName() = "exec"
+select mc
+`
+	p := parse.NewParser(query, "test_method_call.ql")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	loader := makeCompatImportLoader()
+	rm, err := resolve.Resolve(mod, loader)
+	if err != nil {
+		t.Fatalf("resolve error: %v", err)
+	}
+	if len(rm.Errors) > 0 {
+		for _, e := range rm.Errors {
+			t.Errorf("resolve error: %v", e)
+		}
+		t.FailNow()
+	}
+
+	// Verify MethodCallExpr has getMethodName member.
+	mcClass, ok := rm.Env.Classes["MethodCallExpr"]
+	if !ok {
+		t.Fatal("MethodCallExpr class not available")
+	}
+	foundGetMethodName := false
+	foundGetReceiver := false
+	for _, m := range mcClass.Members {
+		if m.Name == "getMethodName" {
+			foundGetMethodName = true
+		}
+		if m.Name == "getReceiver" {
+			foundGetReceiver = true
+		}
+	}
+	if !foundGetMethodName {
+		t.Error("MethodCallExpr class missing getMethodName member")
+	}
+	if !foundGetReceiver {
+		t.Error("MethodCallExpr class missing getReceiver member")
+	}
+
+	_, dsErrors := desugar.Desugar(rm)
+	if len(dsErrors) > 0 {
+		for _, e := range dsErrors {
+			t.Errorf("desugar error: %v", e)
+		}
+	}
+}
+
+// TestImportJavascriptAllClassesAvailable verifies that all compat classes
+// are available in a query after `import javascript`.
+func TestImportJavascriptAllClassesAvailable(t *testing.T) {
+	query := `import javascript
+
+from VarDef v
+select v
+`
+	p := parse.NewParser(query, "test_all_classes.ql")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	loader := makeCompatImportLoader()
+	rm, err := resolve.Resolve(mod, loader)
+	if err != nil {
+		t.Fatalf("resolve error: %v", err)
+	}
+	if len(rm.Errors) > 0 {
+		for _, e := range rm.Errors {
+			t.Errorf("resolve error: %v", e)
+		}
+		t.FailNow()
+	}
+
+	// Verify all compat classes are available after import.
+	for _, cls := range []string{
+		"ASTNode", "File", "Function",
+		"CallExpr", "MethodCallExpr", "NewExpr",
+		"VarDef", "VarAccess", "AssignExpr",
+		"PropAccess", "PropWrite", "AwaitExpr",
+		"ClassDefinition", "InterfaceDefinition", "TypeDefinition",
+		"ImportDeclaration", "ExportDeclaration",
+		"Parameter", "Symbol",
+		"TaintSource", "TaintSink", "TaintAlert",
+	} {
+		if _, ok := rm.Env.Classes[cls]; !ok {
+			t.Errorf("class %q not available after import javascript", cls)
+		}
+	}
+}
+
+// TestImportJavascriptCallExprMembers verifies CallExpr has the expected
+// member predicates with correct names.
+func TestImportJavascriptCallExprMembers(t *testing.T) {
+	files := LoadBridge()
+	data := files["compat_javascript.qll"]
+	p := parse.NewParser(string(data), "compat_javascript.qll")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	rm, _ := resolve.Resolve(mod, nil)
+
+	cd, ok := rm.Env.Classes["CallExpr"]
+	if !ok {
+		t.Fatal("CallExpr class not found")
+	}
+
+	expectedMembers := map[string]bool{
+		"getCallee":      false,
+		"getNumArgument": false,
+		"getArgument":    false,
+		"getAnArgument":  false,
+		"toString":       false,
+	}
+
+	for _, m := range cd.Members {
+		if _, want := expectedMembers[m.Name]; want {
+			expectedMembers[m.Name] = true
+		}
+	}
+
+	for name, found := range expectedMembers {
+		if !found {
+			t.Errorf("CallExpr missing expected member %q", name)
+		}
+	}
+}

--- a/bridge/embed.go
+++ b/bridge/embed.go
@@ -2,7 +2,7 @@ package bridge
 
 import "embed"
 
-//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll tsq_summaries.qll tsq_composition.qll tsq_taint.qll tsq_express.qll tsq_react.qll tsq_node.qll
+//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll tsq_summaries.qll tsq_composition.qll tsq_taint.qll tsq_express.qll tsq_react.qll tsq_node.qll compat_javascript.qll
 var bridgeFS embed.FS
 
 // LoadBridge returns all embedded .qll files as a map from filename to contents.
@@ -26,6 +26,7 @@ func LoadBridge() map[string][]byte {
 		"tsq_express.qll",
 		"tsq_react.qll",
 		"tsq_node.qll",
+		"compat_javascript.qll",
 	}
 	result := make(map[string][]byte, len(files))
 	for _, name := range files {
@@ -69,6 +70,7 @@ func ImportLoader(bridgeFiles map[string][]byte, parseFn func(src, file string) 
 		"tsq::express":     "tsq_express.qll",
 		"tsq::react":       "tsq_react.qll",
 		"tsq::node":        "tsq_node.qll",
+		"javascript":       "compat_javascript.qll",
 	}
 	return func(path string) (interface{}, bool) {
 		filename, ok := pathToFile[path]

--- a/bridge/embed_test.go
+++ b/bridge/embed_test.go
@@ -25,6 +25,7 @@ func TestLoadBridgeReturnsAllFiles(t *testing.T) {
 		"tsq_express.qll",
 		"tsq_react.qll",
 		"tsq_node.qll",
+		"compat_javascript.qll",
 	}
 	files := LoadBridge()
 	if len(files) != len(expected) {
@@ -93,6 +94,7 @@ func TestImportLoaderKnownPaths(t *testing.T) {
 		"tsq::errors",
 		"tsq::types",
 		"tsq::symbols",
+		"javascript",
 	}
 	for _, path := range knownPaths {
 		result, ok := loader(path)
@@ -112,7 +114,6 @@ func TestImportLoaderUnknownPaths(t *testing.T) {
 	loader := ImportLoader(files, stubParse)
 
 	unknownPaths := []string{
-		"javascript",
 		"DataFlow::PathGraph",
 		"",
 	}

--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -435,6 +435,7 @@ func makeBridgeImportLoader(bridgeFiles map[string][]byte) func(path string) (*a
 		"tsq::express":     "tsq_express.qll",
 		"tsq::react":       "tsq_react.qll",
 		"tsq::node":        "tsq_node.qll",
+		"javascript":       "compat_javascript.qll",
 	}
 	return func(path string) (*ast.Module, error) {
 		filename, ok := pathToFile[path]


### PR DESCRIPTION
## Summary

- Add `bridge/compat_javascript.qll` providing CodeQL-compatible class names (CallExpr, MethodCallExpr, VarDef, VarAccess, PropAccess, ClassDefinition, ImportDeclaration, etc.) backed by tsq's existing fact relations
- Map `import javascript` to the compat file in both `bridge/embed.go` (ImportLoader) and `cmd/tsq/main.go` (makeBridgeImportLoader)
- Add comprehensive tests in `bridge/compat_test.go` verifying parse, resolve, desugar, class registration, member predicates, and end-to-end import queries

This is a clean-room implementation -- API surface documented from public CodeQL documentation, implemented from scratch using tsq's fact relations.

## Test plan

- [x] `TestCompatJavascriptParses` -- compat file parses without errors, has class declarations
- [x] `TestCompatJavascriptRegistersClasses` -- all 22 expected classes registered by name
- [x] `TestImportJavascriptQueryParseResolveDesugar` -- `import javascript` + `from CallExpr call select call` end-to-end
- [x] `TestImportJavascriptMethodCallQuery` -- MethodCallExpr with predicate filter, verifies getMethodName/getReceiver members
- [x] `TestImportJavascriptAllClassesAvailable` -- all compat classes available after import
- [x] `TestImportJavascriptCallExprMembers` -- CallExpr has getCallee, getNumArgument, getArgument, getAnArgument, toString
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean