### PR TITLE
Phase 2d: CodeQL-compatible security query libraries

### DIFF
--- a/bridge/compat_security_cmdi.qll
+++ b/bridge/compat_security_cmdi.qll
@@ -1,0 +1,36 @@
+/**
+ * CodeQL-compatible command injection security query library.
+ * Clean-room implementation providing pre-configured source/sink
+ * patterns for OS command injection detection.
+ *
+ * This file is NOT derived from CodeQL source code.
+ * API surface documented from public CodeQL documentation.
+ */
+
+module CommandInjection {
+    /**
+     * A source of user-controlled input that may reach a command injection sink.
+     * Backed by tsq's TaintSource relation with kind "http_input".
+     */
+    class CommandInjectionSource extends @symbol {
+        CommandInjectionSource() { TaintSource(this, "http_input") }
+        string toString() { result = "CommandInjectionSource" }
+    }
+
+    /**
+     * A sink where user-controlled input would cause command injection.
+     * Backed by tsq's TaintSink relation with kind "command_injection".
+     */
+    class CommandInjectionSink extends @symbol {
+        CommandInjectionSink() { TaintSink(this, "command_injection") }
+        string toString() { result = "CommandInjectionSink" }
+    }
+
+    /**
+     * Holds if there is a command injection taint flow from `source` to `sink`.
+     * Backed by tsq's TaintAlert relation filtered to command_injection sinks.
+     */
+    predicate hasCommandInjectionFlow(int source, int sink) {
+        TaintAlert(source, sink, _, "command_injection")
+    }
+}

--- a/bridge/compat_security_pathtraversal.qll
+++ b/bridge/compat_security_pathtraversal.qll
@@ -1,0 +1,39 @@
+/**
+ * CodeQL-compatible path traversal security query library.
+ * Clean-room implementation providing pre-configured source/sink
+ * patterns for path traversal detection.
+ *
+ * This file is NOT derived from CodeQL source code.
+ * API surface documented from public CodeQL documentation.
+ *
+ * Note: path_traversal sink kind is a placeholder — extraction does
+ * not yet populate it. This library is provided for API compatibility.
+ */
+
+module PathTraversal {
+    /**
+     * A source of user-controlled input that may reach a path traversal sink.
+     * Backed by tsq's TaintSource relation with kind "http_input".
+     */
+    class PathTraversalSource extends @symbol {
+        PathTraversalSource() { TaintSource(this, "http_input") }
+        string toString() { result = "PathTraversalSource" }
+    }
+
+    /**
+     * A sink where user-controlled input would cause path traversal.
+     * Backed by tsq's TaintSink relation with kind "path_traversal".
+     */
+    class PathTraversalSink extends @symbol {
+        PathTraversalSink() { TaintSink(this, "path_traversal") }
+        string toString() { result = "PathTraversalSink" }
+    }
+
+    /**
+     * Holds if there is a path traversal taint flow from `source` to `sink`.
+     * Backed by tsq's TaintAlert relation filtered to path_traversal sinks.
+     */
+    predicate hasPathTraversalFlow(int source, int sink) {
+        TaintAlert(source, sink, _, "path_traversal")
+    }
+}

--- a/bridge/compat_security_sqli.qll
+++ b/bridge/compat_security_sqli.qll
@@ -1,0 +1,36 @@
+/**
+ * CodeQL-compatible SQL injection security query library.
+ * Clean-room implementation providing pre-configured source/sink
+ * patterns for SQL injection detection.
+ *
+ * This file is NOT derived from CodeQL source code.
+ * API surface documented from public CodeQL documentation.
+ */
+
+module SqlInjection {
+    /**
+     * A source of user-controlled input that may reach a SQL injection sink.
+     * Backed by tsq's TaintSource relation with kind "http_input".
+     */
+    class SqlInjectionSource extends @symbol {
+        SqlInjectionSource() { TaintSource(this, "http_input") }
+        string toString() { result = "SqlInjectionSource" }
+    }
+
+    /**
+     * A sink where user-controlled input would cause SQL injection.
+     * Backed by tsq's TaintSink relation with kind "sql".
+     */
+    class SqlInjectionSink extends @symbol {
+        SqlInjectionSink() { TaintSink(this, "sql") }
+        string toString() { result = "SqlInjectionSink" }
+    }
+
+    /**
+     * Holds if there is a SQL injection taint flow from `source` to `sink`.
+     * Backed by tsq's TaintAlert relation filtered to sql sinks.
+     */
+    predicate hasSqlInjectionFlow(int source, int sink) {
+        TaintAlert(source, sink, _, "sql")
+    }
+}

