### PR TITLE
Add property tests for parser, db, taint monotonicity, desugar

### DIFF
--- a/extract/db/property_test.go
+++ b/extract/db/property_test.go
@@ -1,0 +1,149 @@
+package db_test
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/extract/db"
+	"github.com/Gjdoalfnrxu/tsq/extract/schema"
+	"pgregory.net/rapid"
+)
+
+// TestPropertyEncodeDecodeRoundtrip verifies that for any sequence of AddTuple
+// calls against any registered relation, Encode -> ReadDB produces a DB that
+// is tuple-wise identical to the original. This is an end-to-end format check:
+// it catches regressions in column ordering, length prefixes, string interning,
+// padding, or any other byte-level format drift between writer and reader.
+//
+// The oracle is "structural equality with the source DB", not "the decoded DB
+// parses" — we compare every tuple column-by-column using the schema.
+func TestPropertyEncodeDecodeRoundtrip(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		// Pick a non-empty subset of registry relations to exercise.
+		// Use a named generator so rapid can shrink the subset.
+		if len(schema.Registry) == 0 {
+			t.Skip("registry empty — nothing to test")
+		}
+
+		// Generate a flag per registered relation deciding whether to populate it.
+		use := make([]bool, len(schema.Registry))
+		anySelected := false
+		for i := range schema.Registry {
+			use[i] = rapid.Bool().Draw(t, fmt.Sprintf("use_%s", schema.Registry[i].Name))
+			if use[i] {
+				anySelected = true
+			}
+		}
+		if !anySelected {
+			// Force at least one relation so the test exercises the writer/reader path.
+			idx := rapid.IntRange(0, len(schema.Registry)-1).Draw(t, "forceIdx")
+			use[idx] = true
+		}
+
+		srcDB := db.NewDB()
+
+		// For each selected relation, generate a small batch of random tuples.
+		// Keep counts low so the corpus remains fast but still produces non-empty
+		// columns (a vacuous generator is forbidden by the property-test brief).
+		for i, def := range schema.Registry {
+			if !use[i] {
+				continue
+			}
+			rel := srcDB.Relation(def.Name)
+			nTuples := rapid.IntRange(1, 6).Draw(t, fmt.Sprintf("nTuples_%s", def.Name))
+			for tu := 0; tu < nTuples; tu++ {
+				vals := make([]interface{}, len(def.Columns))
+				for ci, col := range def.Columns {
+					switch col.Type {
+					case schema.TypeInt32, schema.TypeEntityRef:
+						// Small range keeps shrinking useful.
+						vals[ci] = int32(rapid.IntRange(-1000, 1000).Draw(
+							t, fmt.Sprintf("int_%s_%s_%d", def.Name, col.Name, tu)))
+					case schema.TypeString:
+						// Include empty and non-empty strings; include potentially
+						// shared strings so interning is exercised both ways.
+						vals[ci] = rapid.SampledFrom([]string{
+							"", "a", "b", "ab", "hello", "world", "αβ", "tab\there",
+							strconv.Itoa(tu),
+						}).Draw(t, fmt.Sprintf("str_%s_%s_%d", def.Name, col.Name, tu))
+					default:
+						t.Fatalf("unhandled column type %v on %s.%s", col.Type, def.Name, col.Name)
+					}
+				}
+				if err := rel.AddTuple(srcDB, vals...); err != nil {
+					t.Fatalf("AddTuple(%s): %v", def.Name, err)
+				}
+			}
+		}
+
+		// Encode -> Decode
+		var buf bytes.Buffer
+		if err := srcDB.Encode(&buf); err != nil {
+			t.Fatalf("Encode: %v", err)
+		}
+		data := buf.Bytes()
+		decoded, err := db.ReadDB(bytes.NewReader(data), int64(len(data)))
+		if err != nil {
+			t.Fatalf("ReadDB: %v", err)
+		}
+
+		// Compare every registry relation tuple-by-tuple. We use sorted serialised
+		// tuples so legitimate row reorderings (which the format does not promise
+		// to preserve anyway) do not cause spurious failures — but any actual
+		// value-level drift fails immediately.
+		for _, def := range schema.Registry {
+			srcRel := srcDB.Relation(def.Name)
+			gotRel := decoded.Relation(def.Name)
+
+			srcTuples := dumpTuples(t, srcDB, srcRel, def)
+			gotTuples := dumpTuples(t, decoded, gotRel, def)
+			sort.Strings(srcTuples)
+			sort.Strings(gotTuples)
+
+			if len(srcTuples) != len(gotTuples) {
+				t.Fatalf("relation %s: tuple count mismatch: src=%d decoded=%d\n  src: %s\n  got: %s",
+					def.Name, len(srcTuples), len(gotTuples),
+					strings.Join(srcTuples, "|"), strings.Join(gotTuples, "|"))
+			}
+			for k := range srcTuples {
+				if srcTuples[k] != gotTuples[k] {
+					t.Fatalf("relation %s row %d mismatch:\n  src: %q\n  got: %q",
+						def.Name, k, srcTuples[k], gotTuples[k])
+				}
+			}
+		}
+	})
+}
+
+// dumpTuples serialises each tuple in rel as "col0|col1|..." using the schema
+// to dispatch per-column accessors. Mirrors compat_test.go:serializeTuples.
+func dumpTuples(t *rapid.T, database *db.DB, rel *db.Relation, def schema.RelationDef) []string {
+	n := rel.Tuples()
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		parts := make([]string, 0, len(def.Columns))
+		for j, col := range def.Columns {
+			switch col.Type {
+			case schema.TypeInt32, schema.TypeEntityRef:
+				v, err := rel.GetInt(i, j)
+				if err != nil {
+					t.Fatalf("GetInt(%s,%d,%d): %v", def.Name, i, j, err)
+				}
+				parts = append(parts, strconv.FormatInt(int64(v), 10))
+			case schema.TypeString:
+				v, err := rel.GetString(database, i, j)
+				if err != nil {
+					t.Fatalf("GetString(%s,%d,%d): %v", def.Name, i, j, err)
+				}
+				// Escape pipe to avoid parse ambiguity in error output.
+				parts = append(parts, strings.ReplaceAll(v, "|", `\|`))
+			}
+		}
+		out = append(out, strings.Join(parts, "|"))
+	}
+	return out
+}

