### PR TITLE
Phase 3a: tsgo JSON-RPC client for type resolution

### DIFF
--- a/extract/typecheck/client.go
+++ b/extract/typecheck/client.go
@@ -1,0 +1,297 @@
+package typecheck
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// Client communicates with a tsgo --api --async subprocess via JSON-RPC 2.0
+// using standard LSP Content-Length framing.
+type Client struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout *bufio.Reader
+	nextID atomic.Int64
+	mu     sync.Mutex
+}
+
+// NewClient starts a tsgo subprocess. tsgoPath is the path to the tsgo binary
+// (or "npx @typescript/native-preview" for the npx fallback). cwd is the
+// working directory for the subprocess.
+func NewClient(tsgoPath string, cwd string) (*Client, error) {
+	var cmd *exec.Cmd
+	if strings.HasPrefix(tsgoPath, "npx ") {
+		parts := strings.Fields(tsgoPath)
+		args := append(parts[1:], "--api", "--async")
+		cmd = exec.Command(parts[0], args...)
+	} else {
+		cmd = exec.Command(tsgoPath, "--api", "--async")
+	}
+	cmd.Dir = cwd
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("typecheck: stdin pipe: %w", err)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		stdin.Close()
+		return nil, fmt.Errorf("typecheck: stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		stdin.Close()
+		return nil, fmt.Errorf("typecheck: start tsgo: %w", err)
+	}
+
+	c := &Client{
+		cmd:    cmd,
+		stdin:  stdin,
+		stdout: bufio.NewReader(stdout),
+	}
+	return c, nil
+}
+
+// Close shuts down the tsgo subprocess.
+func (c *Client) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stdin.Close()
+	return c.cmd.Wait()
+}
+
+// call sends a JSON-RPC request and reads the response.
+func (c *Client) call(method string, params interface{}) (json.RawMessage, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	id := c.nextID.Add(1)
+
+	req := jsonrpcRequest{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  method,
+		Params:  params,
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("typecheck: marshal request: %w", err)
+	}
+
+	// Write with Content-Length framing
+	header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(body))
+	if _, err := io.WriteString(c.stdin, header); err != nil {
+		return nil, fmt.Errorf("typecheck: write header: %w", err)
+	}
+	if _, err := c.stdin.Write(body); err != nil {
+		return nil, fmt.Errorf("typecheck: write body: %w", err)
+	}
+
+	// Read response with Content-Length framing
+	resp, err := c.readResponse()
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	return resp.Result, nil
+}
+
+// readResponse reads a Content-Length framed JSON-RPC response.
+func (c *Client) readResponse() (*jsonrpcResponse, error) {
+	// Read headers until blank line
+	contentLength := -1
+	for {
+		line, err := c.stdout.ReadString('\n')
+		if err != nil {
+			return nil, fmt.Errorf("typecheck: read header: %w", err)
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		if strings.HasPrefix(line, "Content-Length: ") {
+			val := strings.TrimPrefix(line, "Content-Length: ")
+			n, err := strconv.Atoi(val)
+			if err != nil {
+				return nil, fmt.Errorf("typecheck: bad Content-Length %q: %w", val, err)
+			}
+			contentLength = n
+		}
+	}
+
+	if contentLength < 0 {
+		return nil, fmt.Errorf("typecheck: missing Content-Length header")
+	}
+
+	// Read exactly contentLength bytes
+	body := make([]byte, contentLength)
+	if _, err := io.ReadFull(c.stdout, body); err != nil {
+		return nil, fmt.Errorf("typecheck: read body: %w", err)
+	}
+
+	var resp jsonrpcResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("typecheck: unmarshal response: %w", err)
+	}
+
+	return &resp, nil
+}
+
+// Initialize sends the initialize request.
+func (c *Client) Initialize() (*InitializeResponse, error) {
+	raw, err := c.call("initialize", map[string]interface{}{})
+	if err != nil {
+		return nil, err
+	}
+	var resp InitializeResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("typecheck: unmarshal initialize: %w", err)
+	}
+	return &resp, nil
+}
+
+// GetProjectForFile gets the project handle for a file path.
+func (c *Client) GetProjectForFile(filePath string) (string, error) {
+	raw, err := c.call("getDefaultProjectForFile", map[string]interface{}{
+		"file": filePath,
+	})
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		Project string `json:"project"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return "", fmt.Errorf("typecheck: unmarshal project: %w", err)
+	}
+	return result.Project, nil
+}
+
+// GetTypeAtPosition returns the type handle and type string at a position.
+func (c *Client) GetTypeAtPosition(project string, file string, line, col int) (*TypeInfo, error) {
+	raw, err := c.call("getTypeAtPosition", map[string]interface{}{
+		"project":  project,
+		"file":     file,
+		"position": map[string]int{"line": line, "character": col},
+	})
+	if err != nil {
+		return nil, err
+	}
+	var info TypeInfo
+	if err := json.Unmarshal(raw, &info); err != nil {
+		return nil, fmt.Errorf("typecheck: unmarshal type: %w", err)
+	}
+	return &info, nil
+}
+
+// GetSymbolAtPosition returns the symbol handle and info at a position.
+func (c *Client) GetSymbolAtPosition(project string, file string, line, col int) (*SymbolInfo, error) {
+	raw, err := c.call("getSymbolAtPosition", map[string]interface{}{
+		"project":  project,
+		"file":     file,
+		"position": map[string]int{"line": line, "character": col},
+	})
+	if err != nil {
+		return nil, err
+	}
+	var info SymbolInfo
+	if err := json.Unmarshal(raw, &info); err != nil {
+		return nil, fmt.Errorf("typecheck: unmarshal symbol: %w", err)
+	}
+	return &info, nil
+}
+
+// GetTypeOfSymbol returns the type of a symbol.
+func (c *Client) GetTypeOfSymbol(project string, symbolHandle string) (*TypeInfo, error) {
+	raw, err := c.call("getTypeOfSymbol", map[string]interface{}{
+		"project": project,
+		"symbol":  symbolHandle,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var info TypeInfo
+	if err := json.Unmarshal(raw, &info); err != nil {
+		return nil, fmt.Errorf("typecheck: unmarshal type of symbol: %w", err)
+	}
+	return &info, nil
+}
+
+// GetMembersOfSymbol returns member symbols.
+func (c *Client) GetMembersOfSymbol(project string, symbolHandle string) ([]MemberInfo, error) {
+	raw, err := c.call("getMembersOfSymbol", map[string]interface{}{
+		"project": project,
+		"symbol":  symbolHandle,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var members []MemberInfo
+	if err := json.Unmarshal(raw, &members); err != nil {
+		return nil, fmt.Errorf("typecheck: unmarshal members: %w", err)
+	}
+	return members, nil
+}
+
+// GetBaseTypes returns base type handles.
+func (c *Client) GetBaseTypes(project string, typeHandle string) ([]TypeInfo, error) {
+	raw, err := c.call("getBaseTypes", map[string]interface{}{
+		"project": project,
+		"type":    typeHandle,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var types []TypeInfo
+	if err := json.Unmarshal(raw, &types); err != nil {
+		return nil, fmt.Errorf("typecheck: unmarshal base types: %w", err)
+	}
+	return types, nil
+}
+
+// TypeToString returns a human-readable type string.
+func (c *Client) TypeToString(project string, typeHandle string) (string, error) {
+	raw, err := c.call("typeToString", map[string]interface{}{
+		"project": project,
+		"type":    typeHandle,
+	})
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		DisplayName string `json:"displayName"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return "", fmt.Errorf("typecheck: unmarshal typeToString: %w", err)
+	}
+	return result.DisplayName, nil
+}
+
+// GetSemanticDiagnostics returns type errors for a file.
+func (c *Client) GetSemanticDiagnostics(project string, file string) ([]Diagnostic, error) {
+	raw, err := c.call("getSemanticDiagnostics", map[string]interface{}{
+		"project": project,
+		"file":    file,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var diags []Diagnostic
+	if err := json.Unmarshal(raw, &diags); err != nil {
+		return nil, fmt.Errorf("typecheck: unmarshal diagnostics: %w", err)
+	}
+	return diags, nil
+}

--- a/extract/typecheck/client_test.go
+++ b/extract/typecheck/client_test.go
@@ -1,0 +1,489 @@
+package typecheck
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"testing"
+)
+
+func TestJSONRPCRequestSerialization(t *testing.T) {
+	req := jsonrpcRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+		Params:  map[string]interface{}{},
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded["jsonrpc"] != "2.0" {
+		t.Errorf("jsonrpc = %q, want %q", decoded["jsonrpc"], "2.0")
+	}
+	if decoded["method"] != "initialize" {
+		t.Errorf("method = %q, want %q", decoded["method"], "initialize")
+	}
+	if id, ok := decoded["id"].(float64); !ok || id != 1 {
+		t.Errorf("id = %v, want 1", decoded["id"])
+	}
+}
+
+func TestJSONRPCRequestWithParams(t *testing.T) {
+	req := jsonrpcRequest{
+		JSONRPC: "2.0",
+		ID:      42,
+		Method:  "getTypeAtPosition",
+		Params: map[string]interface{}{
+			"project":  "p.123",
+			"file":     "/src/index.ts",
+			"position": map[string]int{"line": 10, "character": 5},
+		},
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded jsonrpcRequest
+	decoded.Params = map[string]interface{}{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.Method != "getTypeAtPosition" {
+		t.Errorf("method = %q, want %q", decoded.Method, "getTypeAtPosition")
+	}
+	if decoded.ID != 42 {
+		t.Errorf("id = %d, want 42", decoded.ID)
+	}
+}
+
+func TestResponseParsingSuccess(t *testing.T) {
+	raw := `{"jsonrpc":"2.0","id":1,"result":{"handle":"t00001","displayName":"string","flags":0}}`
+	var resp jsonrpcResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if resp.ID != 1 {
+		t.Errorf("id = %d, want 1", resp.ID)
+	}
+	if resp.Error != nil {
+		t.Errorf("unexpected error: %v", resp.Error)
+	}
+
+	var info TypeInfo
+	if err := json.Unmarshal(resp.Result, &info); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if info.Handle != "t00001" {
+		t.Errorf("handle = %q, want %q", info.Handle, "t00001")
+	}
+	if info.DisplayName != "string" {
+		t.Errorf("displayName = %q, want %q", info.DisplayName, "string")
+	}
+}
+
+func TestResponseParsingError(t *testing.T) {
+	raw := `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`
+	var resp jsonrpcResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if resp.Error == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if resp.Error.Code != -32601 {
+		t.Errorf("error code = %d, want -32601", resp.Error.Code)
+	}
+	if resp.Error.Message != "Method not found" {
+		t.Errorf("error message = %q, want %q", resp.Error.Message, "Method not found")
+	}
+	if resp.Error.Error() != "Method not found" {
+		t.Errorf("Error() = %q, want %q", resp.Error.Error(), "Method not found")
+	}
+}
+
+func TestResponseParsingDiagnostics(t *testing.T) {
+	raw := `[{"file":"/src/index.ts","line":10,"col":5,"message":"Type 'number' is not assignable to type 'string'."}]`
+	var diags []Diagnostic
+	if err := json.Unmarshal([]byte(raw), &diags); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("len(diags) = %d, want 1", len(diags))
+	}
+	if diags[0].Line != 10 {
+		t.Errorf("line = %d, want 10", diags[0].Line)
+	}
+	if diags[0].Message != "Type 'number' is not assignable to type 'string'." {
+		t.Errorf("message = %q", diags[0].Message)
+	}
+}
+
+func TestNewClientBinaryNotFound(t *testing.T) {
+	_, err := NewClient("/nonexistent/path/tsgo-definitely-not-here", "/tmp")
+	if err == nil {
+		t.Fatal("expected error for nonexistent binary, got nil")
+	}
+}
+
+func TestDetectTsgoNoEnvNoPath(t *testing.T) {
+	t.Setenv("TSGO_PATH", "")
+	// This test validates the function doesn't panic.
+	_ = DetectTsgo()
+}
+
+func TestDetectTsgoWithEnvVar(t *testing.T) {
+	t.Setenv("TSGO_PATH", "/nonexistent/tsgo-binary")
+	result := DetectTsgo()
+	if result == "/nonexistent/tsgo-binary" {
+		t.Error("should not return nonexistent path")
+	}
+}
+
+func TestDetectTsgoWithValidEnvVar(t *testing.T) {
+	goPath, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go binary not in PATH")
+	}
+	t.Setenv("TSGO_PATH", goPath)
+	result := DetectTsgo()
+	if result != goPath {
+		t.Errorf("DetectTsgo() = %q, want %q", result, goPath)
+	}
+}
+
+// parseFrame extracts a Content-Length framed message from a byte buffer.
+func parseFrame(data []byte) (msg []byte, rest []byte, ok bool) {
+	s := string(data)
+	idx := indexOf(s, "\r\n\r\n")
+	if idx < 0 {
+		return nil, data, false
+	}
+
+	headers := s[:idx]
+	contentLength := -1
+	for _, line := range splitLines(headers) {
+		if len(line) > 16 && line[:16] == "Content-Length: " {
+			n := 0
+			for _, ch := range line[16:] {
+				if ch >= '0' && ch <= '9' {
+					n = n*10 + int(ch-'0')
+				}
+			}
+			contentLength = n
+		}
+	}
+
+	if contentLength < 0 {
+		return nil, data, false
+	}
+
+	bodyStart := idx + 4 // past \r\n\r\n
+	if len(data) < bodyStart+contentLength {
+		return nil, data, false
+	}
+
+	return data[bodyStart : bodyStart+contentLength], data[bodyStart+contentLength:], true
+}
+
+func indexOf(s, sep string) int {
+	for i := 0; i <= len(s)-len(sep); i++ {
+		if s[i:i+len(sep)] == sep {
+			return i
+		}
+	}
+	return -1
+}
+
+func splitLines(s string) []string {
+	var lines []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			line := s[start:i]
+			if len(line) > 0 && line[len(line)-1] == '\r' {
+				line = line[:len(line)-1]
+			}
+			lines = append(lines, line)
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, s[start:])
+	}
+	return lines
+}
+
+// newMockClient creates a Client connected to a mock server via pipes.
+// The handler function receives each JSON-RPC request and returns either
+// a result value (marshalled to JSON) or a *jsonrpcError for error responses.
+func newMockClient(t *testing.T, handler func(req jsonrpcRequest) interface{}) *Client {
+	t.Helper()
+
+	clientReader, serverWriter := io.Pipe()
+	serverReader, clientWriter := io.Pipe()
+
+	go func() {
+		defer serverWriter.Close()
+		buf := make([]byte, 4096)
+		var accum []byte
+		for {
+			n, err := serverReader.Read(buf)
+			if err != nil {
+				return
+			}
+			accum = append(accum, buf[:n]...)
+
+			for {
+				msg, rest, ok := parseFrame(accum)
+				if !ok {
+					break
+				}
+				accum = rest
+
+				var req jsonrpcRequest
+				if err := json.Unmarshal(msg, &req); err != nil {
+					continue
+				}
+
+				result := handler(req)
+
+				var resp jsonrpcResponse
+				resp.JSONRPC = "2.0"
+				resp.ID = req.ID
+
+				if errResp, ok := result.(*jsonrpcError); ok {
+					resp.Error = errResp
+				} else {
+					body, _ := json.Marshal(result)
+					resp.Result = json.RawMessage(body)
+				}
+
+				respBody, _ := json.Marshal(resp)
+				header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(respBody))
+				serverWriter.Write([]byte(header))
+				serverWriter.Write(respBody)
+			}
+		}
+	}()
+
+	c := &Client{
+		cmd:    exec.Command("true"),
+		stdin:  clientWriter,
+		stdout: bufio.NewReader(clientReader),
+	}
+
+	t.Cleanup(func() {
+		clientWriter.Close()
+		serverReader.Close()
+	})
+
+	return c
+}
+
+func TestMockInitialize(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		if req.Method == "initialize" {
+			return &InitializeResponse{
+				UseCaseSensitiveFileNames: true,
+				CurrentDirectory:          "/project",
+			}
+		}
+		return &jsonrpcError{Code: -32601, Message: "Method not found"}
+	})
+
+	resp, err := c.Initialize()
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if !resp.UseCaseSensitiveFileNames {
+		t.Error("expected UseCaseSensitiveFileNames=true")
+	}
+	if resp.CurrentDirectory != "/project" {
+		t.Errorf("CurrentDirectory = %q, want %q", resp.CurrentDirectory, "/project")
+	}
+}
+
+func TestMockGetProjectForFile(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		if req.Method == "getDefaultProjectForFile" {
+			return map[string]string{"project": "p.abc123"}
+		}
+		return &jsonrpcError{Code: -32601, Message: "Method not found"}
+	})
+
+	proj, err := c.GetProjectForFile("/src/index.ts")
+	if err != nil {
+		t.Fatalf("GetProjectForFile: %v", err)
+	}
+	if proj != "p.abc123" {
+		t.Errorf("project = %q, want %q", proj, "p.abc123")
+	}
+}
+
+func TestMockGetTypeAtPosition(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		if req.Method == "getTypeAtPosition" {
+			return &TypeInfo{Handle: "t00042", DisplayName: "string", Flags: 0}
+		}
+		return &jsonrpcError{Code: -32601, Message: "Method not found"}
+	})
+
+	info, err := c.GetTypeAtPosition("p.1", "/src/index.ts", 10, 5)
+	if err != nil {
+		t.Fatalf("GetTypeAtPosition: %v", err)
+	}
+	if info.Handle != "t00042" {
+		t.Errorf("handle = %q, want %q", info.Handle, "t00042")
+	}
+	if info.DisplayName != "string" {
+		t.Errorf("displayName = %q, want %q", info.DisplayName, "string")
+	}
+}
+
+func TestMockGetSymbolAtPosition(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		if req.Method == "getSymbolAtPosition" {
+			return &SymbolInfo{Handle: "s00001", Name: "foo", Flags: 4}
+		}
+		return &jsonrpcError{Code: -32601, Message: "Method not found"}
+	})
+
+	info, err := c.GetSymbolAtPosition("p.1", "/src/index.ts", 1, 0)
+	if err != nil {
+		t.Fatalf("GetSymbolAtPosition: %v", err)
+	}
+	if info.Name != "foo" {
+		t.Errorf("name = %q, want %q", info.Name, "foo")
+	}
+}
+
+func TestMockErrorResponse(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		return &jsonrpcError{Code: -32600, Message: "Invalid Request"}
+	})
+
+	_, err := c.Initialize()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "Invalid Request" {
+		t.Errorf("error = %q, want %q", err.Error(), "Invalid Request")
+	}
+}
+
+func TestMockGetMembersOfSymbol(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		if req.Method == "getMembersOfSymbol" {
+			return []MemberInfo{
+				{Handle: "s00010", Name: "x"},
+				{Handle: "s00011", Name: "y"},
+			}
+		}
+		return &jsonrpcError{Code: -32601, Message: "Method not found"}
+	})
+
+	members, err := c.GetMembersOfSymbol("p.1", "s00001")
+	if err != nil {
+		t.Fatalf("GetMembersOfSymbol: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("len(members) = %d, want 2", len(members))
+	}
+	if members[0].Name != "x" {
+		t.Errorf("members[0].Name = %q, want %q", members[0].Name, "x")
+	}
+}
+
+func TestMockGetBaseTypes(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		if req.Method == "getBaseTypes" {
+			return []TypeInfo{{Handle: "t00099", DisplayName: "Base", Flags: 0}}
+		}
+		return &jsonrpcError{Code: -32601, Message: "Method not found"}
+	})
+
+	types, err := c.GetBaseTypes("p.1", "t00001")
+	if err != nil {
+		t.Fatalf("GetBaseTypes: %v", err)
+	}
+	if len(types) != 1 || types[0].DisplayName != "Base" {
+		t.Errorf("unexpected base types: %+v", types)
+	}
+}
+
+func TestMockTypeToString(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		if req.Method == "typeToString" {
+			return map[string]string{"displayName": "number | string"}
+		}
+		return &jsonrpcError{Code: -32601, Message: "Method not found"}
+	})
+
+	s, err := c.TypeToString("p.1", "t00001")
+	if err != nil {
+		t.Fatalf("TypeToString: %v", err)
+	}
+	if s != "number | string" {
+		t.Errorf("TypeToString = %q, want %q", s, "number | string")
+	}
+}
+
+func TestMockGetSemanticDiagnostics(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		if req.Method == "getSemanticDiagnostics" {
+			return []Diagnostic{{
+				File:    "/src/index.ts",
+				Line:    5,
+				Col:     3,
+				Message: "Cannot find name 'foo'.",
+			}}
+		}
+		return &jsonrpcError{Code: -32601, Message: "Method not found"}
+	})
+
+	diags, err := c.GetSemanticDiagnostics("p.1", "/src/index.ts")
+	if err != nil {
+		t.Fatalf("GetSemanticDiagnostics: %v", err)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("len(diags) = %d, want 1", len(diags))
+	}
+	if diags[0].Message != "Cannot find name 'foo'." {
+		t.Errorf("message = %q", diags[0].Message)
+	}
+}
+
+func TestMockGetTypeOfSymbol(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		if req.Method == "getTypeOfSymbol" {
+			return &TypeInfo{Handle: "t00055", DisplayName: "number", Flags: 8}
+		}
+		return &jsonrpcError{Code: -32601, Message: "Method not found"}
+	})
+
+	info, err := c.GetTypeOfSymbol("p.1", "s00001")
+	if err != nil {
+		t.Fatalf("GetTypeOfSymbol: %v", err)
+	}
+	if info.Handle != "t00055" {
+		t.Errorf("handle = %q, want %q", info.Handle, "t00055")
+	}
+	if info.DisplayName != "number" {
+		t.Errorf("displayName = %q, want %q", info.DisplayName, "number")
+	}
+}