--- a/bridge/compat_security_test.go
+++ b/bridge/compat_security_test.go
@@ -1,0 +1,322 @@
+package bridge
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/ast"
+	"github.com/Gjdoalfnrxu/tsq/ql/desugar"
+	"github.com/Gjdoalfnrxu/tsq/ql/parse"
+	"github.com/Gjdoalfnrxu/tsq/ql/resolve"
+)
+
+// makeSecurityImportLoader creates an import loader that resolves security
+// query imports (and all tsq:: paths) to the appropriate bridge file.
+func makeSecurityImportLoader() func(string) (*ast.Module, error) {
+	bridgeFiles := LoadBridge()
+	pathToFile := map[string]string{
+		"javascript":       "compat_javascript.qll",
+		"tsq::base":        "tsq_base.qll",
+		"tsq::functions":   "tsq_functions.qll",
+		"tsq::calls":       "tsq_calls.qll",
+		"tsq::variables":   "tsq_variables.qll",
+		"tsq::expressions": "tsq_expressions.qll",
+		"tsq::types":       "tsq_types.qll",
+		"tsq::imports":     "tsq_imports.qll",
+		"tsq::symbols":     "tsq_symbols.qll",
+		"tsq::taint":       "tsq_taint.qll",
+		"semmle.javascript.security.dataflow.XssQuery":              "compat_security_xss.qll",
+		"semmle.javascript.security.dataflow.CommandInjectionQuery": "compat_security_cmdi.qll",
+		"semmle.javascript.security.dataflow.SqlInjectionQuery":     "compat_security_sqli.qll",
+		"semmle.javascript.security.dataflow.PathTraversalQuery":    "compat_security_pathtraversal.qll",
+	}
+	return func(path string) (*ast.Module, error) {
+		filename, ok := pathToFile[path]
+		if !ok {
+			return nil, fmt.Errorf("unknown import: %s", path)
+		}
+		data, ok := bridgeFiles[filename]
+		if !ok {
+			return nil, fmt.Errorf("missing bridge file: %s", filename)
+		}
+		p := parse.NewParser(string(data), filename)
+		return p.Parse()
+	}
+}
+
+// TestSecurityQllFilesParseWithoutErrors verifies all 4 security .qll files
+// parse without errors.
+func TestSecurityQllFilesParseWithoutErrors(t *testing.T) {
+	files := LoadBridge()
+	securityFiles := []string{
+		"compat_security_xss.qll",
+		"compat_security_cmdi.qll",
+		"compat_security_sqli.qll",
+		"compat_security_pathtraversal.qll",
+	}
+	for _, name := range securityFiles {
+		data, ok := files[name]
+		if !ok {
+			t.Errorf("%s not found in embedded bridge files", name)
+			continue
+		}
+		p := parse.NewParser(string(data), name)
+		mod, err := p.Parse()
+		if err != nil {
+			t.Errorf("%s parse error: %v", name, err)
+			continue
+		}
+		if len(mod.Classes) == 0 && len(mod.Modules) == 0 {
+			t.Errorf("%s parsed but contains no classes or modules", name)
+		}
+	}
+}
+
+// TestSecurityXssModuleClassesRegistered verifies XSS module classes are
+// registered after resolve.
+func TestSecurityXssModuleClassesRegistered(t *testing.T) {
+	files := LoadBridge()
+	data := files["compat_security_xss.qll"]
+	p := parse.NewParser(string(data), "compat_security_xss.qll")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("resolve error: %v", err)
+	}
+
+	for _, name := range []string{"Xss::XssSource", "Xss::XssSink"} {
+		if _, ok := rm.Env.Classes[name]; !ok {
+			t.Errorf("XSS module missing expected class %q", name)
+		}
+	}
+}
+
+// TestSecurityCmdiModuleClassesRegistered verifies command injection module
+// classes are registered after resolve.
+func TestSecurityCmdiModuleClassesRegistered(t *testing.T) {
+	files := LoadBridge()
+	data := files["compat_security_cmdi.qll"]
+	p := parse.NewParser(string(data), "compat_security_cmdi.qll")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("resolve error: %v", err)
+	}
+
+	for _, name := range []string{"CommandInjection::CommandInjectionSource", "CommandInjection::CommandInjectionSink"} {
+		if _, ok := rm.Env.Classes[name]; !ok {
+			t.Errorf("CommandInjection module missing expected class %q", name)
+		}
+	}
+}
+
+// TestSecuritySqliModuleClassesRegistered verifies SQL injection module
+// classes are registered after resolve.
+func TestSecuritySqliModuleClassesRegistered(t *testing.T) {
+	files := LoadBridge()
+	data := files["compat_security_sqli.qll"]
+	p := parse.NewParser(string(data), "compat_security_sqli.qll")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("resolve error: %v", err)
+	}
+
+	for _, name := range []string{"SqlInjection::SqlInjectionSource", "SqlInjection::SqlInjectionSink"} {
+		if _, ok := rm.Env.Classes[name]; !ok {
+			t.Errorf("SqlInjection module missing expected class %q", name)
+		}
+	}
+}
+
+// TestSecurityPathTraversalModuleClassesRegistered verifies path traversal
+// module classes are registered after resolve.
+func TestSecurityPathTraversalModuleClassesRegistered(t *testing.T) {
+	files := LoadBridge()
+	data := files["compat_security_pathtraversal.qll"]
+	p := parse.NewParser(string(data), "compat_security_pathtraversal.qll")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("resolve error: %v", err)
+	}
+
+	for _, name := range []string{"PathTraversal::PathTraversalSource", "PathTraversal::PathTraversalSink"} {
+		if _, ok := rm.Env.Classes[name]; !ok {
+			t.Errorf("PathTraversal module missing expected class %q", name)
+		}
+	}
+}
+
+// TestSecurityXssEndToEndQuery tests an end-to-end query that imports the
+// XSS security library and selects from Xss::XssSource.
+func TestSecurityXssEndToEndQuery(t *testing.T) {
+	query := `import semmle.javascript.security.dataflow.XssQuery
+
+from Xss::XssSource src
+select src
+`
+	p := parse.NewParser(query, "test_xss_query.ql")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	if len(mod.Imports) != 1 {
+		t.Fatalf("expected 1 import, got %d", len(mod.Imports))
+	}
+	if mod.Imports[0].Path != "semmle.javascript.security.dataflow.XssQuery" {
+		t.Fatalf("expected import path 'semmle.javascript.security.dataflow.XssQuery', got %q", mod.Imports[0].Path)
+	}
+
+	loader := makeSecurityImportLoader()
+	rm, err := resolve.Resolve(mod, loader)
+	if err != nil {
+		t.Fatalf("resolve error: %v", err)
+	}
+	if len(rm.Errors) > 0 {
+		for _, e := range rm.Errors {
+			t.Errorf("resolve error: %v", e)
+		}
+		t.FailNow()
+	}
+
+	// Verify Xss::XssSource class is available.
+	if _, ok := rm.Env.Classes["Xss::XssSource"]; !ok {
+		t.Error("Xss::XssSource class not available after import XssQuery")
+	}
+
+	// Desugar should succeed.
+	_, dsErrors := desugar.Desugar(rm)
+	if len(dsErrors) > 0 {
+		for _, e := range dsErrors {
+			t.Errorf("desugar error: %v", e)
+		}
+	}
+}
+
+// TestSecurityCmdiEndToEndQuery tests an end-to-end query that imports the
+// command injection security library.
+func TestSecurityCmdiEndToEndQuery(t *testing.T) {
+	query := `import semmle.javascript.security.dataflow.CommandInjectionQuery
+
+from CommandInjection::CommandInjectionSink sink
+select sink
+`
+	p := parse.NewParser(query, "test_cmdi_query.ql")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	loader := makeSecurityImportLoader()
+	rm, err := resolve.Resolve(mod, loader)
+	if err != nil {
+		t.Fatalf("resolve error: %v", err)
+	}
+	if len(rm.Errors) > 0 {
+		for _, e := range rm.Errors {
+			t.Errorf("resolve error: %v", e)
+		}
+		t.FailNow()
+	}
+
+	if _, ok := rm.Env.Classes["CommandInjection::CommandInjectionSink"]; !ok {
+		t.Error("CommandInjection::CommandInjectionSink class not available after import CommandInjectionQuery")
+	}
+
+	_, dsErrors := desugar.Desugar(rm)
+	if len(dsErrors) > 0 {
+		for _, e := range dsErrors {
+			t.Errorf("desugar error: %v", e)
+		}
+	}
+}
+
+// TestSecuritySqliEndToEndQuery tests an end-to-end query that imports the
+// SQL injection security library.
+func TestSecuritySqliEndToEndQuery(t *testing.T) {
+	query := `import semmle.javascript.security.dataflow.SqlInjectionQuery
+
+from SqlInjection::SqlInjectionSource src
+select src
+`
+	p := parse.NewParser(query, "test_sqli_query.ql")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	loader := makeSecurityImportLoader()
+	rm, err := resolve.Resolve(mod, loader)
+	if err != nil {
+		t.Fatalf("resolve error: %v", err)
+	}
+	if len(rm.Errors) > 0 {
+		for _, e := range rm.Errors {
+			t.Errorf("resolve error: %v", e)
+		}
+		t.FailNow()
+	}
+
+	if _, ok := rm.Env.Classes["SqlInjection::SqlInjectionSource"]; !ok {
+		t.Error("SqlInjection::SqlInjectionSource class not available after import SqlInjectionQuery")
+	}
+
+	_, dsErrors := desugar.Desugar(rm)
+	if len(dsErrors) > 0 {
+		for _, e := range dsErrors {
+			t.Errorf("desugar error: %v", e)
+		}
+	}
+}
+
+// TestSecurityPathTraversalEndToEndQuery tests an end-to-end query that
+// imports the path traversal security library.
+func TestSecurityPathTraversalEndToEndQuery(t *testing.T) {
+	query := `import semmle.javascript.security.dataflow.PathTraversalQuery
+
+from PathTraversal::PathTraversalSink sink
+select sink
+`
+	p := parse.NewParser(query, "test_pathtraversal_query.ql")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	loader := makeSecurityImportLoader()
+	rm, err := resolve.Resolve(mod, loader)
+	if err != nil {
+		t.Fatalf("resolve error: %v", err)
+	}
+	if len(rm.Errors) > 0 {
+		for _, e := range rm.Errors {
+			t.Errorf("resolve error: %v", e)
+		}
+		t.FailNow()
+	}
+
+	if _, ok := rm.Env.Classes["PathTraversal::PathTraversalSink"]; !ok {
+		t.Error("PathTraversal::PathTraversalSink class not available after import PathTraversalQuery")
+	}
+
+	_, dsErrors := desugar.Desugar(rm)
+	if len(dsErrors) > 0 {
+		for _, e := range dsErrors {
+			t.Errorf("desugar error: %v", e)
+		}
+	}
+}

