### PR TITLE
Wire tsgo type enrichment into extraction pipeline (Phase 3b)

### DIFF
--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -119,6 +119,9 @@ func v2Manifest() *CapabilityManifest {
 			{Name: "TaintedField", Relation: "TaintedField", File: "tsq_taint.qll"},
 			{Name: "SanitizedEdge", Relation: "SanitizedEdge", File: "tsq_taint.qll"},
 			{Name: "TaintAlert", Relation: "TaintAlert", File: "tsq_taint.qll"},
+			// v3: tsgo-resolved type relations
+			{Name: "ResolvedType", Relation: "ResolvedType", File: "tsq_types.qll"},
+			{Name: "SymbolType", Relation: "SymbolType", File: "tsq_types.qll"},
 			// v2 Phase 2b: CodeQL-compatible DataFlow module
 			{Name: "DataFlow::Node", Relation: "Symbol", File: "compat_dataflow.qll"},
 			{Name: "DataFlow::PathNode", Relation: "Symbol", File: "compat_dataflow.qll"},

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -9,8 +9,8 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	m := V1Manifest()
 	// v2: 28 original + 5 promoted from unavailable + 12 new v2 = 45
 	// But some relations share bridge classes. Count: 28 + 17 = 45
-	if got := len(m.Available); got != 80 {
-		t.Errorf("expected 80 available classes, got %d", got)
+	if got := len(m.Available); got != 82 {
+		t.Errorf("expected 82 available classes, got %d", got)
 	}
 }
 

--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -255,15 +255,22 @@ func enrichWithTsgo(_ context.Context, database *db.DB, tsgoPath, rootDir string
 		// Populate ResolvedType and SymbolType/ExprType relations
 		for _, fact := range facts {
 			typeID := extract.TypeEntityID(fact.TypeHandle)
-			database.Relation("ResolvedType").AddTuple(database, typeID, fact.TypeDisplay)
+			if err := database.Relation("ResolvedType").AddTuple(database, typeID, fact.TypeDisplay); err != nil {
+				fmt.Fprintf(stderr, "warning: add ResolvedType: %v\n", err)
+				continue
+			}
 
 			// Map position back to a node ID for ExprType
 			nodeID := extract.PositionNodeID(filePath, fact.Line, fact.Col)
-			database.Relation("ExprType").AddTuple(database, nodeID, typeID)
+			if err := database.Relation("ExprType").AddTuple(database, nodeID, typeID); err != nil {
+				fmt.Fprintf(stderr, "warning: add ExprType: %v\n", err)
+			}
 
 			// If we can resolve a symbol at this position, populate SymbolType
 			symID := extract.SymID(filePath, "", fact.Line, fact.Col)
-			database.Relation("SymbolType").AddTuple(database, symID, typeID)
+			if err := database.Relation("SymbolType").AddTuple(database, symID, typeID); err != nil {
+				fmt.Fprintf(stderr, "warning: add SymbolType: %v\n", err)
+			}
 		}
 	}
 
@@ -292,13 +299,7 @@ func collectEnrichmentPositions(database *db.DB, filePath string) []typecheck.Po
 			continue
 		}
 		switch kind {
-		case "VariableDeclarator", "RequiredParameter", "OptionalParameter",
-			"FormalParameters", "Identifier":
-			// Only collect Identifier nodes that are inside declarations
-			// For simplicity, collect VariableDeclarator and parameter kinds
-			if kind == "Identifier" {
-				continue
-			}
+		case "VariableDeclarator", "RequiredParameter", "OptionalParameter":
 			line, err := nodeRel.GetInt(i, 3) // col 3 = startLine
 			if err != nil {
 				continue

--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Gjdoalfnrxu/tsq/bridge"
 	"github.com/Gjdoalfnrxu/tsq/extract"
 	"github.com/Gjdoalfnrxu/tsq/extract/db"
+	"github.com/Gjdoalfnrxu/tsq/extract/typecheck"
 	"github.com/Gjdoalfnrxu/tsq/output"
 	"github.com/Gjdoalfnrxu/tsq/ql/ast"
 	"github.com/Gjdoalfnrxu/tsq/ql/desugar"
@@ -121,6 +122,7 @@ func cmdExtract(ctx context.Context, args []string, stdout, stderr io.Writer) in
 	dir := fs.String("dir", ".", "project root directory")
 	outputFile := fs.String("output", "tsq.db", "output fact database file")
 	backendFlag := fs.String("backend", "treesitter", "extraction backend: treesitter or vendored")
+	tsgoFlag := fs.String("tsgo", "", "tsgo binary path (empty=auto-detect, \"off\"=disabled)")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -132,7 +134,7 @@ func cmdExtract(ctx context.Context, args []string, stdout, stderr io.Writer) in
 	fmt.Fprintf(stderr, "extracting from %s (requires CGO_ENABLED=1 for tree-sitter)...\n", *dir)
 
 	database := db.NewDB()
-	walker := extract.NewFactWalker(database)
+	walker := extract.NewTypeAwareWalker(database)
 
 	var backend extract.ExtractorBackend
 	switch *backendFlag {
@@ -154,6 +156,15 @@ func cmdExtract(ctx context.Context, args []string, stdout, stderr io.Writer) in
 	if err := walker.Run(ctx, backend, cfg); err != nil {
 		fmt.Fprintf(stderr, "error: extraction failed: %v\n", err)
 		return 1
+	}
+
+	// tsgo type enrichment phase
+	tsgoPath := resolveTsgo(*tsgoFlag)
+	if tsgoPath != "" {
+		if err := enrichWithTsgo(ctx, database, tsgoPath, *dir, stderr); err != nil {
+			fmt.Fprintf(stderr, "warning: tsgo enrichment failed: %v\n", err)
+			// Continue without type info — graceful degradation
+		}
 	}
 
 	// Write to a temp file first, rename on success to avoid partial output.
@@ -189,6 +200,121 @@ func cmdExtract(ctx context.Context, args []string, stdout, stderr io.Writer) in
 
 	fmt.Fprintf(stderr, "wrote %s\n", *outputFile)
 	return 0
+}
+
+// resolveTsgo determines the tsgo binary path from the flag value.
+// Returns empty string if tsgo is disabled or not found.
+func resolveTsgo(flag string) string {
+	if flag == "off" {
+		return ""
+	}
+	if flag != "" {
+		return flag // explicit path
+	}
+	// Auto-detect
+	return typecheck.DetectTsgo()
+}
+
+// enrichWithTsgo runs tsgo type enrichment over extracted files in the database.
+// It queries tsgo for types at variable declaration and parameter positions,
+// then populates ResolvedType, SymbolType, and ExprType relations.
+func enrichWithTsgo(_ context.Context, database *db.DB, tsgoPath, rootDir string, stderr io.Writer) error {
+	client, err := typecheck.NewClient(tsgoPath, rootDir)
+	if err != nil {
+		return fmt.Errorf("start tsgo: %w", err)
+	}
+
+	enricher, err := typecheck.NewEnricher(client, rootDir)
+	if err != nil {
+		client.Close()
+		return fmt.Errorf("init enricher: %w", err)
+	}
+	defer enricher.Close()
+
+	// Collect extracted file paths from the File relation
+	fileRel := database.Relation("File")
+	numFiles := fileRel.Tuples()
+	for i := 0; i < numFiles; i++ {
+		filePath, err := fileRel.GetString(database, i, 1) // col 1 = path
+		if err != nil {
+			continue
+		}
+
+		// Collect positions: variable declarations and parameters
+		positions := collectEnrichmentPositions(database, filePath)
+		if len(positions) == 0 {
+			continue
+		}
+
+		facts, err := enricher.EnrichFile(filePath, positions)
+		if err != nil {
+			fmt.Fprintf(stderr, "warning: tsgo enrich %s: %v\n", filePath, err)
+			continue
+		}
+
+		// Populate ResolvedType and SymbolType/ExprType relations
+		for _, fact := range facts {
+			typeID := extract.TypeEntityID(fact.TypeHandle)
+			database.Relation("ResolvedType").AddTuple(database, typeID, fact.TypeDisplay)
+
+			// Map position back to a node ID for ExprType
+			nodeID := extract.PositionNodeID(filePath, fact.Line, fact.Col)
+			database.Relation("ExprType").AddTuple(database, nodeID, typeID)
+
+			// If we can resolve a symbol at this position, populate SymbolType
+			symID := extract.SymID(filePath, "", fact.Line, fact.Col)
+			database.Relation("SymbolType").AddTuple(database, symID, typeID)
+		}
+	}
+
+	fmt.Fprintf(stderr, "tsgo type enrichment complete\n")
+	return nil
+}
+
+// collectEnrichmentPositions collects positions of variable declarations and
+// function parameters from the database for a given file.
+func collectEnrichmentPositions(database *db.DB, filePath string) []typecheck.Position {
+	fileID := extract.FileID(filePath)
+	var positions []typecheck.Position
+
+	// Collect variable declaration positions from VarDecl -> Symbol -> Node
+	// We use the Node relation directly: find nodes in this file that are
+	// VariableDeclarator or Parameter kinds.
+	nodeRel := database.Relation("Node")
+	numNodes := nodeRel.Tuples()
+	for i := 0; i < numNodes; i++ {
+		nodeFile, err := nodeRel.GetInt(i, 1) // col 1 = file
+		if err != nil || uint32(nodeFile) != fileID {
+			continue
+		}
+		kind, err := nodeRel.GetString(database, i, 2) // col 2 = kind
+		if err != nil {
+			continue
+		}
+		switch kind {
+		case "VariableDeclarator", "RequiredParameter", "OptionalParameter",
+			"FormalParameters", "Identifier":
+			// Only collect Identifier nodes that are inside declarations
+			// For simplicity, collect VariableDeclarator and parameter kinds
+			if kind == "Identifier" {
+				continue
+			}
+			line, err := nodeRel.GetInt(i, 3) // col 3 = startLine
+			if err != nil {
+				continue
+			}
+			col, err := nodeRel.GetInt(i, 4) // col 4 = startCol
+			if err != nil {
+				continue
+			}
+			positions = append(positions, typecheck.Position{
+				Line: int(line),
+				Col:  int(col),
+			})
+		}
+	}
+
+	return positions
 }
 
 func cmdQuery(ctx context.Context, args []string, stdout, stderr io.Writer) int {

--- a/extract/ids.go
+++ b/extract/ids.go
@@ -51,3 +51,26 @@ func FileID(filePath string) uint32 {
 	h.Write([]byte(filePath))
 	return uint32(h.Sum64())
 }
+
+// TypeEntityID returns a deterministic 32-bit ID for a tsgo type handle.
+// Used to create stable entity references for ResolvedType and ExprType relations.
+func TypeEntityID(typeHandle string) uint32 {
+	h := fnv.New64a()
+	h.Write([]byte("type:"))
+	h.Write([]byte(typeHandle))
+	return uint32(h.Sum64())
+}
+
+// PositionNodeID returns a deterministic 32-bit ID for a node at a file position.
+// This is a simplified version of NodeID used when only position info is available
+// (e.g., during tsgo enrichment where end position and kind aren't known).
+func PositionNodeID(filePath string, line, col int) uint32 {
+	h := fnv.New64a()
+	h.Write([]byte("posnode:"))
+	h.Write([]byte(filePath))
+	h.Write([]byte{0})
+	h.Write([]byte(strconv.Itoa(line)))
+	h.Write([]byte{0})
+	h.Write([]byte(strconv.Itoa(col)))
+	return uint32(h.Sum64())
+}

--- a/extract/schema/relations.go
+++ b/extract/schema/relations.go
@@ -345,6 +345,16 @@ func init() {
 		{Name: "fnId", Type: TypeEntityRef},
 	}})
 
+	// v3: tsgo-resolved type relations
+	RegisterRelation(RelationDef{Name: "ResolvedType", Version: 3, Columns: []ColumnDef{
+		{Name: "typeId", Type: TypeEntityRef},
+		{Name: "displayName", Type: TypeString},
+	}})
+	RegisterRelation(RelationDef{Name: "SymbolType", Version: 3, Columns: []ColumnDef{
+		{Name: "sym", Type: TypeEntityRef},
+		{Name: "typeId", Type: TypeEntityRef},
+	}})
+
 	// Diagnostics
 	RegisterRelation(RelationDef{Name: "ExtractError", Version: 1, Columns: []ColumnDef{
 		{Name: "file", Type: TypeEntityRef},

--- a/extract/schema/relations_test.go
+++ b/extract/schema/relations_test.go
@@ -34,8 +34,8 @@ func TestAllRelationsRegistered(t *testing.T) {
 }
 
 func TestRelationCount(t *testing.T) {
-	if len(Registry) != 69 {
-		t.Fatalf("expected 69 relations in registry, got %d", len(Registry))
+	if len(Registry) != 71 {
+		t.Fatalf("expected 71 relations in registry, got %d", len(Registry))
 	}
 }
 

--- a/extract/typecheck/enricher.go
+++ b/extract/typecheck/enricher.go
@@ -1,0 +1,97 @@
+package typecheck
+
+import (
+	"fmt"
+	"sync"
+)
+
+// TypeFact represents a resolved type for a source position.
+type TypeFact struct {
+	Line        int
+	Col         int
+	TypeDisplay string // human-readable type string from tsgo
+	TypeHandle  string // tsgo type handle for further queries
+}
+
+// Enricher uses a tsgo Client to enrich an extraction database with type information.
+type Enricher struct {
+	client  *Client
+	project string // project handle from tsgo (cached)
+
+	mu          sync.Mutex
+	projectOnce sync.Once
+	projectErr  error
+	rootDir     string
+}
+
+// NewEnricher creates an enricher. It initializes tsgo and opens the project.
+func NewEnricher(client *Client, rootDir string) (*Enricher, error) {
+	_, err := client.Initialize()
+	if err != nil {
+		return nil, fmt.Errorf("enricher: initialize tsgo: %w", err)
+	}
+	return &Enricher{
+		client:  client,
+		rootDir: rootDir,
+	}, nil
+}
+
+// getProject returns the cached project handle, resolving it on first call
+// using the given file path.
+func (e *Enricher) getProject(filePath string) (string, error) {
+	e.projectOnce.Do(func() {
+		e.project, e.projectErr = e.client.GetProjectForFile(filePath)
+	})
+	return e.project, e.projectErr
+}
+
+// EnrichFile queries tsgo for type information about symbols at the given positions.
+// positions is a list of (line, col) pairs representing variable declarations and
+// function parameters. The caller determines which positions to query.
+// Returns TypeFact entries for each position where tsgo returned a valid type.
+func (e *Enricher) EnrichFile(filePath string, positions []Position) ([]TypeFact, error) {
+	proj, err := e.getProject(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("enricher: get project for %s: %w", filePath, err)
+	}
+
+	var facts []TypeFact
+	for _, pos := range positions {
+		sym, err := e.client.GetSymbolAtPosition(proj, filePath, pos.Line, pos.Col)
+		if err != nil {
+			// Gracefully skip positions where tsgo can't resolve a symbol
+			continue
+		}
+		if sym.Handle == "" {
+			continue
+		}
+
+		typeInfo, err := e.client.GetTypeOfSymbol(proj, sym.Handle)
+		if err != nil {
+			continue
+		}
+		if typeInfo.Handle == "" && typeInfo.DisplayName == "" {
+			continue
+		}
+
+		facts = append(facts, TypeFact{
+			Line:        pos.Line,
+			Col:         pos.Col,
+			TypeDisplay: typeInfo.DisplayName,
+			TypeHandle:  typeInfo.Handle,
+		})
+	}
+
+	return facts, nil
+}
+
+// Close releases tsgo resources.
+func (e *Enricher) Close() error {
+	return e.client.Close()
+}
+
+// Position represents a source position to query.
+type Position struct {
+	Line int
+	Col  int
+}

--- a/extract/typecheck/enricher.go
+++ b/extract/typecheck/enricher.go
@@ -18,7 +18,6 @@ type Enricher struct {
 	client  *Client
 	project string // project handle from tsgo (cached)
 
-	mu          sync.Mutex
 	projectOnce sync.Once
 	projectErr  error
 	rootDir     string

--- a/extract/typecheck/enricher_test.go
+++ b/extract/typecheck/enricher_test.go
@@ -1,0 +1,235 @@
+package typecheck
+
+import (
+	"testing"
+)
+
+func TestEnricherEnrichFile(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		switch req.Method {
+		case "initialize":
+			return &InitializeResponse{
+				UseCaseSensitiveFileNames: true,
+				CurrentDirectory:          "/project",
+			}
+		case "getDefaultProjectForFile":
+			return map[string]string{"project": "p.test"}
+		case "getSymbolAtPosition":
+			return &SymbolInfo{Handle: "s00001", Name: "x", Flags: 0}
+		case "getTypeOfSymbol":
+			return &TypeInfo{Handle: "t00001", DisplayName: "number", Flags: 0}
+		default:
+			return &jsonrpcError{Code: -32601, Message: "Method not found"}
+		}
+	})
+
+	enricher, err := NewEnricher(c, "/project")
+	if err != nil {
+		t.Fatalf("NewEnricher: %v", err)
+	}
+
+	positions := []Position{
+		{Line: 1, Col: 4},
+		{Line: 3, Col: 6},
+	}
+
+	facts, err := enricher.EnrichFile("/project/src/index.ts", positions)
+	if err != nil {
+		t.Fatalf("EnrichFile: %v", err)
+	}
+
+	if len(facts) != 2 {
+		t.Fatalf("len(facts) = %d, want 2", len(facts))
+	}
+	if facts[0].TypeDisplay != "number" {
+		t.Errorf("facts[0].TypeDisplay = %q, want %q", facts[0].TypeDisplay, "number")
+	}
+	if facts[0].TypeHandle != "t00001" {
+		t.Errorf("facts[0].TypeHandle = %q, want %q", facts[0].TypeHandle, "t00001")
+	}
+	if facts[0].Line != 1 {
+		t.Errorf("facts[0].Line = %d, want 1", facts[0].Line)
+	}
+	if facts[1].Line != 3 {
+		t.Errorf("facts[1].Line = %d, want 3", facts[1].Line)
+	}
+}
+
+func TestEnricherHandlesSymbolError(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		switch req.Method {
+		case "initialize":
+			return &InitializeResponse{
+				UseCaseSensitiveFileNames: true,
+				CurrentDirectory:          "/project",
+			}
+		case "getDefaultProjectForFile":
+			return map[string]string{"project": "p.test"}
+		case "getSymbolAtPosition":
+			return &jsonrpcError{Code: -32000, Message: "No symbol at position"}
+		default:
+			return &jsonrpcError{Code: -32601, Message: "Method not found"}
+		}
+	})
+
+	enricher, err := NewEnricher(c, "/project")
+	if err != nil {
+		t.Fatalf("NewEnricher: %v", err)
+	}
+
+	positions := []Position{
+		{Line: 1, Col: 4},
+	}
+
+	facts, err := enricher.EnrichFile("/project/src/index.ts", positions)
+	if err != nil {
+		t.Fatalf("EnrichFile: %v", err)
+	}
+
+	// Should gracefully return empty when tsgo returns errors
+	if len(facts) != 0 {
+		t.Errorf("len(facts) = %d, want 0 (graceful degradation)", len(facts))
+	}
+}
+
+func TestEnricherHandlesTypeError(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		switch req.Method {
+		case "initialize":
+			return &InitializeResponse{
+				UseCaseSensitiveFileNames: true,
+				CurrentDirectory:          "/project",
+			}
+		case "getDefaultProjectForFile":
+			return map[string]string{"project": "p.test"}
+		case "getSymbolAtPosition":
+			return &SymbolInfo{Handle: "s00001", Name: "x", Flags: 0}
+		case "getTypeOfSymbol":
+			return &jsonrpcError{Code: -32000, Message: "Type resolution failed"}
+		default:
+			return &jsonrpcError{Code: -32601, Message: "Method not found"}
+		}
+	})
+
+	enricher, err := NewEnricher(c, "/project")
+	if err != nil {
+		t.Fatalf("NewEnricher: %v", err)
+	}
+
+	positions := []Position{
+		{Line: 1, Col: 4},
+	}
+
+	facts, err := enricher.EnrichFile("/project/src/index.ts", positions)
+	if err != nil {
+		t.Fatalf("EnrichFile: %v", err)
+	}
+
+	if len(facts) != 0 {
+		t.Errorf("len(facts) = %d, want 0 (graceful degradation)", len(facts))
+	}
+}
+
+func TestEnricherEmptySymbolHandle(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		switch req.Method {
+		case "initialize":
+			return &InitializeResponse{
+				UseCaseSensitiveFileNames: true,
+				CurrentDirectory:          "/project",
+			}
+		case "getDefaultProjectForFile":
+			return map[string]string{"project": "p.test"}
+		case "getSymbolAtPosition":
+			return &SymbolInfo{Handle: "", Name: "", Flags: 0}
+		default:
+			return &jsonrpcError{Code: -32601, Message: "Method not found"}
+		}
+	})
+
+	enricher, err := NewEnricher(c, "/project")
+	if err != nil {
+		t.Fatalf("NewEnricher: %v", err)
+	}
+
+	positions := []Position{
+		{Line: 1, Col: 4},
+	}
+
+	facts, err := enricher.EnrichFile("/project/src/index.ts", positions)
+	if err != nil {
+		t.Fatalf("EnrichFile: %v", err)
+	}
+
+	if len(facts) != 0 {
+		t.Errorf("len(facts) = %d, want 0 (empty handle should be skipped)", len(facts))
+	}
+}
+
+func TestEnricherInitializeError(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		return &jsonrpcError{Code: -32000, Message: "Init failed"}
+	})
+
+	_, err := NewEnricher(c, "/project")
+	if err == nil {
+		t.Fatal("expected error from NewEnricher when initialize fails, got nil")
+	}
+}
+
+func TestEnricherProjectError(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		switch req.Method {
+		case "initialize":
+			return &InitializeResponse{
+				UseCaseSensitiveFileNames: true,
+				CurrentDirectory:          "/project",
+			}
+		case "getDefaultProjectForFile":
+			return &jsonrpcError{Code: -32000, Message: "No project found"}
+		default:
+			return &jsonrpcError{Code: -32601, Message: "Method not found"}
+		}
+	})
+
+	enricher, err := NewEnricher(c, "/project")
+	if err != nil {
+		t.Fatalf("NewEnricher: %v", err)
+	}
+
+	positions := []Position{{Line: 1, Col: 4}}
+
+	_, err = enricher.EnrichFile("/project/src/index.ts", positions)
+	if err == nil {
+		t.Fatal("expected error when project resolution fails, got nil")
+	}
+}
+
+func TestEnricherNoPositions(t *testing.T) {
+	c := newMockClient(t, func(req jsonrpcRequest) interface{} {
+		switch req.Method {
+		case "initialize":
+			return &InitializeResponse{
+				UseCaseSensitiveFileNames: true,
+				CurrentDirectory:          "/project",
+			}
+		case "getDefaultProjectForFile":
+			return map[string]string{"project": "p.test"}
+		default:
+			return &jsonrpcError{Code: -32601, Message: "Method not found"}
+		}
+	})
+
+	enricher, err := NewEnricher(c, "/project")
+	if err != nil {
+		t.Fatalf("NewEnricher: %v", err)
+	}
+
+	facts, err := enricher.EnrichFile("/project/src/index.ts", nil)
+	if err != nil {
+		t.Fatalf("EnrichFile: %v", err)
+	}
+	if len(facts) != 0 {
+		t.Errorf("len(facts) = %d, want 0", len(facts))
+	}
+}


### PR DESCRIPTION
## Summary
- Switches `cmdExtract` from `NewFactWalker` to `NewTypeAwareWalker` as the default walker (degrades gracefully without tsgo)
- Adds `--tsgo` flag to the `extract` command: empty string = auto-detect, `"off"` = disabled, or explicit path to binary
- Creates `extract/typecheck/enricher.go` — the `Enricher` type queries tsgo for types at variable declaration and function parameter positions via `getSymbolAtPosition` + `getTypeOfSymbol`
- Adds two new v3 schema relations: `ResolvedType(typeId, displayName)` and `SymbolType(sym, typeId)` for tsgo-resolved type facts
- Adds `TypeEntityID` and `PositionNodeID` helper functions in `extract/ids.go`
- If tsgo is not found, extraction proceeds normally with a warning to stderr — no hard dependency

## Test plan
- [x] All 7 new enricher tests pass (mock client, error handling, edge cases)
- [x] Full `go test ./...` passes (71 schema relations, 82 manifest classes)
- [ ] Manual test with tsgo binary installed to verify end-to-end type fact population
- [ ] Verify `--tsgo off` flag disables enrichment
- [ ] Verify auto-detection warns when tsgo not found