--- a/extract/typecheck/detect.go
+++ b/extract/typecheck/detect.go
@@ -1,0 +1,36 @@
+package typecheck
+
+import (
+	"os"
+	"os/exec"
+)
+
+// DetectTsgo attempts to find the tsgo binary. Checks:
+//  1. TSGO_PATH environment variable
+//  2. "tsgo" in PATH
+//  3. npx @typescript/native-preview (fallback)
+//
+// Returns the path to the tsgo binary, or empty string if not found.
+func DetectTsgo() string {
+	// 1. Explicit env var
+	if p := os.Getenv("TSGO_PATH"); p != "" {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+
+	// 2. In PATH
+	if p, err := exec.LookPath("tsgo"); err == nil {
+		return p
+	}
+
+	// 3. npx fallback — check if npx can resolve the package
+	if npx, err := exec.LookPath("npx"); err == nil {
+		cmd := exec.Command(npx, "--yes", "@typescript/native-preview", "--version")
+		if err := cmd.Run(); err == nil {
+			return "npx @typescript/native-preview"
+		}
+	}
+
+	return ""
+}

--- a/extract/typecheck/jsonrpc.go
+++ b/extract/typecheck/jsonrpc.go
@@ -1,0 +1,29 @@
+package typecheck
+
+import "encoding/json"
+
+// jsonrpcRequest is a JSON-RPC 2.0 request.
+type jsonrpcRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      int64       `json:"id"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params"`
+}
+
+// jsonrpcResponse is a JSON-RPC 2.0 response.
+type jsonrpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *jsonrpcError   `json:"error,omitempty"`
+}
+
+// jsonrpcError represents a JSON-RPC 2.0 error.
+type jsonrpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *jsonrpcError) Error() string {
+	return e.Message
+}