--- a/bridge/compat_security_xss.qll
+++ b/bridge/compat_security_xss.qll
@@ -1,0 +1,36 @@
+/**
+ * CodeQL-compatible XSS security query library.
+ * Clean-room implementation providing pre-configured source/sink
+ * patterns for cross-site scripting detection.
+ *
+ * This file is NOT derived from CodeQL source code.
+ * API surface documented from public CodeQL documentation.
+ */
+
+module Xss {
+    /**
+     * A source of user-controlled input that may reach an XSS sink.
+     * Backed by tsq's TaintSource relation with kind "http_input".
+     */
+    class XssSource extends @symbol {
+        XssSource() { TaintSource(this, "http_input") }
+        string toString() { result = "XssSource" }
+    }
+
+    /**
+     * A sink where user-controlled input would cause XSS.
+     * Backed by tsq's TaintSink relation with kind "xss".
+     */
+    class XssSink extends @symbol {
+        XssSink() { TaintSink(this, "xss") }
+        string toString() { result = "XssSink" }
+    }
+
+    /**
+     * Holds if there is an XSS taint flow from `source` to `sink`.
+     * Backed by tsq's TaintAlert relation filtered to http_input -> xss.
+     */
+    predicate hasXssFlow(int source, int sink) {
+        TaintAlert(source, sink, "http_input", "xss")
+    }
+}

