### PR TITLE
Harden weak tests flagged in test quality audit

### DIFF
--- a/bridge/compat_dataflow_test.go
+++ b/bridge/compat_dataflow_test.go
@@ -183,7 +183,10 @@ func TestDataFlowNodeMembers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
-	rm, _ := resolve.Resolve(mod, nil)
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
 
 	nodeClass, ok := rm.Env.Classes["DataFlow::Node"]
 	if !ok {

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -34,15 +34,6 @@ func TestAllRelationsCovered(t *testing.T) {
 	}
 }
 
-// TestCheckQueryWarnings verifies that importing unavailable classes produces warnings.
-func TestCheckQueryWarnings(t *testing.T) {
-	m := V1Manifest()
-	warnings := m.CheckQuery([]string{"TaintTracking", "ASTNode", "UnknownModule"})
-	if len(warnings) != 0 {
-		t.Errorf("expected 0 warnings (TaintTracking now available, others not in unavailable list), got %d", len(warnings))
-	}
-}
-
 // TestCheckQueryNoWarnings verifies that importing available classes produces no warnings.
 func TestCheckQueryNoWarnings(t *testing.T) {
 	m := V1Manifest()

--- a/extract/rules/callgraph_test.go
+++ b/extract/rules/callgraph_test.go
@@ -539,9 +539,11 @@ func TestInheritedMethodCallResolution(t *testing.T) {
 
 	rs := planAndEval(t, CallGraphRules(), query, baseRels)
 	// Known gap: inherited methods don't participate in call resolution yet.
-	// This test documents the current behavior. When fixed, update expected count to 1.
-	t.Logf("CallTarget rows for inherited method call: %d (0 = known gap, 1 = fixed)", len(rs.Rows))
-	// TODO: When MethodDecl is unified with MethodDeclInherited, assert len == 1 here.
+	// Pin current (broken) behaviour so a future fix flips this test red.
+	// TODO: When MethodDecl is unified with MethodDeclInherited, change expected to 1.
+	if got := len(rs.Rows); got != 0 {
+		t.Errorf("expected 0 rows (known gap), got %d — if this is the fix, update the assertion", got)
+	}
 }
 
 // TestMergeSystemRulesNilProg regression: nil program should not panic.

--- a/extract/rules/taint_test.go
+++ b/extract/rules/taint_test.go
@@ -191,8 +191,14 @@ func TestTaintAlert_SanitizedFlow(t *testing.T) {
 		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(501), iv(5)),
 		"CallArg":        makeRel("CallArg", 3, iv(500), iv(0), iv(400)),
 		"CallResultSym":  makeRel("CallResultSym", 2, iv(500), iv(30)),
-		"ReturnStmt":     makeRel("ReturnStmt", 3, iv(5), iv(81), iv(250)),
-		"ReturnSym":      makeRel("ReturnSym", 2, iv(5), iv(29)),
+		// ParamToReturn(fn=5, paramIdx=0): sanitizer passes its input through
+		// to its return value. Needed for InterFlow to produce an edge from the
+		// caller's arg sym (10) to the call result sym (30), which the sanitizer
+		// rule can then block. Without this, the SanitizedEdge rule cannot fire
+		// and the test was silently skipping (masking regressions).
+		"ParamToReturn": makeRel("ParamToReturn", 2, iv(5), iv(0)),
+		"ReturnStmt":    makeRel("ReturnStmt", 3, iv(5), iv(81), iv(250)),
+		"ReturnSym":     makeRel("ReturnSym", 2, iv(5), iv(29)),
 		"SymInFunction": makeRel("SymInFunction", 2,
 			iv(10), iv(1),
 			iv(30), iv(1),
@@ -216,7 +222,7 @@ func TestTaintAlert_SanitizedFlow(t *testing.T) {
 	}
 	rsEdge := planAndEval(t, AllSystemRules(), queryEdge, baseRels)
 	if len(rsEdge.Rows) == 0 {
-		t.Skip("SKIP: no SanitizedEdge produced — inter-procedural flow setup insufficient for this unit test. Sanitizer blocking is tested end-to-end in integration tests.")
+		t.Fatalf("expected at least one SanitizedEdge row, got 0 — sanitizer blocking has regressed or the fixture is broken")
 	}
 
 	// The key invariant: sym 30 (the sink sym) should not be tainted with "http_input"

--- a/extract/scope_test.go
+++ b/extract/scope_test.go
@@ -350,6 +350,6 @@ func TestScopeAnalyzer_TDZ_FromFile(t *testing.T) {
 		}
 	}
 	if !foundTDZ {
-		t.Log("note: no TDZ declarations found at file scope in scoping.ts — may be inside function scopes")
+		t.Fatalf("expected at least one TDZ declaration at file scope in scoping.ts, found none — TDZ analysis has regressed or the fixture is broken")
 	}
 }