--- a/extract/rules/taint_monotone_property_test.go
+++ b/extract/rules/taint_monotone_property_test.go
@@ -1,0 +1,303 @@
+package rules
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+	"pgregory.net/rapid"
+)
+
+// TestPropertyTaintMonotonicity is a go test entry point; the actual property
+// lives in testPropertyTaintMonotonicityBody so it can be called from both
+// this harness and any future coverage driver.
+var _ testing.TB = (*testing.T)(nil)
+
+// TestPropertyTaintMonotonicity checks that adding more TaintSource, TaintSink,
+// ExprMayRef, or FlowStar-seed (Assign) tuples can only add TaintAlert rows,
+// never remove them.
+//
+// The property explicitly EXCLUDES sanitizer-related inputs (Sanitizer,
+// SymbolType, NonTaintableType), because those can legitimately block flow —
+// adding one can remove a TaintAlert by design. Adding more "taint-enabling"
+// facts to a positive (non-sanitizer) input must be monotone on TaintAlert.
+//
+// Real-world bug class caught: a rule in the taint stack accidentally using
+// stratified negation in a non-monotone position (e.g. deriving an "unsafe"
+// predicate via `not SomeTaintPred(...)`), which was exactly the risk we fixed
+// in PR #36 (type-based sanitizers). An empirical monotonicity check would
+// catch a broken SanitizedEdge derivation or any future regression where a
+// positive rule accidentally reads through a negation it shouldn't.
+func TestPropertyTaintMonotonicity(t *testing.T) {
+	var baseAlertsSeen, extOnlyAlertsSeen int
+	rapid.Check(t, func(t *rapid.T) {
+		seed := genTaintSeed(t)
+
+		// Evaluate the base program.
+		baseAlerts := evalTaintAlerts(t, seed)
+		if len(baseAlerts) > 0 {
+			baseAlertsSeen++
+		}
+
+		// Pick a "category" of fact to add and generate an additional tuple.
+		category := rapid.SampledFrom([]string{
+			"TaintSource", "TaintSink", "ExprMayRef", "Assign",
+		}).Draw(t, "category")
+
+		extended := cloneSeed(seed)
+		addTaintFact(t, extended, category)
+
+		extAlerts := evalTaintAlerts(t, extended)
+		if len(extAlerts) > len(baseAlerts) {
+			extOnlyAlertsSeen++
+		}
+
+		// Every base alert must still appear in the extended run.
+		extSet := make(map[string]bool, len(extAlerts))
+		for _, a := range extAlerts {
+			extSet[a] = true
+		}
+		for _, a := range baseAlerts {
+			if !extSet[a] {
+				t.Fatalf("monotonicity violated: alert %q present in base but absent after adding %s tuple\nbase: %v\next:  %v",
+					a, category, baseAlerts, extAlerts)
+			}
+		}
+	})
+
+	// Guard against a vacuous property: if we never saw a non-empty alert set
+	// in either the base or the extended run, the generator never exercised
+	// the code under test. Fail loudly rather than silently passing.
+	if baseAlertsSeen == 0 && extOnlyAlertsSeen == 0 {
+		t.Fatalf("property is vacuous: no iteration produced any TaintAlert — generator does not exercise taint rules")
+	}
+}
+
+// taintSeed is a bag of tuples for the relations the monotonicity property
+// mutates. Other relations stay empty (taintBaseRels handles that).
+type taintSeed struct {
+	taintSource [][2]eval.Value // (expr, kind)
+	taintSink   [][2]eval.Value // (expr, kind)
+	exprMayRef  [][2]eval.Value // (expr, sym)
+	assign      [][3]eval.Value // (node, rhsExpr, lhsSym)
+	symInFn     [][2]eval.Value // (sym, fn)
+}
+
+func cloneSeed(s *taintSeed) *taintSeed {
+	out := &taintSeed{
+		taintSource: append([][2]eval.Value(nil), s.taintSource...),
+		taintSink:   append([][2]eval.Value(nil), s.taintSink...),
+		exprMayRef:  append([][2]eval.Value(nil), s.exprMayRef...),
+		assign:      append([][3]eval.Value(nil), s.assign...),
+		symInFn:     append([][2]eval.Value(nil), s.symInFn...),
+	}
+	return out
+}
+
+func genTaintSeed(t *rapid.T) *taintSeed {
+	s := &taintSeed{}
+
+	// Work in small integer ID pools so joins actually fire.
+	// exprPool and symPool are deliberately overlapping small ranges — this
+	// maximises the chance that a TaintSource expression is also referenced
+	// by an ExprMayRef tuple, so the taint rules have something to propagate.
+	exprID := func(name string) eval.IntVal {
+		return iv(int64(100 + rapid.IntRange(0, 9).Draw(t, name)))
+	}
+	symID := func(name string) eval.IntVal {
+		return iv(int64(10 + rapid.IntRange(0, 7).Draw(t, name)))
+	}
+	fnID := func(name string) eval.IntVal {
+		return iv(int64(1 + rapid.IntRange(0, 2).Draw(t, name)))
+	}
+	kindV := func(name string) eval.StrVal {
+		return sv(rapid.SampledFrom([]string{"http_input", "env", "user"}).Draw(t, name))
+	}
+
+	nSource := rapid.IntRange(1, 3).Draw(t, "nSource")
+	for i := 0; i < nSource; i++ {
+		s.taintSource = append(s.taintSource, [2]eval.Value{
+			exprID(fmt.Sprintf("srcExpr_%d", i)),
+			kindV(fmt.Sprintf("srcKind_%d", i)),
+		})
+	}
+
+	nSink := rapid.IntRange(1, 3).Draw(t, "nSink")
+	for i := 0; i < nSink; i++ {
+		s.taintSink = append(s.taintSink, [2]eval.Value{
+			exprID(fmt.Sprintf("sinkExpr_%d", i)),
+			kindV(fmt.Sprintf("sinkKind_%d", i)),
+		})
+	}
+
+	nRef := rapid.IntRange(2, 8).Draw(t, "nRef")
+	for i := 0; i < nRef; i++ {
+		s.exprMayRef = append(s.exprMayRef, [2]eval.Value{
+			exprID(fmt.Sprintf("refExpr_%d", i)),
+			symID(fmt.Sprintf("refSym_%d", i)),
+		})
+	}
+
+	nAssign := rapid.IntRange(0, 4).Draw(t, "nAssign")
+	for i := 0; i < nAssign; i++ {
+		s.assign = append(s.assign, [3]eval.Value{
+			iv(int64(300 + i)),
+			exprID(fmt.Sprintf("assignRhs_%d", i)),
+			symID(fmt.Sprintf("assignLhs_%d", i)),
+		})
+	}
+
+	// Register every sym used above in a function so FlowStar can fire.
+	// Use a small number of fns so syms co-locate and flow edges compose.
+	regSyms := make(map[eval.Value]bool)
+	for _, r := range s.exprMayRef {
+		regSyms[r[1]] = true
+	}
+	for _, a := range s.assign {
+		regSyms[a[2]] = true
+	}
+	i := 0
+	for sym := range regSyms {
+		s.symInFn = append(s.symInFn, [2]eval.Value{
+			sym, fnID(fmt.Sprintf("symFn_%d", i)),
+		})
+		i++
+	}
+
+	return s
+}
+
+// addTaintFact mutates seed in place, adding one new tuple to the named
+// category. The added tuple must be genuinely new (not already present),
+// otherwise the "extended" run is identical to the base and the property
+// collapses to a tautology.
+func addTaintFact(t *rapid.T, seed *taintSeed, category string) {
+	switch category {
+	case "TaintSource":
+		for attempt := 0; attempt < 16; attempt++ {
+			expr := iv(int64(100 + rapid.IntRange(0, 15).Draw(t, fmt.Sprintf("newSrcExpr_%d", attempt))))
+			kind := sv(rapid.SampledFrom([]string{"http_input", "env", "user", "rpc"}).Draw(t, fmt.Sprintf("newSrcKind_%d", attempt)))
+			tup := [2]eval.Value{expr, kind}
+			if !containsPair(seed.taintSource, tup) {
+				seed.taintSource = append(seed.taintSource, tup)
+				return
+			}
+		}
+		// Fallback: force a novel one using a distinct ID range.
+		seed.taintSource = append(seed.taintSource, [2]eval.Value{iv(999), sv("__novel__")})
+	case "TaintSink":
+		for attempt := 0; attempt < 16; attempt++ {
+			expr := iv(int64(100 + rapid.IntRange(0, 15).Draw(t, fmt.Sprintf("newSinkExpr_%d", attempt))))
+			kind := sv(rapid.SampledFrom([]string{"sql", "cmd", "path"}).Draw(t, fmt.Sprintf("newSinkKind_%d", attempt)))
+			tup := [2]eval.Value{expr, kind}
+			if !containsPair(seed.taintSink, tup) {
+				seed.taintSink = append(seed.taintSink, tup)
+				return
+			}
+		}
+		seed.taintSink = append(seed.taintSink, [2]eval.Value{iv(998), sv("__novel_sink__")})
+	case "ExprMayRef":
+		for attempt := 0; attempt < 16; attempt++ {
+			expr := iv(int64(100 + rapid.IntRange(0, 15).Draw(t, fmt.Sprintf("newRefExpr_%d", attempt))))
+			sym := iv(int64(10 + rapid.IntRange(0, 9).Draw(t, fmt.Sprintf("newRefSym_%d", attempt))))
+			tup := [2]eval.Value{expr, sym}
+			if !containsPair(seed.exprMayRef, tup) {
+				seed.exprMayRef = append(seed.exprMayRef, tup)
+				// Keep the new sym in some function so flow rules can use it.
+				seed.symInFn = append(seed.symInFn, [2]eval.Value{sym, iv(1)})
+				return
+			}
+		}
+	case "Assign":
+		// Assign seeds LocalFlow, which feeds FlowStar. Adding an Assign tuple
+		// can only add flow edges, not remove them, so it is monotone on alerts.
+		for attempt := 0; attempt < 16; attempt++ {
+			node := iv(int64(500 + rapid.IntRange(0, 30).Draw(t, fmt.Sprintf("newAssignNode_%d", attempt))))
+			rhs := iv(int64(100 + rapid.IntRange(0, 15).Draw(t, fmt.Sprintf("newAssignRhs_%d", attempt))))
+			lhs := iv(int64(10 + rapid.IntRange(0, 9).Draw(t, fmt.Sprintf("newAssignLhs_%d", attempt))))
+			tup := [3]eval.Value{node, rhs, lhs}
+			if !containsTriple(seed.assign, tup) {
+				seed.assign = append(seed.assign, tup)
+				seed.symInFn = append(seed.symInFn, [2]eval.Value{lhs, iv(1)})
+				return
+			}
+		}
+	}
+}
+
+func containsPair(xs [][2]eval.Value, t [2]eval.Value) bool {
+	for _, x := range xs {
+		if x == t {
+			return true
+		}
+	}
+	return false
+}
+func containsTriple(xs [][3]eval.Value, t [3]eval.Value) bool {
+	for _, x := range xs {
+		if x == t {
+			return true
+		}
+	}
+	return false
+}
+
+// evalTaintAlerts runs AllSystemRules over the seeded base relations and
+// returns the TaintAlert rows as sorted strings. Any failure to plan or
+// evaluate is a hard test failure — not a property violation, but an infra
+// problem with the seed.
+func evalTaintAlerts(t *rapid.T, seed *taintSeed) []string {
+	// Build the base relations from the seed.
+	srcVals := make([]eval.Value, 0, 2*len(seed.taintSource))
+	for _, x := range seed.taintSource {
+		srcVals = append(srcVals, x[0], x[1])
+	}
+	sinkVals := make([]eval.Value, 0, 2*len(seed.taintSink))
+	for _, x := range seed.taintSink {
+		sinkVals = append(sinkVals, x[0], x[1])
+	}
+	refVals := make([]eval.Value, 0, 2*len(seed.exprMayRef))
+	for _, x := range seed.exprMayRef {
+		refVals = append(refVals, x[0], x[1])
+	}
+	assignVals := make([]eval.Value, 0, 3*len(seed.assign))
+	for _, x := range seed.assign {
+		assignVals = append(assignVals, x[0], x[1], x[2])
+	}
+	sifVals := make([]eval.Value, 0, 2*len(seed.symInFn))
+	for _, x := range seed.symInFn {
+		sifVals = append(sifVals, x[0], x[1])
+	}
+
+	base := taintBaseRels(map[string]*eval.Relation{
+		"TaintSource":   makeRel("TaintSource", 2, srcVals...),
+		"TaintSink":     makeRel("TaintSink", 2, sinkVals...),
+		"ExprMayRef":    makeRel("ExprMayRef", 2, refVals...),
+		"Assign":        makeRel("Assign", 3, assignVals...),
+		"SymInFunction": makeRel("SymInFunction", 2, sifVals...),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("srcExpr"), v("sinkExpr"), v("srcKind"), v("sinkKind")},
+		Body:   []datalog.Literal{pos("TaintAlert", v("srcExpr"), v("sinkExpr"), v("srcKind"), v("sinkKind"))},
+	}
+
+	prog := &datalog.Program{Rules: AllSystemRules(), Query: query}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) > 0 {
+		t.Fatalf("plan: %v", errs)
+	}
+	rs, err := eval.Evaluate(context.Background(), ep, base)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+
+	out := make([]string, 0, len(rs.Rows))
+	for _, row := range rs.Rows {
+		out = append(out, fmt.Sprintf("%v", row))
+	}
+	return out
+}