--- a/bridge/embed.go
+++ b/bridge/embed.go
@@ -2,7 +2,7 @@ package bridge
 
 import "embed"
 
-//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll tsq_summaries.qll tsq_composition.qll tsq_taint.qll tsq_express.qll tsq_react.qll tsq_node.qll compat_javascript.qll compat_dataflow.qll compat_tainttracking.qll
+//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll tsq_summaries.qll tsq_composition.qll tsq_taint.qll tsq_express.qll tsq_react.qll tsq_node.qll compat_javascript.qll compat_dataflow.qll compat_tainttracking.qll compat_security_xss.qll compat_security_cmdi.qll compat_security_sqli.qll compat_security_pathtraversal.qll
 var bridgeFS embed.FS
 
 // LoadBridge returns all embedded .qll files as a map from filename to contents.
@@ -29,6 +29,10 @@ func LoadBridge() map[string][]byte {
 		"compat_javascript.qll",
 		"compat_dataflow.qll",
 		"compat_tainttracking.qll",
+		"compat_security_xss.qll",
+		"compat_security_cmdi.qll",
+		"compat_security_sqli.qll",
+		"compat_security_pathtraversal.qll",
 	}
 	result := make(map[string][]byte, len(files))
 	for _, name := range files {
@@ -75,6 +79,10 @@ func ImportLoader(bridgeFiles map[string][]byte, parseFn func(src, file string) 
 		"javascript":          "compat_javascript.qll",
 		"DataFlow::PathGraph": "compat_dataflow.qll",
 		"TaintTracking":       "compat_tainttracking.qll",
+		"semmle.javascript.security.dataflow.XssQuery":              "compat_security_xss.qll",
+		"semmle.javascript.security.dataflow.CommandInjectionQuery": "compat_security_cmdi.qll",
+		"semmle.javascript.security.dataflow.SqlInjectionQuery":     "compat_security_sqli.qll",
+		"semmle.javascript.security.dataflow.PathTraversalQuery":    "compat_security_pathtraversal.qll",
 	}
 	return func(path string) (interface{}, bool) {
 		filename, ok := pathToFile[path]

--- a/bridge/embed_test.go
+++ b/bridge/embed_test.go
@@ -28,6 +28,10 @@ func TestLoadBridgeReturnsAllFiles(t *testing.T) {
 		"compat_javascript.qll",
 		"compat_dataflow.qll",
 		"compat_tainttracking.qll",
+		"compat_security_xss.qll",
+		"compat_security_cmdi.qll",
+		"compat_security_sqli.qll",
+		"compat_security_pathtraversal.qll",
 	}
 	files := LoadBridge()
 	if len(files) != len(expected) {
@@ -99,6 +103,10 @@ func TestImportLoaderKnownPaths(t *testing.T) {
 		"javascript",
 		"DataFlow::PathGraph",
 		"TaintTracking",
+		"semmle.javascript.security.dataflow.XssQuery",
+		"semmle.javascript.security.dataflow.CommandInjectionQuery",
+		"semmle.javascript.security.dataflow.SqlInjectionQuery",
+		"semmle.javascript.security.dataflow.PathTraversalQuery",
 	}
 	for _, path := range knownPaths {
 		result, ok := loader(path)

--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -124,6 +124,15 @@ func v2Manifest() *CapabilityManifest {
 			{Name: "DataFlow::PathNode", Relation: "Symbol", File: "compat_dataflow.qll"},
 			// v2 Phase 2c: CodeQL-compatible TaintTracking module
 			{Name: "TaintTracking::Configuration", Relation: "Symbol", File: "compat_tainttracking.qll"},
+			// v2 Phase 2d: CodeQL-compatible security query libraries
+			{Name: "Xss::XssSource", Relation: "Symbol", File: "compat_security_xss.qll"},
+			{Name: "Xss::XssSink", Relation: "Symbol", File: "compat_security_xss.qll"},
+			{Name: "CommandInjection::CommandInjectionSource", Relation: "Symbol", File: "compat_security_cmdi.qll"},
+			{Name: "CommandInjection::CommandInjectionSink", Relation: "Symbol", File: "compat_security_cmdi.qll"},
+			{Name: "SqlInjection::SqlInjectionSource", Relation: "Symbol", File: "compat_security_sqli.qll"},
+			{Name: "SqlInjection::SqlInjectionSink", Relation: "Symbol", File: "compat_security_sqli.qll"},
+			{Name: "PathTraversal::PathTraversalSource", Relation: "Symbol", File: "compat_security_pathtraversal.qll"},
+			{Name: "PathTraversal::PathTraversalSink", Relation: "Symbol", File: "compat_security_pathtraversal.qll"},
 		},
 		Unavailable: []UnavailableClass{},
 	}

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -9,8 +9,8 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	m := V1Manifest()
 	// v2: 28 original + 5 promoted from unavailable + 12 new v2 = 45
 	// But some relations share bridge classes. Count: 28 + 17 = 45
-	if got := len(m.Available); got != 72 {
-		t.Errorf("expected 72 available classes, got %d", got)
+	if got := len(m.Available); got != 80 {
+		t.Errorf("expected 80 available classes, got %d", got)
 	}
 }
 

--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -438,6 +438,10 @@ func makeBridgeImportLoader(bridgeFiles map[string][]byte) func(path string) (*a
 		"javascript":          "compat_javascript.qll",
 		"DataFlow::PathGraph": "compat_dataflow.qll",
 		"TaintTracking":       "compat_tainttracking.qll",
+		"semmle.javascript.security.dataflow.XssQuery":              "compat_security_xss.qll",
+		"semmle.javascript.security.dataflow.CommandInjectionQuery": "compat_security_cmdi.qll",
+		"semmle.javascript.security.dataflow.SqlInjectionQuery":     "compat_security_sqli.qll",
+		"semmle.javascript.security.dataflow.PathTraversalQuery":    "compat_security_pathtraversal.qll",
 	}
 	return func(path string) (*ast.Module, error) {
 		filename, ok := pathToFile[path]

--- a/ql/parse/parser.go
+++ b/ql/parse/parser.go
@@ -211,19 +211,23 @@ func (p *Parser) parseImport() (*ast.ImportDecl, error) {
 		Span: ast.Span{File: p.file, StartLine: tok.Line, StartCol: tok.Col},
 	}
 
-	// Parse the import path: ident (:: ident)*
+	// Parse the import path: ident ((:: | .) ident)*
 	name, err := p.expect(TokIdent)
 	if err != nil {
 		return nil, err
 	}
 	path := name.Lit
-	for p.at(TokColCol) {
+	for p.at(TokColCol) || p.at(TokDot) {
+		sep := "::"
+		if p.at(TokDot) {
+			sep = "."
+		}
 		p.advance()
 		next, err := p.expect(TokIdent)
 		if err != nil {
 			return nil, err
 		}
-		path += "::" + next.Lit
+		path += sep + next.Lit
 	}
 	imp.Path = path
 


### PR DESCRIPTION
## Summary
- Add 4 security query bridge files (`compat_security_xss.qll`, `compat_security_cmdi.qll`, `compat_security_sqli.qll`, `compat_security_pathtraversal.qll`) providing pre-configured source/sink classes matching CodeQL's public security query API
- Extend the QL import parser to support dotted import paths (e.g. `semmle.javascript.security.dataflow.XssQuery`), enabling CodeQL-style security query imports
- Register all new files in embed, manifest, and import loader mappings; add comprehensive tests (parse, resolve, end-to-end queries for all 4 libraries)

## Details
Each security library provides a module with Source/Sink classes backed by tsq's TaintSource/TaintSink relations and a flow predicate backed by TaintAlert. Path traversal is a placeholder (sink kind not yet populated by extraction).

Import mappings added:
- `semmle.javascript.security.dataflow.XssQuery` -> `compat_security_xss.qll`
- `semmle.javascript.security.dataflow.CommandInjectionQuery` -> `compat_security_cmdi.qll`
- `semmle.javascript.security.dataflow.SqlInjectionQuery` -> `compat_security_sqli.qll`
- `semmle.javascript.security.dataflow.PathTraversalQuery` -> `compat_security_pathtraversal.qll`

## Test plan
- [x] All 4 .qll files parse without errors
- [x] Module classes registered with correct qualified names after resolve
- [x] End-to-end queries with CodeQL-style dotted imports resolve and desugar successfully
- [x] Existing tests unaffected (manifest count updated 72 -> 80)
- [x] `go test ./...` passes