--- a/extract/typecheck/client_test.go
+++ b/extract/typecheck/client_test.go
@@ -141,9 +141,13 @@ func TestNewClientBinaryNotFound(t *testing.T) {
 }
 
 func TestDetectTsgoNoEnvNoPath(t *testing.T) {
+	// With no TSGO_PATH and an empty PATH, DetectTsgo must return "".
+	// (t.Setenv automatically restores the previous value on test exit.)
 	t.Setenv("TSGO_PATH", "")
-	// This test validates the function doesn't panic.
-	_ = DetectTsgo()
+	t.Setenv("PATH", "")
+	if got := DetectTsgo(); got != "" {
+		t.Errorf("DetectTsgo() = %q, want \"\" when no env and no PATH", got)
+	}
 }
 
 func TestDetectTsgoWithEnvVar(t *testing.T) {

--- a/extract/walker_v2_test.go
+++ b/extract/walker_v2_test.go
@@ -84,20 +84,87 @@ interface Loggable {
 	}
 }
 
-// TestV2Extends verifies Extends tuples for class/interface inheritance.
+// entityIDByName scans a relation (e.g. ClassDecl, InterfaceDecl) whose
+// column 0 is an entity id and column 1 is a string name, and returns the
+// id for the first row whose name matches. Fails the test if not found.
+func entityIDByName(t *testing.T, database *db.DB, relName, name string) int32 {
+	t.Helper()
+	r := rel(t, database, relName)
+	for i := 0; i < r.Tuples(); i++ {
+		s, err := r.GetString(database, i, 1)
+		if err != nil {
+			continue
+		}
+		if s == name {
+			id, err := r.GetInt(i, 0)
+			if err != nil {
+				t.Fatalf("%s[%d].id: %v", relName, i, err)
+			}
+			return id
+		}
+	}
+	t.Fatalf("%s: no entity named %q", relName, name)
+	return 0
+}
+
+// hasIntPair returns true if relation r has a tuple with (col0=a, col1=b).
+func hasIntPair(r *db.Relation, a, b int32) bool {
+	for i := 0; i < r.Tuples(); i++ {
+		x, errA := r.GetInt(i, 0)
+		y, errB := r.GetInt(i, 1)
+		if errA == nil && errB == nil && x == a && y == b {
+			return true
+		}
+	}
+	return false
+}
+
+// hasChildID returns true if relation r has a tuple whose column 0 equals id.
+func hasChildID(r *db.Relation, id int32) bool {
+	for i := 0; i < r.Tuples(); i++ {
+		if got, err := r.GetInt(i, 0); err == nil && got == id {
+			return true
+		}
+	}
+	return false
+}
+
+// TestV2Extends verifies Extends tuples for class inheritance.
+// Pins (child=Dog's ClassDecl id, parent=some non-Dog id) so that a walker bug
+// emitting the reversed Extends(Animal, Dog) or a self-loop Extends(Dog, Dog)
+// would fail the test.
+//
+// Note: the walker currently emits Extends with the parent column referring to
+// a *type reference* entity id — not the parent ClassDecl's own id — so we
+// cannot assert parent == Animal's ClassDecl id here. The child column IS the
+// Dog ClassDecl id, which is what we pin.
 func TestV2Extends(t *testing.T) {
 	src := `
 class Animal {}
 class Dog extends Animal {}
 `
 	database := v2WalkerTestDB(t, src)
+	dogID := entityIDByName(t, database, "ClassDecl", "Dog")
+	animalID := entityIDByName(t, database, "ClassDecl", "Animal")
 	r := rel(t, database, "Extends")
 	if r.Tuples() == 0 {
 		t.Fatal("Extends: expected tuples for Dog extends Animal")
 	}
+	if !hasChildID(r, dogID) {
+		t.Errorf("Extends: no row with child=Dog's ClassDecl id (%d); rows are for a different child", dogID)
+	}
+	if hasChildID(r, animalID) {
+		t.Errorf("Extends: found row with child=Animal's ClassDecl id (%d) — child/parent columns appear reversed", animalID)
+	}
+	// Self-loop check: (Dog, Dog) would indicate the walker emitted the same id twice.
+	if hasIntPair(r, dogID, dogID) {
+		t.Errorf("Extends: found self-loop row (Dog, Dog)")
+	}
 }
 
-// TestV2Implements verifies Implements tuples.
+// TestV2Implements verifies Implements tuples. Same caveat as TestV2Extends:
+// the interface column references a type-use id, not the InterfaceDecl id, so
+// we pin only the class column (= Dog's ClassDecl id).
 func TestV2Implements(t *testing.T) {
 	src := `
 interface Serializable { serialize(): string; }
@@ -106,9 +173,20 @@ class Dog implements Serializable {
 }
 `
 	database := v2WalkerTestDB(t, src)
+	dogID := entityIDByName(t, database, "ClassDecl", "Dog")
+	ifaceID := entityIDByName(t, database, "InterfaceDecl", "Serializable")
 	r := rel(t, database, "Implements")
 	if r.Tuples() == 0 {
 		t.Fatal("Implements: expected tuples for Dog implements Serializable")
+	}
+	if !hasChildID(r, dogID) {
+		t.Errorf("Implements: no row with class=Dog's ClassDecl id (%d)", dogID)
+	}
+	if hasChildID(r, ifaceID) {
+		t.Errorf("Implements: found row with class=Serializable's InterfaceDecl id (%d) — class/iface columns appear reversed", ifaceID)
+	}
+	if hasIntPair(r, dogID, dogID) {
+		t.Errorf("Implements: found self-loop row (Dog, Dog)")
 	}
 }
 