--- a/extract/typecheck/types.go
+++ b/extract/typecheck/types.go
@@ -1,0 +1,42 @@
+package typecheck
+
+// InitializeResponse is returned by the initialize method.
+type InitializeResponse struct {
+	UseCaseSensitiveFileNames bool   `json:"useCaseSensitiveFileNames"`
+	CurrentDirectory          string `json:"currentDirectory"`
+}
+
+// TypeInfo describes a resolved type.
+type TypeInfo struct {
+	Handle      string `json:"handle"`
+	DisplayName string `json:"displayName"`
+	Flags       int    `json:"flags"`
+}
+
+// SymbolInfo describes a resolved symbol.
+type SymbolInfo struct {
+	Handle string `json:"handle"`
+	Name   string `json:"name"`
+	Flags  int    `json:"flags"`
+}
+
+// MemberInfo describes a member of a symbol or type.
+type MemberInfo struct {
+	Handle string `json:"handle"`
+	Name   string `json:"name"`
+}
+
+// Diagnostic represents a type error or warning from the checker.
+type Diagnostic struct {
+	File    string `json:"file"`
+	Line    int    `json:"line"`
+	Col     int    `json:"col"`
+	Message string `json:"message"`
+}
+
+// Location is a source position for batch queries.
+type Location struct {
+	File string `json:"file"`
+	Line int    `json:"line"`
+	Col  int    `json:"col"`
+}


### PR DESCRIPTION
## Summary
- Adds `extract/typecheck/` package with a JSON-RPC 2.0 client for communicating with `tsgo --api --async`
- Implements Content-Length framed LSP protocol over stdin/stdout subprocess communication
- Provides full API coverage: type queries, symbol queries, member enumeration, base types, diagnostics
- Includes `DetectTsgo()` for binary discovery (TSGO_PATH env, PATH lookup, npx fallback)
- 19 tests covering serialization, response parsing, error handling, binary detection, and mock subprocess communication

## Test plan
- [x] All 19 new tests pass (`go test ./extract/typecheck/`)
- [x] Full repo test suite passes (`go test ./...` -- 17 packages, all green)
- [ ] No existing files modified (self-contained new package)