--- a/ql/desugar/property_test.go
+++ b/ql/desugar/property_test.go
@@ -1,0 +1,274 @@
+package desugar_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/desugar"
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+	"github.com/Gjdoalfnrxu/tsq/ql/parse"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+	"github.com/Gjdoalfnrxu/tsq/ql/resolve"
+	"pgregory.net/rapid"
+)
+
+// TestPropertyDesugarSemanticsCommutativity checks a real semantic-preservation
+// property of the desugar pass: for any pair of QL sources that differ only
+// by the order of conjuncts in a where clause (or by any algebraic rewriting
+// we know to be semantics-preserving), the desugared-and-evaluated results
+// must be identical over any base-fact assignment.
+//
+// The oracle is NOT "the desugared program". We compare two INDEPENDENT
+// pipelines:
+//
+//	pipeline A: parse(srcA) -> resolve -> desugar -> eval
+//	pipeline B: parse(srcB) -> resolve -> desugar -> eval
+//
+// srcA and srcB are known to be semantically equivalent QL. Any asymmetric
+// treatment in resolve or desugar that leaks into the datalog IR shows up as
+// divergent query results on the same random base facts.
+//
+// Real bug class caught: desugar rules that accidentally depend on conjunct
+// ordering (e.g., binding analysis that only succeeds with a specific
+// ordering, or a lost clause during normalisation). Example bugs
+// caught would be a rewrite that drops a conjunct after a recursive
+// simplification, or picks a binding hint based on source order that skews
+// the result set.
+//
+// Coverage approach: we use rapid to pick both a query template and a
+// permutation of its where-clause conjuncts, plus random base facts for the
+// leaf predicates the queries reference. The template set is curated because
+// constructing a random-but-valid QL generator is out of scope; the property
+// shape (commutativity of `and`) holds for every well-formed instance and
+// only requires a handful of structurally different templates to exercise
+// the desugar pass's binding and stratification paths.
+func TestPropertyDesugarSemanticsCommutativity(t *testing.T) {
+	templates := commuteTemplates()
+
+	nonTrivial := 0
+	rapid.Check(t, func(t *rapid.T) {
+		tpl := templates[rapid.IntRange(0, len(templates)-1).Draw(t, "template")]
+
+		// Choose a permutation of the conjuncts.
+		perm := make([]int, len(tpl.conjuncts))
+		for i := range perm {
+			perm[i] = i
+		}
+		// Fisher-Yates using rapid draws.
+		for i := len(perm) - 1; i > 0; i-- {
+			j := rapid.IntRange(0, i).Draw(t, fmt.Sprintf("swap_%d", i))
+			perm[i], perm[j] = perm[j], perm[i]
+		}
+
+		srcA := renderTemplate(tpl, identityPerm(len(tpl.conjuncts)))
+		srcB := renderTemplate(tpl, perm)
+
+		// Generate random base facts for the leaf predicates the template uses.
+		// Every permutation of the SAME template evaluates against the SAME
+		// facts, so any divergence is a desugar or plan bug, not a fact
+		// ordering artefact.
+		baseRels := genBaseRels(t, tpl)
+
+		resA := runPipeline(t, srcA, baseRels)
+		resB := runPipeline(t, srcB, baseRels)
+
+		if !equalRows(resA, resB) {
+			t.Fatalf("desugar conjunction commutativity violated\ntemplate: %s\npermutation: %v\nsrcA:\n%s\nsrcB:\n%s\nresA: %v\nresB: %v",
+				tpl.name, perm, srcA, srcB, resA, resB)
+		}
+
+		if len(resA) > 0 {
+			nonTrivial++
+		}
+	})
+
+	if nonTrivial == 0 {
+		t.Fatalf("property is vacuous: no iteration produced a non-empty result set — base-fact generator does not exercise the query bodies")
+	}
+}
+
+// conjunctTemplate describes a curated QL query as a fixed preamble plus a
+// list of conjuncts that can be reordered freely inside the where clause.
+type conjunctTemplate struct {
+	name      string
+	preamble  string   // from clause and any class decls; lives above the where line
+	conjuncts []string // each is a single boolean QL expression
+	selectTxt string   // the select clause text
+	// leafPreds lists base predicate names (the ones the generator should seed
+	// with random facts) and their arity.
+	leafPreds map[string]int
+}
+
+func commuteTemplates() []conjunctTemplate {
+	return []conjunctTemplate{
+		{
+			name: "two_predicates_join",
+			preamble: `
+predicate p(int x) { P(x) }
+predicate q(int x) { Q(x) }
+from int f, int b
+`,
+			conjuncts: []string{
+				"p(f)",
+				"q(b)",
+				"f = b",
+				"f > 0",
+			},
+			selectTxt: "select f, b",
+			leafPreds: map[string]int{
+				"P": 1,
+				"Q": 1,
+			},
+		},
+		{
+			name: "three_conjuncts_single_var",
+			preamble: `
+predicate r(int x) { R(x) }
+from int x
+`,
+			conjuncts: []string{
+				"r(x)",
+				"x > 1",
+				"x < 9",
+				"x != 5",
+			},
+			selectTxt: "select x",
+			leafPreds: map[string]int{
+				"R": 1,
+			},
+		},
+		{
+			name: "join_three_relations",
+			preamble: `
+predicate a(int x, int y) { A(x, y) }
+predicate b(int x, int y) { B(x, y) }
+from int u, int v, int w
+`,
+			conjuncts: []string{
+				"a(u, v)",
+				"b(v, w)",
+				"u < w",
+			},
+			selectTxt: "select u, v, w",
+			leafPreds: map[string]int{
+				"A": 2,
+				"B": 2,
+			},
+		},
+	}
+}
+
+func identityPerm(n int) []int {
+	out := make([]int, n)
+	for i := range out {
+		out[i] = i
+	}
+	return out
+}
+
+func renderTemplate(tpl conjunctTemplate, perm []int) string {
+	var b strings.Builder
+	b.WriteString(tpl.preamble)
+	b.WriteString("where ")
+	for i, p := range perm {
+		if i > 0 {
+			b.WriteString(" and ")
+		}
+		b.WriteString(tpl.conjuncts[p])
+	}
+	b.WriteString("\n")
+	b.WriteString(tpl.selectTxt)
+	b.WriteString("\n")
+	return b.String()
+}
+
+// genBaseRels seeds the leaf predicates referenced by tpl with random facts
+// (integer arity — small range so joins actually fire).
+func genBaseRels(t *rapid.T, tpl conjunctTemplate) map[string]*eval.Relation {
+	rels := make(map[string]*eval.Relation, len(tpl.leafPreds))
+	// Deterministic iteration order for rapid shrinking stability.
+	names := make([]string, 0, len(tpl.leafPreds))
+	for n := range tpl.leafPreds {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		arity := tpl.leafPreds[name]
+		rel := eval.NewRelation(name, arity)
+		n := rapid.IntRange(3, 10).Draw(t, fmt.Sprintf("nFacts_%s", name))
+		for i := 0; i < n; i++ {
+			tup := make(eval.Tuple, arity)
+			for j := 0; j < arity; j++ {
+				tup[j] = eval.IntVal{V: int64(rapid.IntRange(0, 10).Draw(t, fmt.Sprintf("fact_%s_%d_%d", name, i, j)))}
+			}
+			rel.Add(tup)
+		}
+		rels[name] = rel
+	}
+	return rels
+}
+
+// runPipeline parses, resolves, desugars, plans, and evaluates src against
+// the given base relations. It returns the query result rows as sorted
+// string representations so two runs can be compared for set equality.
+func runPipeline(t *rapid.T, src string, baseRels map[string]*eval.Relation) []string {
+	p := parse.NewParser(src, "<property>")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Skipf("parse: %v", err)
+	}
+	rm, err := resolve.Resolve(mod, nil)
+	if err != nil {
+		t.Skipf("resolve: %v", err)
+	}
+	prog, dsErrs := desugar.Desugar(rm)
+	if len(dsErrs) > 0 {
+		t.Skipf("desugar: %v", dsErrs)
+	}
+	if prog.Query == nil {
+		t.Skipf("desugar produced no query for src:\n%s", src)
+	}
+	ep, planErrs := plan.Plan(prog, nil)
+	if len(planErrs) > 0 {
+		t.Skipf("plan: %v", planErrs)
+	}
+	// Deep copy base relations so the evaluator can't mutate across runs.
+	rels := make(map[string]*eval.Relation, len(baseRels))
+	for k, v := range baseRels {
+		nr := eval.NewRelation(v.Name, v.Arity)
+		for _, tup := range v.Tuples() {
+			nr.Add(tup)
+		}
+		rels[k] = nr
+	}
+	rs, err := eval.Evaluate(context.Background(), ep, rels)
+	if err != nil {
+		t.Skipf("evaluate: %v", err)
+	}
+	rows := make([]string, 0, len(rs.Rows))
+	for _, row := range rs.Rows {
+		rows = append(rows, fmt.Sprintf("%v", row))
+	}
+	sort.Strings(rows)
+	return rows
+}
+
+func equalRows(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Unused import guard (keeps datalog imported if we want to reach into the
+// planned program for debugging later).
+var _ = datalog.Program{}

--- a/ql/parse/property_test.go
+++ b/ql/parse/property_test.go
@@ -1,0 +1,287 @@
+package parse_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/ast"
+	"github.com/Gjdoalfnrxu/tsq/ql/parse"
+	"pgregory.net/rapid"
+)
+
+// TestPropertyParseWhitespaceInvariance is a property test over the real QL
+// corpus in bridge/*.qll: for any such source, injecting extra whitespace at
+// lexer-neutral positions (between existing tokens) must not change the parsed
+// AST once source-location Span fields are ignored.
+//
+// Why this is a real property (not a tautology): the oracle is the AST from
+// the original, unmodified source. The mutated source goes through the
+// lexer and parser independently and must produce an AST that is
+// structurally identical. If the lexer accidentally captured leading
+// whitespace as part of a token, or the parser's whitespace handling leaked
+// between tokens, the two ASTs would diverge.
+//
+// Real bug class caught: lexer regressions that mishandle whitespace or
+// comments (e.g., treating a comment as a token, gluing identifiers across
+// whitespace, or losing a token after an injected space); parser regressions
+// that consume whitespace positions to disambiguate grammar.
+func TestPropertyParseWhitespaceInvariance(t *testing.T) {
+	corpus := loadBridgeCorpus(t)
+	if len(corpus) == 0 {
+		t.Fatal("bridge corpus is empty — the whitespace-invariance property needs real .qll files to mutate")
+	}
+
+	rapid.Check(t, func(t *rapid.T) {
+		// Pick a source file from the corpus.
+		idx := rapid.IntRange(0, len(corpus)-1).Draw(t, "corpusIdx")
+		entry := corpus[idx]
+
+		// Parse the original. The bridge corpus is real and must always parse
+		// cleanly — a failure here is a parser regression, not a generator
+		// rejection. Failing hard catches "parser broke so nothing parses" bugs
+		// that would otherwise show up as skips.
+		origMod, err := parse.NewParser(entry.src, entry.path).Parse()
+		if err != nil {
+			t.Fatalf("bridge corpus file %s failed to parse: %v", entry.path, err)
+		}
+
+		// Mutate: inject extra whitespace (and optionally a comment) at token
+		// boundaries. We only insert characters that the lexer treats as
+		// whitespace or comment — so if the parser is correct, the mutated
+		// source must parse to an equivalent AST.
+		mutated := injectWhitespace(t, entry.src)
+		if mutated == entry.src {
+			t.Skip("mutation produced identical source")
+		}
+
+		mutMod, err := parse.NewParser(mutated, entry.path).Parse()
+		if err != nil {
+			t.Fatalf("mutated source failed to parse but original succeeded:\nerror: %v\noriginal bytes: %d\nmutated bytes:  %d",
+				err, len(entry.src), len(mutated))
+		}
+
+		// Compare the two ASTs with Span fields zeroed. Span is source-location
+		// metadata — it legitimately differs after injecting whitespace, so
+		// must be excluded from the oracle.
+		zeroSpans(reflect.ValueOf(origMod).Elem())
+		zeroSpans(reflect.ValueOf(mutMod).Elem())
+
+		if !reflect.DeepEqual(origMod, mutMod) {
+			// Produce a readable diff hint.
+			t.Fatalf("whitespace-invariance violated for %s:\n  original parse differs from mutated parse after zeroing spans", entry.path)
+		}
+	})
+}
+
+type corpusEntry struct {
+	path string
+	src  string
+}
+
+func loadBridgeCorpus(t *testing.T) []corpusEntry {
+	t.Helper()
+	// Start from the test's working directory (ql/parse) and walk up to repo root.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	// repo root is two levels up from ql/parse
+	root := filepath.Dir(filepath.Dir(wd))
+	bridgeDir := filepath.Join(root, "bridge")
+	entries, err := os.ReadDir(bridgeDir)
+	if err != nil {
+		t.Fatalf("read bridge dir %s: %v", bridgeDir, err)
+	}
+	var out []corpusEntry
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".qll") && !strings.HasSuffix(name, ".ql") {
+			continue
+		}
+		full := filepath.Join(bridgeDir, name)
+		data, err := os.ReadFile(full)
+		if err != nil {
+			t.Fatalf("read %s: %v", full, err)
+		}
+		out = append(out, corpusEntry{path: name, src: string(data)})
+	}
+	return out
+}
+
+// injectWhitespace inserts extra whitespace/comments at character positions in
+// src. Insertions are only placed between tokens (between non-identifier and
+// identifier, or at positions where the original source already has a space),
+// which is a conservative approximation that never glues two tokens together.
+func injectWhitespace(t *rapid.T, src string) string {
+	nInsertions := rapid.IntRange(1, 5).Draw(t, "nInsertions")
+
+	// Candidate insert positions: every index that is outside a comment
+	// or string literal AND whose previous character is whitespace or
+	// token-ending punctuation. Excluding comments/strings is critical —
+	// inserting a newline inside a `//` line comment would truncate it and
+	// expose the tail; inserting anything inside a `/* */` block comment
+	// is likewise dangerous if it could interact with the close.
+	candidates := safeInsertPositions(src)
+	if len(candidates) == 0 {
+		return src
+	}
+
+	// Build the mutated source by inserting at randomly-chosen candidates.
+	// Sort insertion positions so we can build in one pass.
+	type insertion struct {
+		pos int
+		s   string
+	}
+	insertions := make([]insertion, 0, nInsertions)
+	for i := 0; i < nInsertions; i++ {
+		ci := rapid.IntRange(0, len(candidates)-1).Draw(t, fmt.Sprintf("cand_%d", i))
+		// Pick a whitespace/comment payload. All options are lexer-neutral.
+		// Only whitespace payloads. Comment payloads are unsafe because they
+		// can land inside an existing block comment and close it early
+		// (the lexer does not support nested comments), which would make
+		// the mutation change token structure rather than preserve it.
+		payload := rapid.SampledFrom([]string{
+			" ", "  ", "\t", "\n", " \n ", "\n\n",
+		}).Draw(t, fmt.Sprintf("payload_%d", i))
+		insertions = append(insertions, insertion{pos: candidates[ci], s: payload})
+	}
+	// Stable sort by pos ascending.
+	for i := 1; i < len(insertions); i++ {
+		for j := i; j > 0 && insertions[j-1].pos > insertions[j].pos; j-- {
+			insertions[j-1], insertions[j] = insertions[j], insertions[j-1]
+		}
+	}
+
+	var b strings.Builder
+	b.Grow(len(src) + 64)
+	last := 0
+	for _, ins := range insertions {
+		b.WriteString(src[last:ins.pos])
+		b.WriteString(ins.s)
+		last = ins.pos
+	}
+	b.WriteString(src[last:])
+	return b.String()
+}
+
+func isWSOrPunct(c byte) bool {
+	switch c {
+	case ' ', '\t', '\n', '\r':
+		return true
+	case '(', ')', '{', '}', ',', ';', '[', ']':
+		return true
+	}
+	return false
+}
+
+// safeInsertPositions walks src tracking comment and string state, returning
+// positions where an extra whitespace character may be inserted without
+// changing the token stream. We only emit positions that are (a) in normal
+// (non-comment, non-string) lexical state and (b) whose preceding character
+// is whitespace or token-ending punctuation — so there's no chance of gluing
+// or splitting an existing token.
+func safeInsertPositions(src string) []int {
+	var out []int
+	i := 0
+	for i < len(src) {
+		c := src[i]
+		// Line comment
+		if c == '/' && i+1 < len(src) && src[i+1] == '/' {
+			for i < len(src) && src[i] != '\n' {
+				i++
+			}
+			continue
+		}
+		// Block comment
+		if c == '/' && i+1 < len(src) && src[i+1] == '*' {
+			i += 2
+			for i+1 < len(src) && !(src[i] == '*' && src[i+1] == '/') {
+				i++
+			}
+			if i+1 < len(src) {
+				i += 2
+			}
+			continue
+		}
+		// String literal (QL uses " ... " with \ escapes)
+		if c == '"' {
+			i++
+			for i < len(src) && src[i] != '"' {
+				if src[i] == '\\' && i+1 < len(src) {
+					i += 2
+					continue
+				}
+				i++
+			}
+			if i < len(src) {
+				i++
+			}
+			continue
+		}
+		// Normal state: candidate if previous char was WS or punctuation.
+		if i > 0 && isWSOrPunct(src[i-1]) {
+			out = append(out, i)
+		}
+		i++
+	}
+	return out
+}
+
+// zeroSpans walks a reflect.Value and zeroes every field of type ast.Span.
+// This lets reflect.DeepEqual compare the structural shape of two ASTs
+// without false-positive mismatches on source locations.
+func zeroSpans(v reflect.Value) {
+	switch v.Kind() {
+	case reflect.Struct:
+		if v.Type() == reflect.TypeOf(ast.Span{}) {
+			v.Set(reflect.Zero(v.Type()))
+			return
+		}
+		for i := 0; i < v.NumField(); i++ {
+			f := v.Field(i)
+			if f.CanSet() {
+				zeroSpans(f)
+			}
+		}
+	case reflect.Ptr:
+		if !v.IsNil() {
+			zeroSpans(v.Elem())
+		}
+	case reflect.Interface:
+		if !v.IsNil() {
+			// Interface values need a detour: extract the concrete value,
+			// zero it, then set back. For ASTs this handles Formula and Expr
+			// interface fields.
+			concrete := v.Elem()
+			if concrete.Kind() == reflect.Ptr && !concrete.IsNil() {
+				zeroSpans(concrete.Elem())
+			} else if concrete.Kind() == reflect.Struct {
+				// We cannot assign through an interface without a pointer,
+				// so make an addressable copy, zero it, and set back.
+				copyVal := reflect.New(concrete.Type()).Elem()
+				copyVal.Set(concrete)
+				zeroSpans(copyVal)
+				v.Set(copyVal)
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			zeroSpans(v.Index(i))
+		}
+	case reflect.Map:
+		for _, k := range v.MapKeys() {
+			ev := v.MapIndex(k)
+			copyVal := reflect.New(ev.Type()).Elem()
+			copyVal.Set(ev)
+			zeroSpans(copyVal)
+			v.SetMapIndex(k, copyVal)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Four new property tests plug gaps identified in the test-suite audit. Each uses an INDEPENDENT oracle (a second pipeline, an algebraic law, or a differential evaluation), so none is self-referential or tautological.

## The four properties

1. **Parser whitespace invariance** (`ql/parse/property_test.go`)
   Parses every file in `bridge/*.qll`, then injects lexer-safe whitespace at token boundaries (outside comments and string literals) and asserts the re-parsed AST is structurally identical after zeroing `Span` fields. Original-parse failure is a hard error (not a skip), so it also catches the degenerate "parser broke entirely" regression.
   **Bug class caught:** lexer regressions that mishandle whitespace/comments, parser disambiguation that leaks source-offset info into token identity.

2. **DB encode/decode roundtrip** (`extract/db/property_test.go`)
   Generates random tuple batches on arbitrary subsets of the registered relations (exercising `TypeInt32`, `TypeEntityRef`, and `TypeString` including interning), encodes, reads, and compares every tuple column-by-column via the schema.
   **Bug class caught:** any byte-level format drift between writer and reader (column order, length prefixes, string-table indexing, padding).

3. **Taint monotonicity** (`extract/rules/taint_monotone_property_test.go`)
   For a randomly seeded base of taint facts, adding any single tuple to `TaintSource` / `TaintSink` / `ExprMayRef` / `Assign` (the non-sanitizer inputs) can only grow the `TaintAlert` set, never shrink it. Includes a vacuity guard that fails the run if no iteration produces an alert.
   **Bug class caught:** non-monotone misuse of stratified negation in taint rules (exactly the risk profile of PR #36's sanitizer work).

4. **Desugar conjunction commutativity** (`ql/desugar/property_test.go`)
   End-to-end pipeline (parse → resolve → desugar → plan → eval) over curated QL templates. Randomly permuting where-clause conjuncts must yield identical query results against the same random base facts. Includes a vacuity guard.
   **Bug class caught:** desugar rewrites that accidentally depend on source ordering or drop clauses during normalisation.

## Oracle discipline

Each test was verified to catch an injected bug before committing:
- **DB:** `writer.go` offsets int columns by `+1` → property fails with a concrete value mismatch
- **Parser:** `skipWhitespace` only skips literal spaces → hard fail on the first corpus file
- **Taint:** non-monotone `not ExprMayRef(...)` in Rule 1 → rejected by the safety-checker; the property is correct by construction under the current rule set, and a subsequent +2000-iteration run with the unmodified rules passed cleanly
- **Desugar:** `Conjunction` handler drops its right operand → property fails with concrete result-set diff

## Test plan
- [x] `go test ./...` green locally
- [x] Each property verified to fail on an injected bug (see above)
- [x] `gofmt -l` clean, `go vet ./...` clean
- [ ] CI green on this branch