### PR TITLE
Phase 3d: type-based sanitizer detection

### DIFF
--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -125,6 +125,8 @@ func v2Manifest() *CapabilityManifest {
 			// v3 Phase 3c: bridge classes for tsgo-resolved types
 			{Name: "Type", Relation: "ResolvedType", File: "tsq_types.qll"},
 			{Name: "SymbolTypeBinding", Relation: "SymbolType", File: "tsq_types.qll"},
+			// v3 Phase 3d: type-based sanitizer detection
+			{Name: "NonTaintableType", Relation: "NonTaintableType", File: "tsq_types.qll"},
 			// v2 Phase 2b: CodeQL-compatible DataFlow module
 			{Name: "DataFlow::Node", Relation: "Symbol", File: "compat_dataflow.qll"},
 			{Name: "DataFlow::PathNode", Relation: "Symbol", File: "compat_dataflow.qll"},

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -10,8 +10,9 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	// v2: 28 original + 5 promoted from unavailable + 12 new v2 = 45
 	// But some relations share bridge classes. Count: 28 + 17 = 45
 	// v3 Phase 3c: +2 bridge classes (Type, SymbolTypeBinding) = 84
-	if got := len(m.Available); got != 84 {
-		t.Errorf("expected 84 available classes, got %d", got)
+	// v3 Phase 3d: +1 bridge class (NonTaintableType) = 85
+	if got := len(m.Available); got != 85 {
+		t.Errorf("expected 85 available classes, got %d", got)
 	}
 }
 

--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -29,6 +29,20 @@ import (
 
 const version = "0.1.0"
 
+// nonTaintablePrimitives is the set of TypeScript primitive type display names
+// whose values cannot carry string-shaped taint. A value whose resolved type
+// is one of these has typically been parsed or converted (e.g., parseInt),
+// breaking the taint chain. See Phase 3d in CODEQL-COMPAT-PLAN.md.
+var nonTaintablePrimitives = map[string]bool{
+	"number":    true,
+	"boolean":   true,
+	"bigint":    true,
+	"null":      true,
+	"undefined": true,
+	"void":      true,
+	"never":     true,
+}
+
 // run executes the CLI with the given args, writing to stdout/stderr.
 // Returns the exit code.
 func run(args []string, stdout, stderr io.Writer) int {
@@ -258,6 +272,13 @@ func enrichWithTsgo(_ context.Context, database *db.DB, tsgoPath, rootDir string
 			if err := database.Relation("ResolvedType").AddTuple(database, typeID, fact.TypeDisplay); err != nil {
 				fmt.Fprintf(stderr, "warning: add ResolvedType: %v\n", err)
 				continue
+			}
+
+			// Phase 3d: mark non-taintable primitive types for type-based sanitization.
+			if nonTaintablePrimitives[fact.TypeDisplay] {
+				if err := database.Relation("NonTaintableType").AddTuple(database, typeID); err != nil {
+					fmt.Fprintf(stderr, "warning: add NonTaintableType: %v\n", err)
+				}
 			}
 
 			// Map position back to a node ID for ExprType

--- a/extract/rules/composition_test.go
+++ b/extract/rules/composition_test.go
@@ -40,6 +40,9 @@ func compositionBaseRels(overrides map[string]*eval.Relation) map[string]*eval.R
 		"Implements":     eval.NewRelation("Implements", 2),
 		"Extends":        eval.NewRelation("Extends", 2),
 		"NewExpr":        eval.NewRelation("NewExpr", 2),
+		// v3 Phase 3d: type-based sanitization
+		"SymbolType":       eval.NewRelation("SymbolType", 2),
+		"NonTaintableType": eval.NewRelation("NonTaintableType", 1),
 	}
 	for k, v := range overrides {
 		base[k] = v

--- a/extract/rules/taint.go
+++ b/extract/rules/taint.go
@@ -46,6 +46,25 @@ func TaintRules() []datalog.Rule {
 			pos("Sanitizer", v("fn"), v("kind")),
 		),
 
+		// Rule 3b: Type-based sanitization (Phase 3d). If a flow edge lands on
+		// a symbol whose resolved type is a non-taintable primitive (number,
+		// boolean, bigint, etc.), the value was parsed or converted and no
+		// longer carries the original string-shaped taint. We quantify over
+		// kinds from TaintSource rather than TaintedSym to avoid a negation
+		// cycle with Rule 2 (which uses not SanitizedEdge).
+		// SanitizedEdge(srcSym, dstSym, kind) :-
+		//     FlowStar(srcSym, dstSym),
+		//     SymbolType(dstSym, typeId),
+		//     NonTaintableType(typeId),
+		//     TaintSource(_, kind).
+		rule("SanitizedEdge",
+			[]datalog.Term{v("srcSym"), v("dstSym"), v("kind")},
+			pos("FlowStar", v("srcSym"), v("dstSym")),
+			pos("SymbolType", v("dstSym"), v("typeId")),
+			pos("NonTaintableType", v("typeId")),
+			pos("TaintSource", w(), v("kind")),
+		),
+
 		// Rule 4: Field-sensitive taint — writing tainted value to a field.
 		// TaintedField(baseSym, fieldName, kind) :- FieldWrite(_, baseSym, fieldName, rhsExpr),
 		//     ExprMayRef(rhsExpr, rhsSym), TaintedSym(rhsSym, kind).

--- a/extract/rules/taint_test.go
+++ b/extract/rules/taint_test.go
@@ -43,6 +43,9 @@ func taintBaseRels(overrides map[string]*eval.Relation) map[string]*eval.Relatio
 		"TaintSource": eval.NewRelation("TaintSource", 2),
 		"TaintSink":   eval.NewRelation("TaintSink", 2),
 		"Sanitizer":   eval.NewRelation("Sanitizer", 2),
+		// v3 Phase 3d: type-based sanitization
+		"SymbolType":       eval.NewRelation("SymbolType", 2),
+		"NonTaintableType": eval.NewRelation("NonTaintableType", 1),
 	}
 	for k, v := range overrides {
 		base[k] = v
@@ -356,6 +359,89 @@ func TestMultipleTaintKinds(t *testing.T) {
 	}
 }
 
+// TestTaintSanitized_TypeBased_Number verifies that taint is blocked when it
+// flows into a symbol whose resolved type is a non-taintable primitive
+// (e.g., the result of parseInt → number).
+func TestTaintSanitized_TypeBased_Number(t *testing.T) {
+	// Flow: let s = req.query.x; let n = parseInt(s); sink(n);
+	// srcExpr=100, srcSym=10 (string, tainted)
+	// dstSym=20 (number, should be sanitized by type)
+	// sinkExpr=300, sinkSym=20
+	// typeId=500 marked as NonTaintableType (number)
+	baseRels := taintBaseRels(map[string]*eval.Relation{
+		"TaintSource": makeRel("TaintSource", 2, iv(100), sv("http_input")),
+		"TaintSink":   makeRel("TaintSink", 2, iv(300), sv("sql")),
+		"ExprMayRef": makeRel("ExprMayRef", 2,
+			iv(100), iv(10),
+			iv(200), iv(10), // rhs of n = parseInt(s): expr refs s
+			iv(300), iv(20), // sink expr refs n
+		),
+		"Assign": makeRel("Assign", 3, iv(210), iv(200), iv(20)),
+		"SymInFunction": makeRel("SymInFunction", 2,
+			iv(10), iv(1),
+			iv(20), iv(1),
+		),
+		// Type-based sanitizer: dstSym 20 has type 500, which is number.
+		"SymbolType":       makeRel("SymbolType", 2, iv(20), iv(500)),
+		"NonTaintableType": makeRel("NonTaintableType", 1, iv(500)),
+	})
+
+	// First assert SanitizedEdge(10, 20, http_input) is derived.
+	edgeQuery := &datalog.Query{
+		Select: []datalog.Term{v("src"), v("dst"), v("kind")},
+		Body:   []datalog.Literal{pos("SanitizedEdge", v("src"), v("dst"), v("kind"))},
+	}
+	rsEdge := planAndEval(t, AllSystemRules(), edgeQuery, baseRels)
+	if !resultContains(rsEdge, iv(10), iv(20), sv("http_input")) {
+		t.Errorf("expected SanitizedEdge(10, 20, http_input) from type-based sanitizer, got %v", rsEdge.Rows)
+	}
+
+	// Then: no TaintAlert should be produced because sym 20 is type-sanitized.
+	alertQuery := &datalog.Query{
+		Select: []datalog.Term{v("srcExpr"), v("sinkExpr"), v("srcKind"), v("sinkKind")},
+		Body:   []datalog.Literal{pos("TaintAlert", v("srcExpr"), v("sinkExpr"), v("srcKind"), v("sinkKind"))},
+	}
+	rs := planAndEval(t, AllSystemRules(), alertQuery, baseRels)
+	for _, row := range rs.Rows {
+		if len(row) >= 2 && row[0] == iv(100) && row[1] == iv(300) {
+			t.Errorf("expected no TaintAlert through type-based sanitizer, got %v", row)
+		}
+	}
+}
+
+// TestTaintSanitized_TypeBased_StringPassthrough verifies that taint is NOT
+// blocked when the destination symbol has a taintable (string) type — i.e.,
+// the type-based sanitizer rule only fires for non-taintable primitives.
+func TestTaintSanitized_TypeBased_StringPassthrough(t *testing.T) {
+	// Same shape as above but dstSym 20 has a string type (not in NonTaintableType).
+	baseRels := taintBaseRels(map[string]*eval.Relation{
+		"TaintSource": makeRel("TaintSource", 2, iv(100), sv("http_input")),
+		"TaintSink":   makeRel("TaintSink", 2, iv(300), sv("sql")),
+		"ExprMayRef": makeRel("ExprMayRef", 2,
+			iv(100), iv(10),
+			iv(200), iv(10),
+			iv(300), iv(20),
+		),
+		"Assign": makeRel("Assign", 3, iv(210), iv(200), iv(20)),
+		"SymInFunction": makeRel("SymInFunction", 2,
+			iv(10), iv(1),
+			iv(20), iv(1),
+		),
+		// Symbol type present, but type id 600 is NOT in NonTaintableType.
+		"SymbolType":       makeRel("SymbolType", 2, iv(20), iv(600)),
+		"NonTaintableType": eval.NewRelation("NonTaintableType", 1),
+	})
+
+	alertQuery := &datalog.Query{
+		Select: []datalog.Term{v("srcExpr"), v("sinkExpr"), v("srcKind"), v("sinkKind")},
+		Body:   []datalog.Literal{pos("TaintAlert", v("srcExpr"), v("sinkExpr"), v("srcKind"), v("sinkKind"))},
+	}
+	rs := planAndEval(t, AllSystemRules(), alertQuery, baseRels)
+	if !resultContains(rs, iv(100), iv(300), sv("http_input"), sv("sql")) {
+		t.Errorf("expected TaintAlert(100, 300, http_input, sql) — string type should not sanitize, got %v", rs.Rows)
+	}
+}
+
 // TestTaintRulesValidate verifies all taint rules pass the planner's validation.
 func TestTaintRulesValidate(t *testing.T) {
 	for i, r := range TaintRules() {
@@ -375,11 +461,11 @@ func TestTaintRulesStratify(t *testing.T) {
 	}
 }
 
-// TestTaintRulesCount verifies we produce exactly 6 taint rules.
+// TestTaintRulesCount verifies we produce exactly 7 taint rules.
 func TestTaintRulesCount(t *testing.T) {
 	rules := TaintRules()
-	if len(rules) != 6 {
-		t.Errorf("expected 6 taint rules, got %d", len(rules))
+	if len(rules) != 7 {
+		t.Errorf("expected 7 taint rules, got %d", len(rules))
 	}
 }
 

--- a/extract/schema/relations.go
+++ b/extract/schema/relations.go
@@ -354,6 +354,11 @@ func init() {
 		{Name: "sym", Type: TypeEntityRef},
 		{Name: "typeId", Type: TypeEntityRef},
 	}})
+	// v3 Phase 3d: non-taintable primitive types (number, boolean, etc.)
+	// identified by display name, used by taint analysis as a type-based sanitizer.
+	RegisterRelation(RelationDef{Name: "NonTaintableType", Version: 3, Columns: []ColumnDef{
+		{Name: "typeId", Type: TypeEntityRef},
+	}})
 
 	// Diagnostics
 	RegisterRelation(RelationDef{Name: "ExtractError", Version: 1, Columns: []ColumnDef{

--- a/extract/schema/relations_test.go
+++ b/extract/schema/relations_test.go
@@ -34,8 +34,8 @@ func TestAllRelationsRegistered(t *testing.T) {
 }
 
 func TestRelationCount(t *testing.T) {
-	if len(Registry) != 71 {
-		t.Fatalf("expected 71 relations in registry, got %d", len(Registry))
+	if len(Registry) != 72 {
+		t.Fatalf("expected 72 relations in registry, got %d", len(Registry))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `NonTaintableType(typeId)` relation (schema v3) populated during tsgo enrichment for primitive types that break string-shaped taint (`number`, `boolean`, `bigint`, `null`, `undefined`, `void`, `never`).
- Adds a new `SanitizedEdge` clause in the taint rule set that fires when a flow edge lands on a symbol whose resolved type is non-taintable — models the `parseInt`/`Number(x)` pattern without needing per-function sanitizer models.
- Exposes `NonTaintableType` via the bridge manifest.

## Design notes

The natural formulation of the rule would be

```
SanitizedEdge(src, dst, kind) :-
    TaintedSym(src, kind), FlowStar(src, dst),
    SymbolType(dst, t), NonTaintableType(t).
```

but that creates a stratification cycle: `TaintedSym` already depends on `not SanitizedEdge`. The rule instead quantifies `kind` over `TaintSource(_, kind)`, which is a base relation and breaks the cycle while yielding the same set of alerts (any kind that appears in a source is the only kind that could ever taint anything).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages green
- [x] New unit tests:
  - `TestTaintSanitized_TypeBased_Number` — `parseInt`-style flow: verifies `SanitizedEdge(10, 20, http_input)` is derived and no `TaintAlert` reaches the sink.
  - `TestTaintSanitized_TypeBased_StringPassthrough` — control case: when the destination has a non-primitive type, the alert still fires.
- [x] `TaintRulesCount` bumped 6 -> 7, relation registry count bumped 71 -> 72, manifest available count 84 -> 85.