### PR TITLE
Phase 3c: add Type and SymbolTypeBinding bridge classes

### DIFF
--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -122,6 +122,9 @@ func v2Manifest() *CapabilityManifest {
 			// v3: tsgo-resolved type relations
 			{Name: "ResolvedType", Relation: "ResolvedType", File: "tsq_types.qll"},
 			{Name: "SymbolType", Relation: "SymbolType", File: "tsq_types.qll"},
+			// v3 Phase 3c: bridge classes for tsgo-resolved types
+			{Name: "Type", Relation: "ResolvedType", File: "tsq_types.qll"},
+			{Name: "SymbolTypeBinding", Relation: "SymbolType", File: "tsq_types.qll"},
 			// v2 Phase 2b: CodeQL-compatible DataFlow module
 			{Name: "DataFlow::Node", Relation: "Symbol", File: "compat_dataflow.qll"},
 			{Name: "DataFlow::PathNode", Relation: "Symbol", File: "compat_dataflow.qll"},

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -9,8 +9,9 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	m := V1Manifest()
 	// v2: 28 original + 5 promoted from unavailable + 12 new v2 = 45
 	// But some relations share bridge classes. Count: 28 + 17 = 45
-	if got := len(m.Available); got != 82 {
-		t.Errorf("expected 82 available classes, got %d", got)
+	// v3 Phase 3c: +2 bridge classes (Type, SymbolTypeBinding) = 84
+	if got := len(m.Available); got != 84 {
+		t.Errorf("expected 84 available classes, got %d", got)
 	}
 }
 

--- a/bridge/tsq_types.qll
+++ b/bridge/tsq_types.qll
@@ -1,8 +1,19 @@
 /**
- * Bridge library for type-aware relations (v2).
+ * Bridge library for type-aware relations (v2/v3).
  * Maps ClassDecl, InterfaceDecl, Implements, Extends, MethodDecl,
- * MethodCall, NewExpr, ExprType, TypeDecl.
+ * MethodCall, NewExpr, ExprType, TypeDecl, Type, SymbolTypeBinding.
  */
+
+/** A resolved type (requires tsgo enrichment). */
+class Type extends @resolved_type {
+    Type() { ResolvedType(this, _) }
+
+    /** Gets the display name of this type. */
+    string getDisplayName() { ResolvedType(this, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = this.getDisplayName() }
+}
 
 /** A class declaration. */
 class ClassDecl extends @class_decl {
@@ -119,8 +130,19 @@ class ExprType extends @expr_type {
     /** Gets the expression. */
     ASTNode getExpr() { result = this }
 
-    /** Gets the type. */
-    int getType() { ExprType(this, result) }
+    /** Gets the resolved type of this expression. */
+    Type getType() { ExprType(this, result) }
+}
+
+/** A binding from a symbol to its resolved type (requires tsgo). */
+class SymbolTypeBinding extends @symbol_type {
+    SymbolTypeBinding() { SymbolType(this, _) }
+
+    /** Gets the symbol. */
+    int getSym() { result = this }
+
+    /** Gets the resolved type of this symbol. */
+    Type getType() { SymbolType(this, result) }
 }
 
 /** A type declaration (type alias, enum, etc.). */


### PR DESCRIPTION
## Summary
- Add a `Type` QL class backed by `@resolved_type` (from the v3 `ResolvedType` relation) with `getDisplayName()` and `toString()`.
- Add a `SymbolTypeBinding` QL class backed by `@symbol_type` (from the v3 `SymbolType` relation) exposing `getSym()` and `getType()`.
- Update `ExprType.getType()` to return the new `Type` class instead of a raw `int`, so expression-to-type traversal is typed.
- Register the two new bridge classes in `v2Manifest()` and bump the expected available-class count from 82 to 84.

This lets queries traverse from an expression or symbol to its tsgo-resolved type via a proper QL class, completing the bridge-library side of the Phase 3 type-aware enrichment work.

## Test plan
- [x] `go test ./bridge/... ./extract/schema/...`
- [x] `go test ./...` (full suite)
- [x] `go build ./...`