--- a/output/json_test.go
+++ b/output/json_test.go
@@ -110,11 +110,17 @@ func TestWriteJSONLines_MultipleRows(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("lines = %d, want 2", len(lines))
 	}
-	// Each line must be valid JSON.
+	want := []string{"a", "b"}
 	for i, line := range lines {
 		var obj map[string]interface{}
 		if err := json.Unmarshal([]byte(line), &obj); err != nil {
 			t.Errorf("line %d invalid JSON: %v", i, err)
+			continue
+		}
+		if got, ok := obj["x"]; !ok {
+			t.Errorf("line %d: missing 'x' field: %v", i, obj)
+		} else if got != want[i] {
+			t.Errorf("line %d: x = %v, want %q", i, got, want[i])
 		}
 	}
 }

--- a/ql/plan/magicset_test.go
+++ b/ql/plan/magicset_test.go
@@ -86,7 +86,10 @@ func TestMagicSetTransformPreservesResults(t *testing.T) {
 			t.Fatal("magic-set plan has nil query")
 		}
 
-		// Verify structural properties: magic-set plan should have magic predicates.
+		// Verify structural properties: with a binding on the IDB predicate
+		// `Derived`, the magic-set transform must produce at least one
+		// magic_<pred> rule. If none is emitted, the transform silently
+		// no-op'd and the results-preservation guarantee is meaningless.
 		hasMagic := false
 		for _, s := range ep2.Strata {
 			for _, r := range s.Rules {
@@ -95,7 +98,9 @@ func TestMagicSetTransformPreservesResults(t *testing.T) {
 				}
 			}
 		}
-		_ = hasMagic // Base-only rules may not generate magic predicates.
+		if !hasMagic {
+			t.Fatalf("magic-set plan did not emit any magic_* rules despite Derived binding")
+		}
 
 		// NOTE: End-to-end evaluation comparison (magic-set vs naive produces
 		// identical results) is tested in the integration test at the repo root

--- a/testdata/ts/scoping.ts
+++ b/testdata/ts/scoping.ts
@@ -1,6 +1,8 @@
 // scoping.ts — nested blocks, shadowing, temporal dead zone
 
 var x = 1;
+const tdzConst = 42;
+let tdzLet = 7;
 
 function outer() {
   var x = 2; // shadows file-level x (var, function-scoped)


### PR DESCRIPTION
## Summary

Fixes all 10 weak/vacuous tests called out in the tsq test quality audit. Each fix turns a test that could silently pass into one that will flip red on the regression it claims to guard against.

**Notable:** Fix #2 (`TestTaintAlert_SanitizedFlow`) uncovered a real fixture gap. The test called `t.Skip()` whenever `SanitizedEdge` was empty — but the fixture was missing a `ParamToReturn(5, 0)` fact, which meant `InterFlow` could never produce the edge the sanitizer rule needed. `SanitizedEdge` was empty on every run and the test was silently skipping. Fixture fixed, Skip replaced with `t.Fatalf`, sanitizer blocking is now genuinely exercised.

**Partial:** Fixes #5/#6 (`TestV2Extends` / `TestV2Implements`) pin the child column to the expected `ClassDecl` id but cannot pin the parent column. The walker currently emits a type-reference id in the parent slot rather than the `ClassDecl`/`InterfaceDecl` id of the actual parent. The tests still catch the reversed-column bug the audit called out, and document the limitation.

No `t.Skip` added anywhere in this PR.

## Fix list

1. `callgraph_test.go` — `TestInheritedMethodCallResolution` pins `len(rs.Rows) == 0` (known gap)
2. `taint_test.go` — fixture gap fixed, `Skip` → `Fatalf`
3. `magicset_test.go` — assert `hasMagic == true` instead of discarding
4. `manifest_test.go` — delete vacuous `TestCheckQueryWarnings` duplicate
5. `walker_v2_test.go` — `TestV2Extends` pins child id, rejects reversed row
6. `walker_v2_test.go` — `TestV2Implements` same fix
7. `output/json_test.go` — `TestWriteJSONLines_MultipleRows` asserts `x` field values
8. `bridge/compat_dataflow_test.go` — `TestDataFlowNodeMembers` fatals on resolve error
9. `extract/scope_test.go` — `TestScopeAnalyzer_TDZ_FromFile` fatals on no-TDZ; fixture gained file-level `const`/`let`
10. `extract/typecheck/client_test.go` — `TestDetectTsgoNoEnvNoPath` clears PATH and asserts `""`

## Test plan

- [x] `go test ./...` passes locally
- [ ] CI green on the PR