### PR TITLE
docs: add PR-sized impl plans for CodeQL compat work

### DIFF
--- a/docs/impl-plans/01-rank-aggregate.md
+++ b/docs/impl-plans/01-rank-aggregate.md
@@ -1,0 +1,93 @@
+# 01 — True ordinal `rank` aggregate
+
+## Scope
+
+Replace the v1 `rank` aggregate implementation (which returns the size of
+the group, making `rank` behave identically to `count`) with a true
+ordinal ranking: for each tuple in the group, emit its 1-indexed position
+after ordering by the ranking expression. This finishes compat-plan item
+1h, which shipped the keyword and parser support but deferred full
+semantics.
+
+This PR does NOT introduce new aggregate functions, does NOT change the
+syntactic surface of `rank`, and does NOT touch `concat`/`strictcount`/
+`strictsum` (already correct).
+
+## Dependencies
+
+None. `rank` is already parsed and plumbed through; only the evaluator
+behaviour changes.
+
+## Files to change
+
+- `/tmp/tsq/ql/eval/aggregate.go` — replace the `case "rank"` branch
+  with real ordinal logic; may require changing the caller signature so
+  `rank` can return a relation (multiple tuples) rather than a scalar.
+- `/tmp/tsq/ql/eval/aggregate_test.go` — add ordering-sensitive tests
+  covering duplicate values, empty groups, and stable ordering.
+- `/tmp/tsq/ql/desugar/desugar.go` — verify `rank` desugaring passes
+  the ordering expression through; adjust if it was assumed scalar.
+- `/tmp/tsq/ql/eval/seminaive.go` — confirm aggregate dispatch handles
+  relation-valued results (read-only check; may need a one-line patch).
+
+## Implementation steps
+
+1. Read `ql/eval/aggregate.go` lines 1–195 to understand the current
+   `computeAggregate` signature and call sites.
+2. In `aggregate.go`, change `rank`'s branch: sort `vals` by the
+   ordering key provided by the aggregate expression, then return a
+   slice of `(rank, value)` pairs. If the current signature cannot
+   return multiple tuples, introduce a sibling function
+   `computeRankAggregate` that returns `[]binding` and dispatch to it
+   from the caller.
+3. In the caller (`seminaive.go` aggregate dispatch), branch on
+   aggregate kind and feed rank results into the outer relation as
+   multiple tuples.
+4. Add test `TestRankOrdinal` in `aggregate_test.go` asserting that
+   `rank(int i | i in [10, 20, 30] | i)` yields `{1, 2, 3}`, not `{3}`.
+5. Add test `TestRankWithTies` asserting documented tie-breaking
+   (choose dense rank or standard competition rank — pick one, document
+   it in a comment above the branch, and stick to it).
+6. Add test `TestRankEmptyGroup` asserting empty input yields no rows.
+7. Update the wiki note in `~/Documents/ObsidianVault/Wiki/Tech/tsq-codeql-compat.md`
+   to remove the "v1 approximation" caveat after merge.
+
+## Test strategy
+
+- `ql/eval/aggregate_test.go::TestRankOrdinal` — three-value input,
+  assert emitted tuples match expected ranks.
+- `ql/eval/aggregate_test.go::TestRankWithTies` — duplicate values.
+- `ql/eval/aggregate_test.go::TestRankEmptyGroup` — empty input.
+- Full suite (`go test ./...`) must remain green; in particular
+  `ql/eval/aggregate_test.go` existing `rank` tests must be updated, not
+  deleted.
+
+## Acceptance criteria
+
+- [ ] `rank` returns ordinal positions, not group size.
+- [ ] Tie-breaking semantics documented in a comment in `aggregate.go`.
+- [ ] New tests above pass; existing tests updated where they asserted
+  the old approximation behaviour.
+- [ ] `go test ./...` green.
+- [ ] No changes to `concat`/`strictcount`/`strictsum`.
+
+## Risks and open questions
+
+- The current `computeAggregate` signature returns a single `Value`.
+  Rank is inherently multi-tuple. If we keep the scalar contract, the
+  desugarer must expand `rank` into a multi-row helper predicate
+  instead — heavier change. Decide which at implementation time.
+- CodeQL's documented `rank` semantics must be re-read before coding;
+  if tsq already has dependent tests pinning the approximation, they
+  need updating in the same PR.
+- Ordering stability: tsq relations are unordered sets, so the sort key
+  must be an explicit expression in the aggregate body, not tuple
+  insertion order.
+
+## Out of scope
+
+- `rank` with partitioning (CodeQL supports `rank[grp]` style). Keep
+  global-group rank only.
+- Performance optimisation of repeated rank evaluations.
+- Updating the CodeQL compat spec documentation beyond the one-line
+  caveat removal.

--- a/docs/impl-plans/02-annotation-private.md
+++ b/docs/impl-plans/02-annotation-private.md
@@ -1,0 +1,89 @@
+# 02 — Enforce `private` predicate visibility
+
+## Scope
+
+Compat-plan item 1l shipped annotation parsing only. `private` is
+parsed and stored on `PredicateDecl.Annotations` and
+`MemberDecl.Annotations`, but the resolver does not enforce it — a
+`private` predicate in one module is currently callable from any other
+module. This PR adds visibility checking at name resolution.
+
+This PR does NOT touch the other annotations (`deprecated`,
+`pragma[...]`, `bindingset[...]`, `language[...]`). Those remain
+parse-only; `deprecated` is plan 03, the rest are intentionally
+no-ops.
+
+## Dependencies
+
+None. Parsing and storage already exist.
+
+## Files to change
+
+- `/tmp/tsq/ql/resolve/resolve.go` — add a `callerModule` tracking
+  mechanism to each resolve context; when resolving a predicate call,
+  reject `private` predicates declared in a different module.
+- `/tmp/tsq/ql/resolve/resolve_test.go` — add positive (same module) and
+  negative (cross module) tests.
+- `/tmp/tsq/ql/ast/ast.go` — no change expected; read to confirm
+  `Annotation` shape.
+
+## Implementation steps
+
+1. Read `ql/resolve/resolve.go` and find where predicate calls are
+   resolved (search for `resolveCall` or similar — do not guess).
+2. Add a helper `isPrivate(PredicateDecl) bool` that returns true iff
+   any `Annotation` has `Name == "private"`.
+3. Track the "current module path" through the resolver walk. Each
+   `ModuleDecl` push/pop updates a stack. Top-level resolver context is
+   the empty module.
+4. When resolving a predicate call, if the target is private AND its
+   declaring module path differs from the caller's module path, emit
+   a resolve error: `"predicate X is private to module Y"`.
+5. Apply the same rule to class member calls: `private` members are
+   only callable from within the same class declaration (or its
+   subclasses — check how CodeQL defines it; default to strict "same
+   class" if unsure and note in risks).
+6. Add tests:
+   - `TestPrivatePredicateSameModule` — call succeeds.
+   - `TestPrivatePredicateCrossModule` — resolve error.
+   - `TestPrivateMemberSameClass` — call succeeds.
+   - `TestPrivateMemberCrossClass` — resolve error.
+
+## Test strategy
+
+- `ql/resolve/resolve_test.go::TestPrivatePredicateSameModule`:
+  define a module with a private predicate and a public predicate that
+  calls it; assert resolve succeeds.
+- `ql/resolve/resolve_test.go::TestPrivatePredicateCrossModule`:
+  define two modules; call the private predicate from the second
+  module; assert a `ResolveError` with a message containing "private".
+- Full `go test ./ql/...` must pass.
+
+## Acceptance criteria
+
+- [ ] Private predicate calls across module boundaries produce a
+  resolve error with a clear message.
+- [ ] Private predicate calls within the same module succeed.
+- [ ] Existing bridge files that use `private` (check `bridge/*.qll`
+  with `grep private`) still resolve correctly — if they don't, the
+  bridge was implicitly relying on lax visibility and must be fixed in
+  the same PR.
+- [ ] `go test ./...` green.
+
+## Risks and open questions
+
+- Bridge `.qll` files may already use `private` liberally assuming it
+  is a no-op. Grep before implementing: if the bridge breaks,
+  coordinate which is the bug.
+- CodeQL's exact scoping rule for `private` class members (same class
+  only vs. subclasses) needs confirmation from the spec. Default to
+  the stricter rule and leave looser semantics to a follow-up.
+- Module path comparison must handle nested modules. An inner module
+  should be able to call its own `private` helpers — decide
+  prefix-match vs exact-match.
+
+## Out of scope
+
+- `deprecated` warnings (plan 03).
+- Visibility for `pragma[private]` or other non-standard forms.
+- IDE/tooling hints; errors only surface at query compile time.

--- a/docs/impl-plans/03-annotation-deprecated.md
+++ b/docs/impl-plans/03-annotation-deprecated.md
@@ -1,0 +1,86 @@
+# 03 — Emit warnings for `deprecated` predicates and classes
+
+## Scope
+
+Compat-plan item 1l parses `deprecated` but does nothing with it. This
+PR makes the resolver emit a non-fatal warning when a query references
+a deprecated predicate, class, or member. Warnings are collected
+alongside errors and surfaced by the CLI at the end of compilation.
+
+This PR does NOT add a `--deprecation=error` flag (could be a
+follow-up). It does NOT touch `private` (plan 02) or the pragma/
+bindingset/language annotations.
+
+## Dependencies
+
+None strictly, but coordinates with plan 02 which adds annotation
+awareness to the resolver. Implement after 02 if both are in flight, so
+the plumbing is consistent.
+
+## Files to change
+
+- `/tmp/tsq/ql/resolve/resolve.go` — add a warning channel to the
+  resolver (or reuse error list with a Severity field), emit a warning
+  when resolving a deprecated target.
+- `/tmp/tsq/ql/resolve/resolve_test.go` — add tests.
+- `/tmp/tsq/cmd/tsq/main.go` — surface warnings in CLI output (after
+  compile, before running). Keep exit code 0.
+- `/tmp/tsq/ql/ast/ast.go` — no change.
+
+## Implementation steps
+
+1. Decide the warning representation: either a separate
+   `Resolver.Warnings []Warning` field or reuse errors with a
+   `Severity` enum. Prefer the former — errors and warnings are
+   semantically different and mixing them complicates exit codes.
+2. Add `isDeprecated(ann []Annotation) bool` helper.
+3. At each call-site resolution (predicate, class reference, member
+   call), after looking up the target, check the target's annotations
+   and append a warning to the resolver if deprecated. Include the
+   caller's span in the warning.
+4. Thread warnings out through the resolver's result struct.
+5. In `cmd/tsq/main.go`, print warnings to stderr after a successful
+   compile, one per line, with file:line prefix. Do not increase exit
+   code.
+6. Tests as below.
+
+## Test strategy
+
+- `ql/resolve/resolve_test.go::TestDeprecatedPredicateWarning`: define
+  a deprecated predicate and call it; assert resolve succeeds AND
+  the returned warnings list contains one entry mentioning the
+  predicate name.
+- `ql/resolve/resolve_test.go::TestDeprecatedClassWarning`: same for
+  a class reference.
+- `ql/resolve/resolve_test.go::TestNoWarningForUndeprecated`: control
+  case — same query without the annotation emits no warnings.
+- `cmd/tsq/main_test.go` (if it exists) or a new `cmd/tsq/cli_test.go`
+  asserting stderr contains the warning but exit code is 0.
+
+## Acceptance criteria
+
+- [ ] Deprecated call-sites emit warnings at resolve time.
+- [ ] Warnings do not cause compile failure.
+- [ ] CLI prints warnings to stderr, exit code unchanged.
+- [ ] Existing tests still pass (the bridge may use `deprecated` — if
+  so, suppress noise in the bridge loader or accept warnings in
+  bridge-level tests; document the choice).
+
+## Risks and open questions
+
+- If any bridge file is already marked `deprecated`, running the test
+  suite will start producing noise. Grep for it first. If present,
+  either fix the bridge or add a flag to suppress warnings originating
+  from `compat_*.qll`.
+- Warning format: match CodeQL's or invent a tsq style? Pick tsq style
+  and document.
+- Deduplication: if a deprecated predicate is called 100 times, do we
+  warn 100 times or once? Default to once per (target, caller-span)
+  and note in risks that this may need tuning.
+
+## Out of scope
+
+- A `--deprecation=error` flag.
+- Deprecation messages in annotations (CodeQL's `deprecated` takes no
+  arg; plan does not add one).
+- Suppressing specific deprecations via pragma.

--- a/docs/impl-plans/04-tsgo-direct-go-api.md
+++ b/docs/impl-plans/04-tsgo-direct-go-api.md
@@ -1,0 +1,105 @@
+# 04 — Replace tsgo JSON-RPC client with direct Go API
+
+## Scope
+
+The original compat plan (section 3a) said tsgo would be imported as a
+Go module and called in-process. The shipped implementation (PR #33)
+instead spawns tsgo as a subprocess and talks to it over JSON-RPC 2.0
+with LSP framing. This works but re-introduces the subprocess/IPC
+overhead the plan explicitly wanted to avoid.
+
+This PR replaces the JSON-RPC transport with a direct Go import of
+tsgo's checker packages, preserving the existing public API of
+`extract/typecheck` so callers don't change.
+
+This PR does NOT change the fact schema, does NOT add new type
+relations, and does NOT touch the bridge `.qll` files. It is a
+pure transport swap behind a stable interface.
+
+## Dependencies
+
+None among the impl plans. Depends on tsgo upstream exposing enough
+public API to perform program construction, file checking, and
+type/symbol lookup. See risks.
+
+## Files to change
+
+- `/tmp/tsq/go.mod` — add tsgo (or `typescript-go`) dependency; run
+  `go mod tidy`.
+- `/tmp/tsq/extract/typecheck/client.go` — replace the subprocess +
+  JSON-RPC implementation with direct calls. Preserve the exported
+  method set: `NewClient`, `CheckFile`, `GetTypeAt`, `GetSymbolAt`,
+  `Close`.
+- `/tmp/tsq/extract/typecheck/jsonrpc.go` — delete (or retain for
+  fallback, gated by build tag `//go:build tsgo_jsonrpc`).
+- `/tmp/tsq/extract/typecheck/detect.go` — replace binary detection
+  with a no-op; direct import means no external binary.
+- `/tmp/tsq/extract/typecheck/client_test.go` — update tests that
+  assumed the subprocess model; add a pure-in-process smoke test.
+- `/tmp/tsq/extract/typecheck/enricher.go` — read only, verify it
+  calls the preserved API surface.
+- `/tmp/tsq/HANDOVER-phase-3a.md` — update the "Transport" section to
+  reflect the change.
+
+## Implementation steps
+
+1. Probe tsgo upstream (`github.com/microsoft/typescript-go`) and
+   identify the public packages that expose program creation, file
+   checking, and type/symbol access. Record findings in the PR
+   description.
+2. If required API is available: add dependency, write a thin wrapper
+   in `client.go` that matches the existing interface.
+3. If required API is NOT fully available: either (a) open an upstream
+   issue and pause this PR, or (b) use `internal` packages via a
+   `replace` directive and document the coupling.
+4. Delete the JSON-RPC framing code or gate it behind a build tag.
+5. Update `detect.go` so `NewClient` no longer requires a tsgo binary
+   on PATH.
+6. Run the enricher tests (`go test ./extract/typecheck/...`); fix
+   anything that assumed subprocess semantics (stderr routing,
+   timeouts, etc.).
+7. Update HANDOVER doc.
+
+## Test strategy
+
+- `extract/typecheck/client_test.go::TestDirectCheckerBasic` — create
+  a checker, check a one-file TS program, assert a known type at a
+  known position.
+- `extract/typecheck/enricher_test.go` — existing tests must still
+  pass unchanged (the interface is stable).
+- `integration_test.go` — existing extraction tests that pull in type
+  facts should not regress.
+
+## Acceptance criteria
+
+- [ ] `go.mod` has a direct tsgo dependency; `go mod tidy` clean.
+- [ ] `extract/typecheck/client.go` has no `os/exec`, no JSON-RPC.
+- [ ] Exported interface of `extract/typecheck` unchanged.
+- [ ] All existing enricher tests pass.
+- [ ] Smoke test for the new transport passes.
+- [ ] `go test ./...` green.
+
+## Risks and open questions
+
+- **tsgo API maturity.** The package may still be experimental with
+  no stable Go-facing checker API. The compat plan explicitly flags
+  three fallbacks (upstream contribution, internal packages, Node.js
+  bridge). If none is viable, this PR cannot land — note that
+  outcome in the PR and close without merging.
+- **Build weight.** Importing the TS checker pulls a lot of code into
+  tsq's binary. Confirm binary size stays acceptable.
+- **CGO / platform issues.** Depending on the upstream, Windows or
+  musl-libc builds might regress.
+- **Test flakiness.** The JSON-RPC client had subprocess startup
+  timing logic; in-process removes that but may introduce global
+  state (checker caches) that tests must reset between cases.
+- **Licence.** tsgo is MIT — still confirm no additional copyleft
+  transitive deps appear in `go.mod`.
+
+## Out of scope
+
+- Type fact schema changes.
+- Any new tsgo features beyond what the JSON-RPC client already
+  consumed.
+- Performance benchmarking the transport swap (a separate follow-up
+  PR can measure it).

--- a/docs/impl-plans/05-compat-query-fixtures.md
+++ b/docs/impl-plans/05-compat-query-fixtures.md
@@ -1,0 +1,87 @@
+# 05 — Add CodeQL-syntax query fixtures
+
+## Scope
+
+Create the `testdata/compat/` directory with CodeQL-syntax `.ql` query
+files that exercise the compat bridge (`import javascript`,
+`DataFlow::Configuration`, etc.). This PR adds ONLY the static fixture
+files and a short README — no Go test code. Plan 06 wires them into a
+test harness; plans 07–10 add the per-query goldens.
+
+Splitting fixture creation from harness creation lets the static files
+be reviewed for clean-room correctness (do any of these look like
+CodeQL source?) without being tangled up with Go plumbing.
+
+## Dependencies
+
+None.
+
+## Files to change
+
+- `/tmp/tsq/testdata/compat/README.md` (new) — explains the clean-room
+  rule: these queries are written from scratch against the public
+  CodeQL API documentation, not copied from CodeQL's repository.
+- `/tmp/tsq/testdata/compat/find_xss.ql` (new) — stub XSS query.
+- `/tmp/tsq/testdata/compat/find_sqli.ql` (new) — stub SQL injection.
+- `/tmp/tsq/testdata/compat/custom_config.ql` (new) — user-defined
+  `DataFlow::Configuration` subclass.
+- `/tmp/tsq/testdata/compat/ast_query.ql` (new) — simple AST query:
+  "find all `eval()` calls" in CodeQL syntax.
+- `/tmp/tsq/testdata/compat/projects/basic/src/index.js` (new) — a
+  tiny JS source file the queries can run against.
+
+## Implementation steps
+
+1. Confirm `testdata/compat/` does not exist on `main` (it doesn't as
+   of writing). If it's been created by another PR, rebase and merge
+   contents.
+2. Write `README.md` with the clean-room disclaimer and a pointer to
+   CODEQL-COMPAT-PLAN.md.
+3. Write each `.ql` file. Every query must:
+   - Start with `import javascript` (or `DataFlow::PathGraph` etc.)
+   - Be syntactically valid per tsq's current parser (compile-only,
+     running is plan 06's problem)
+   - Contain comments pointing to the CodeQL documentation URL the
+     query's structure was derived from
+4. Write `projects/basic/src/index.js` containing enough code for each
+   query to produce at least one result: a `document.write(userInput)`
+   (XSS), a `db.query(userInput)` (SQLi), an `eval(x)` (AST), and a
+   helper that imports `express`.
+5. Run `go run ./cmd/tsq compile testdata/compat/find_xss.ql` (or
+   equivalent) manually to verify each file at least parses and
+   resolves against the bridge. Record any that don't in the PR
+   description — plan 07+ will assert actual results.
+
+## Test strategy
+
+No Go tests in this PR. Verification is:
+- `grep -r "CodeQL source" testdata/compat/` returns nothing
+  (no copied code markers).
+- Each `.ql` file parses cleanly with the existing tsq parser.
+- `testdata/compat/projects/basic/src/index.js` is valid JS (visually
+  reviewed or run through a parser).
+
+## Acceptance criteria
+
+- [ ] Four `.ql` files under `testdata/compat/`.
+- [ ] One JS fixture project under `testdata/compat/projects/basic/`.
+- [ ] README with clean-room rule.
+- [ ] Each `.ql` file parses without error (manual check or ad-hoc
+  script in the PR description).
+- [ ] No Go changes.
+
+## Risks and open questions
+
+- Clean-room discipline: reviewer must confirm the files don't look
+  line-for-line like CodeQL's published examples. Paraphrase structure
+  where needed.
+- The JS fixture project must be small enough to review but realistic
+  enough to hit all the queries.
+- File naming: `find_xss.ql` vs `xss.ql` — match the compat plan's
+  naming (`find_xss.ql`) for consistency.
+
+## Out of scope
+
+- Go test code (plan 06).
+- Golden output files (plans 07–10).
+- Additional queries beyond the four named in the compat plan.

--- a/docs/impl-plans/06-compat-e2e-harness.md
+++ b/docs/impl-plans/06-compat-e2e-harness.md
@@ -1,0 +1,86 @@
+# 06 — End-to-end compat test harness
+
+## Scope
+
+Add a top-level Go test file `compat_test.go` that runs the CodeQL-
+syntax fixture queries from plan 05 against the basic fixture project
+and compares the emitted tuples against golden CSVs. The harness
+mirrors the existing `integration_test.go` shape: extract a project,
+load the bridge, run a query, diff against a golden.
+
+This PR delivers the harness plus a single smoke golden (for
+`ast_query.ql`, the simplest fixture). Plans 07–10 then add goldens
+for the other three queries.
+
+## Dependencies
+
+- Plan 05 (`testdata/compat/` fixtures must exist).
+
+## Files to change
+
+- `/tmp/tsq/compat_test.go` (new) — top-level test file in package
+  `tsq_test` (or `compat_test`); mirrors integration_test.go style.
+- `/tmp/tsq/testdata/compat/expected/ast_query.csv` (new) — golden for
+  the smoke test.
+- `/tmp/tsq/Makefile` — add a `test-compat` target that runs
+  `go test -run TestCompat ./...` (optional but consistent with
+  existing targets — check first).
+
+## Implementation steps
+
+1. Read `integration_test.go` lines 1–200 to learn the fixture→DB→
+   query→result pattern. Copy the `extractProject`, `runQuery`, and
+   golden-diffing helpers, adapted to use the compat import loader.
+2. Use `bridge.LoadBridge()` + an import loader that maps
+   `"javascript"`, `"DataFlow"`, `"TaintTracking"`, and
+   `"semmle.javascript.security.*"` to the bridge's compat files
+   (same map as `bridge/compat_test.go::makeCompatImportLoader`).
+3. Add `TestCompatASTQuery` that:
+   - Extracts `testdata/compat/projects/basic/`
+   - Runs `testdata/compat/find_ast_query.ql` (name per plan 05)
+   - Serializes results to CSV (column order: sort by first column)
+   - Diffs against `testdata/compat/expected/ast_query.csv`
+   - Supports the `-update` flag like integration_test.go
+4. Add a table-driven scaffold (empty cases) so plans 07–10 only need
+   to append rows.
+5. Generate the initial golden with `go test -update`. Review it.
+   Commit.
+
+## Test strategy
+
+- `compat_test.go::TestCompatASTQuery` passes against a committed
+  golden. Running with `-update` regenerates the golden.
+- The harness rejects empty result sets (guard against "golden is
+  empty because query silently failed").
+- Import loader must also map `"tsq::*"` paths so queries can mix
+  compat and native imports if they want.
+
+## Acceptance criteria
+
+- [ ] `compat_test.go` compiles and runs.
+- [ ] `TestCompatASTQuery` passes.
+- [ ] Running `go test -update ./...` regenerates
+  `testdata/compat/expected/ast_query.csv`.
+- [ ] Table-driven scaffold is present so plans 07–10 add one line.
+- [ ] `go test ./...` green.
+- [ ] No regression in `integration_test.go`.
+
+## Risks and open questions
+
+- Import loader duplication: three loaders now exist
+  (`bridge/compat_test.go`, `integration_test.go`,
+  `compat_test.go`). Decide whether to extract a shared helper into
+  `bridge/` or live with the duplication. Default: duplicate — the
+  shared helper can be a follow-up.
+- Result ordering: QL eval yields unordered tuples; CSV must be
+  sorted deterministically before diffing.
+- Golden brittleness: span offsets in results will change if the
+  fixture JS file changes. Consider stripping spans to
+  `file:line` granularity.
+
+## Out of scope
+
+- Goldens for XSS/SQLi/custom config (plans 07–09).
+- Performance benchmarks for compat queries.
+- Running compat tests in CI parallel to integration tests — they
+  will run under `go test ./...` by default, that's enough.

--- a/docs/impl-plans/07-compat-find-xss-golden.md
+++ b/docs/impl-plans/07-compat-find-xss-golden.md
@@ -1,0 +1,68 @@
+# 07 — XSS compat query golden
+
+## Scope
+
+Add end-to-end coverage for `testdata/compat/find_xss.ql`: a new
+fixture file with a known XSS sink, a golden CSV, and one more row in
+the harness table. Validates that the `DomBasedXss`-style
+reconstruction in `bridge/compat_security_xss.qll` actually produces
+alerts when run end-to-end.
+
+## Dependencies
+
+- Plan 05 (fixtures exist)
+- Plan 06 (harness exists)
+
+## Files to change
+
+- `/tmp/tsq/testdata/compat/projects/xss/src/app.js` (new) — minimal
+  app with `document.write(location.hash)` or similar.
+- `/tmp/tsq/testdata/compat/expected/find_xss.csv` (new) — golden.
+- `/tmp/tsq/compat_test.go` — append one row to the table-driven test
+  case list.
+
+## Implementation steps
+
+1. Re-read `testdata/compat/find_xss.ql` from plan 05. If the query
+   uses `DataFlow::PathGraph`, the harness needs to support it — check
+   plan 06 output.
+2. Write `projects/xss/src/app.js` with:
+   - One intentional taint: `var x = location.hash; document.write(x);`
+   - One negative control: `document.write("static")` — must NOT
+     appear in results.
+3. Add the table case:
+   `{Name: "xss", Project: "xss", Query: "find_xss.ql", Expected: "find_xss.csv"}`.
+4. Generate the golden: `go test -update -run TestCompat ./...`.
+5. Review: the golden must contain the taint row(s) and not the
+   static string row.
+6. Commit query, fixture, golden.
+
+## Test strategy
+
+- `compat_test.go::TestCompat/xss` — runs `find_xss.ql` against
+  `projects/xss`, asserts matches the golden.
+- Manual inspection of the golden: confirm the reported source is
+  `location.hash` and the sink is `document.write`.
+
+## Acceptance criteria
+
+- [ ] Golden file committed, non-empty.
+- [ ] Golden contains the taint case, not the control.
+- [ ] `go test ./...` green.
+- [ ] No change to the harness beyond appending one case.
+
+## Risks and open questions
+
+- The bridge's XSS detection may not yet cover `location.hash` →
+  `document.write` without additional source models. If the golden
+  comes out empty, either broaden the fixture or file a bug on the
+  bridge. Do not widen the bridge in this PR.
+- Alert span format may differ between runs (absolute paths). Use
+  the harness's path-normalisation helper (add one in plan 06 if
+  missing).
+
+## Out of scope
+
+- Improving the compat XSS bridge library.
+- Adding more XSS sink types beyond what the fixture exercises.
+- Path-query SARIF output.

--- a/docs/impl-plans/08-compat-find-sqli-golden.md
+++ b/docs/impl-plans/08-compat-find-sqli-golden.md
@@ -1,0 +1,62 @@
+# 08 — SQL injection compat query golden
+
+## Scope
+
+End-to-end golden for `testdata/compat/find_sqli.ql`. Mirror of
+plan 07 for SQL injection: fixture project, golden CSV, one more
+harness row.
+
+## Dependencies
+
+- Plan 05 (fixtures)
+- Plan 06 (harness)
+
+## Files to change
+
+- `/tmp/tsq/testdata/compat/projects/sqli/src/handler.js` (new) —
+  Express-style route handler that concatenates `req.query.id` into
+  a SQL string and passes it to `db.query(...)`.
+- `/tmp/tsq/testdata/compat/projects/sqli/package.json` (new,
+  minimal) — so the extractor treats it as a project root.
+- `/tmp/tsq/testdata/compat/expected/find_sqli.csv` (new) — golden.
+- `/tmp/tsq/compat_test.go` — append one row.
+
+## Implementation steps
+
+1. Confirm `find_sqli.ql` from plan 05 uses the compat SQL injection
+   library (`import semmle.javascript.security.dataflow.SqlInjectionQuery`
+   or the equivalent mapped path — plan 05 should have decided this).
+2. Write `handler.js`:
+   - Taint case: `app.get("/x", (req, res) => { db.query("SELECT * FROM t WHERE id=" + req.query.id); });`
+   - Negative control: `db.query("SELECT * FROM t WHERE id = ?", [userId])` — parameterised, should NOT appear.
+3. Append case to `compat_test.go` table.
+4. Generate golden with `-update`, review, commit.
+
+## Test strategy
+
+- `compat_test.go::TestCompat/sqli` passes.
+- Golden contains the concatenation taint, not the parameterised
+  query.
+
+## Acceptance criteria
+
+- [ ] Golden non-empty, committed.
+- [ ] Negative control absent.
+- [ ] All tests green.
+
+## Risks and open questions
+
+- The compat bridge's SQL injection source list may not include
+  `req.query.*` out of the box. Check
+  `bridge/compat_security_sqli.qll` before writing the fixture. If
+  missing, the fixture should use a source the bridge does know
+  about, and note the limitation in the PR.
+- `db` object shape: the bridge may look for specific sink names
+  (`execute`, `query`, etc.) — match whatever the bridge already
+  handles.
+
+## Out of scope
+
+- Extending the SQLi bridge.
+- Multi-file taint paths.
+- Prepared-statement detection beyond the single negative control.

--- a/docs/impl-plans/09-compat-custom-config-golden.md
+++ b/docs/impl-plans/09-compat-custom-config-golden.md
@@ -1,0 +1,69 @@
+# 09 — User-defined DataFlow::Configuration golden
+
+## Scope
+
+End-to-end test that a user-written `.ql` file defining its own
+`DataFlow::Configuration` subclass (overriding `isSource` and
+`isSink`) runs correctly against tsq. Proves the dynamic dispatch
+and abstract-class override machinery (compat items 1a + 1d)
+actually wires up at query time, not just at parse time.
+
+## Dependencies
+
+- Plan 05 (fixtures)
+- Plan 06 (harness)
+
+## Files to change
+
+- `/tmp/tsq/testdata/compat/projects/custom/src/sample.js` (new) —
+  contains two functions: one calling `dangerous(userInput)`, one
+  calling `safe(constInput)`.
+- `/tmp/tsq/testdata/compat/expected/custom_config.csv` (new).
+- `/tmp/tsq/compat_test.go` — append row.
+
+## Implementation steps
+
+1. Review `testdata/compat/custom_config.ql` from plan 05. It should
+   define something like:
+   ```
+   class MyConfig extends DataFlow::Configuration {
+     MyConfig() { this = "MyConfig" }
+     override predicate isSource(DataFlow::Node n) { ... }
+     override predicate isSink(DataFlow::Node n) { ... }
+   }
+   ```
+2. Write `sample.js` so the config's `isSource`/`isSink` predicates
+   are satisfied exactly once.
+3. Append harness row. Generate golden with `-update`.
+4. Review: golden should contain one row.
+5. Also add a negative assertion — a second test case using a config
+   whose `isSource` never matches, asserting zero results. This
+   catches the "everything always matches" regression mode.
+
+## Test strategy
+
+- `compat_test.go::TestCompat/custom_config` — one expected match.
+- `compat_test.go::TestCompat/custom_config_noop` (variant) — zero
+  results with a restrictive config.
+
+## Acceptance criteria
+
+- [ ] Both positive and zero-result cases pass.
+- [ ] Override resolution demonstrably works (positive case).
+- [ ] All tests green.
+
+## Risks and open questions
+
+- The abstract class extent machinery already passes unit tests
+  (compat item 1d), but may have gaps at the query level. If the
+  override doesn't dispatch, file a bug; do not fix here.
+- `MyConfig()` characteristic predicate syntax — confirm tsq parser
+  accepts `this = "..."` form; if not, use `any()`.
+- Multiple-config interaction: don't test that here, one config at
+  a time.
+
+## Out of scope
+
+- Multiple configurations in the same query.
+- Path queries (`DataFlow::PathGraph`).
+- Performance of override dispatch.

--- a/docs/impl-plans/10-compat-ast-query-golden.md
+++ b/docs/impl-plans/10-compat-ast-query-golden.md
@@ -1,0 +1,69 @@
+# 10 — AST query compat golden
+
+## Scope
+
+Promote the smoke golden committed in plan 06 into a full test: more
+AST shapes covered by `find_ast_query.ql`, expanded JS fixture, and
+confirmation that simple (non-dataflow) CodeQL-syntax queries work
+against the `javascript.qll` compat layer.
+
+## Dependencies
+
+- Plan 05
+- Plan 06 (uses the harness and the smoke case)
+
+## Files to change
+
+- `/tmp/tsq/testdata/compat/projects/basic/src/index.js` — expand
+  to include variety: `eval()`, a `new Function(...)`, a class,
+  an arrow function, an import, a string literal.
+- `/tmp/tsq/testdata/compat/find_ast_query.ql` — expand to select
+  several AST shapes (CallExpr where callee is `eval`,
+  ClassDefinition, ArrowFunctionExpr) with comments per case.
+- `/tmp/tsq/testdata/compat/expected/ast_query.csv` — regenerate.
+- `/tmp/tsq/compat_test.go` — no structural change; the existing
+  row is reused.
+
+## Implementation steps
+
+1. Expand `index.js` with the features above. Keep it under ~30
+   lines.
+2. Expand `find_ast_query.ql` to return a union of shapes. Each
+   result row includes a kind tag so the golden is readable.
+3. Regenerate golden with `-update`.
+4. Review golden for correctness:
+   - One `eval` call row
+   - One class row
+   - One arrow-function row
+   - One import row
+5. Confirm the test passes without `-update` after commit.
+
+## Test strategy
+
+- `compat_test.go::TestCompat/ast_query` passes against the expanded
+  golden.
+- Manually verify that removing one feature from `index.js` causes
+  the corresponding row to disappear (quick sanity check, not
+  committed).
+
+## Acceptance criteria
+
+- [ ] Golden has >=4 rows.
+- [ ] Every row corresponds to a feature present in `index.js`.
+- [ ] All tests green.
+- [ ] No regression to plans 07–09 goldens.
+
+## Risks and open questions
+
+- CodeQL class name mapping: make sure each class used in the query
+  (`CallExpr`, `ClassDefinition`, etc.) is defined in
+  `bridge/compat_javascript.qll`. If any are missing, narrow the
+  query rather than widening the bridge.
+- The JS fixture is shared with plan 06's smoke golden — any change
+  here regenerates that golden. Coordinate merge order.
+
+## Out of scope
+
+- Any type-based AST queries (those belong in plans 11–12).
+- JSX-specific AST queries (could be a follow-up).
+- Adding more fixture projects.

--- a/docs/impl-plans/11-typed-ts-fixtures.md
+++ b/docs/impl-plans/11-typed-ts-fixtures.md
@@ -1,0 +1,70 @@
+# 11 — Typed TypeScript fixture projects
+
+## Scope
+
+Create `testdata/ts/typed/` with TypeScript source files exercising
+the type features tsgo is supposed to resolve: generics, conditional
+types, mapped types, union/intersection, type aliases, and literal
+types. Static fixtures only — consumed by plan 12's unit tests and
+possibly by future typed compat queries.
+
+## Dependencies
+
+None. Fixtures are inert until plan 12 reads them.
+
+## Files to change
+
+- `/tmp/tsq/testdata/ts/typed/README.md` (new) — what each file
+  exercises and why it matters.
+- `/tmp/tsq/testdata/ts/typed/generics.ts` (new) — generic
+  function, generic class, bounded generic.
+- `/tmp/tsq/testdata/ts/typed/conditional.ts` (new) — `T extends U
+  ? X : Y` types.
+- `/tmp/tsq/testdata/ts/typed/mapped.ts` (new) — `{ [K in keyof T]: ... }`.
+- `/tmp/tsq/testdata/ts/typed/union_intersection.ts` (new).
+- `/tmp/tsq/testdata/ts/typed/literal_types.ts` (new) — string
+  and numeric literal types.
+- `/tmp/tsq/testdata/ts/typed/tsconfig.json` (new) — minimal
+  strict config so tsgo has something to parse.
+
+## Implementation steps
+
+1. Confirm directory does not exist (it doesn't as of writing).
+2. Write each `.ts` file as the smallest valid example that
+   produces at least one non-trivial type fact. Each file gets
+   a top-of-file comment listing which type features it
+   exercises.
+3. Write `tsconfig.json` with `"strict": true`,
+   `"target": "ES2022"`, `"module": "commonjs"`.
+4. Write the README as a table: file → features.
+5. Manually run `tsc --noEmit` (or tsgo equivalent) against the
+   fixtures to confirm they type-check cleanly.
+
+## Test strategy
+
+No Go tests in this PR. Verification:
+- Each `.ts` file type-checks cleanly under `tsc`.
+- Each feature in the README has at least one corresponding file.
+
+## Acceptance criteria
+
+- [ ] Five `.ts` files + tsconfig + README.
+- [ ] All files type-check under `tsc --noEmit`.
+- [ ] README table accurate.
+- [ ] No Go changes.
+
+## Risks and open questions
+
+- Feature coverage vs. fixture size: easy to let these files
+  balloon. Keep each under ~40 lines.
+- Version: pick one TS version (matching tsgo's supported version)
+  and document it.
+- Some features (e.g., variadic tuple types) may not be needed by
+  tsq's type facts yet — omit anything not on the compat-plan 3b
+  relation list.
+
+## Out of scope
+
+- Go test code (plan 12).
+- Golden output files.
+- Real-world snippets — keep fixtures synthetic and small.

--- a/docs/impl-plans/12-typecheck-checker-test.md
+++ b/docs/impl-plans/12-typecheck-checker-test.md
@@ -1,0 +1,84 @@
+# 12 — Unit tests for the typecheck client and enricher
+
+## Scope
+
+Add per-feature unit tests under `extract/typecheck/` that run the
+current typecheck client against plan 11's fixtures and assert that
+specific type facts (generics instantiations, union members,
+conditional type branches, etc.) are emitted into the extracted DB.
+
+The existing `extract/typecheck/client_test.go` and
+`extract/typecheck/enricher_test.go` cover happy-path basics; this
+PR adds feature-specific assertions that catch regressions when
+tsgo upstream changes.
+
+## Dependencies
+
+- Plan 11 (fixtures must exist).
+- Plan 04 is helpful but not required — these tests work against
+  whichever transport is live.
+
+## Files to change
+
+- `/tmp/tsq/extract/typecheck/checker_test.go` (new) — feature-
+  specific tests. If the name collides with an existing file, use
+  `typed_features_test.go`.
+- `/tmp/tsq/extract/typecheck/enricher_test.go` — extend with new
+  sub-tests that consume plan 11 fixtures.
+- `/tmp/tsq/extract/typecheck/testdata/` (new, if not already) —
+  no new files here; reuse `testdata/ts/typed/` via a relative
+  path.
+
+## Implementation steps
+
+1. Read the existing `enricher_test.go` to learn the test shape
+   (how it creates a client, runs enrichment, and inspects facts).
+2. For each fixture file in `testdata/ts/typed/`, add a sub-test:
+   - `TestEnricher_Generics` — assert at least one
+     `GenericInstantiation` tuple is emitted.
+   - `TestEnricher_Conditional` — assert `TypeInfo` contains
+     conditional-type kind.
+   - `TestEnricher_Mapped` — assert mapped-type facts.
+   - `TestEnricher_UnionIntersection` — assert `UnionMember` and
+     `IntersectionMember` populated.
+   - `TestEnricher_LiteralTypes` — assert literal-type kind.
+3. Each sub-test loads the fixture, runs extraction with tsgo
+   enrichment on, and queries the resulting DB directly (no QL
+   layer — keep these low-level).
+4. If any expected relation is not populated, the test fails with
+   a message pointing to the specific fact that's missing.
+
+## Test strategy
+
+- Five new sub-tests under `extract/typecheck/`.
+- Each passes against the current enricher implementation OR fails
+  with a precise "expected X, got Y" message that tells the next
+  implementer what to fix in the enricher.
+- Run `go test ./extract/typecheck/...` — must be green OR failing
+  for a documented reason (e.g., enricher gap).
+
+## Acceptance criteria
+
+- [ ] Five feature-specific tests added.
+- [ ] Each test uses a committed fixture from plan 11.
+- [ ] Test failures (if any) are documented in the PR as known
+  enricher gaps, not test bugs.
+- [ ] `go test ./...` passes OR failures are explicitly skipped
+  with `t.Skip("enricher gap: ...")` and tracked.
+
+## Risks and open questions
+
+- Enricher may not emit all the relations listed in compat-plan
+  3b — some may still be no-ops. If so, skip the test and file an
+  issue; do not retrofit the enricher here.
+- Transport flakiness: if the JSON-RPC client has timing bugs,
+  these tests will be flaky. Plan 04 fixes that; until then, mark
+  flaky tests with a TODO comment referencing plan 04.
+- tsgo version drift: pin the version in go.mod.
+
+## Out of scope
+
+- Enricher improvements.
+- New schema relations.
+- QL-layer tests for type queries (those belong in a future compat
+  typed-query plan, not this testing PR).

--- a/docs/impl-plans/13-stdlib-class-coverage.md
+++ b/docs/impl-plans/13-stdlib-class-coverage.md
@@ -1,0 +1,90 @@
+# 13 — CodeQL stdlib class coverage matrix
+
+## Scope
+
+Compat-plan item 4c says "every CodeQL standard library class gets at
+least one test." This PR implements that as a single coverage matrix:
+a test that enumerates every class exported by the compat bridge
+files (`bridge/compat_*.qll`) and asserts that at least one query in
+`testdata/compat/` (or a dedicated stub query) references it.
+
+Two possible failure modes the matrix catches:
+1. A class is added to the bridge but never exercised.
+2. A class is removed/renamed in the bridge and silently breaks
+   queries downstream.
+
+## Dependencies
+
+- Plan 06 (harness exists, so a coverage test can slot into the same
+  package).
+- Plans 07–10 (goldens exist so the "referenced by a test" check
+  is meaningful).
+
+## Files to change
+
+- `/tmp/tsq/bridge/manifest.go` — read only; the manifest already
+  enumerates available classes (see `compat_test.go` reference to
+  `available classes 84 -> 85`). If not, extend it.
+- `/tmp/tsq/compat_test.go` — add `TestCompatStdlibCoverage`:
+  - Load the bridge manifest.
+  - Parse every `testdata/compat/*.ql` and collect referenced
+    class names.
+  - Assert that every class in the manifest appears in at least
+    one query — or is in an allowlist of "intentionally unused
+    for now" classes.
+- `/tmp/tsq/testdata/compat/coverage_probe.ql` (new, optional) —
+  a query that touches classes not covered elsewhere, so the
+  matrix can be green without hand-writing 85 fixture queries.
+
+## Implementation steps
+
+1. Read `bridge/manifest.go` and confirm it exposes a list of
+   available class names per compat file. If it doesn't, add a
+   `ListCompatClasses()` helper returning `[]string`.
+2. In `compat_test.go`, add `TestCompatStdlibCoverage`:
+   - Walk `testdata/compat/*.ql`.
+   - For each file, parse it (using `ql/parse`) and collect every
+     `TypeRef` that mentions a CodeQL compat name.
+   - Diff against the manifest.
+   - Fail with the list of uncovered classes.
+3. If the diff is non-empty (likely — 85 classes is a lot), add
+   `coverage_probe.ql` that just does `from <Class> c select c` for
+   each uncovered class. This keeps the matrix meaningful without
+   80 separate files.
+4. Add an explicit allowlist in the test for classes that must
+   remain uncovered (e.g., internal helpers). Default: empty.
+
+## Test strategy
+
+- `compat_test.go::TestCompatStdlibCoverage` passes.
+- Removing a class from the manifest causes the test to fail
+  because the probe query no longer resolves.
+- Adding a class and failing to include it in the probe causes
+  the test to fail with a clear "uncovered: [ClassName]" message.
+
+## Acceptance criteria
+
+- [ ] Coverage test passes against every class currently in the
+  manifest.
+- [ ] `coverage_probe.ql` exists (if needed) and parses cleanly.
+- [ ] Allowlist is empty OR has entries with inline justification
+  comments.
+- [ ] Manifest helper method (if added) is exported cleanly.
+
+## Risks and open questions
+
+- Parsing `.ql` files in a test is brittle — consider instead
+  grepping the text for class names. Faster and simpler. Prefer
+  grep unless it produces false positives.
+- "Covered by reference" is a weak form of coverage. A real test
+  would assert each class can actually match at least one tuple
+  in a fixture project. That is a much bigger lift — defer.
+- Adding a class to the bridge should then require a matching
+  probe update in the same PR. Document this in CONTRIBUTING
+  (covered by plan 14).
+
+## Out of scope
+
+- Per-class assertion that tuples flow through.
+- Generating queries automatically from the manifest.
+- Coverage metrics beyond the matrix.

--- a/docs/impl-plans/14-adversarial-review-checklist.md
+++ b/docs/impl-plans/14-adversarial-review-checklist.md
@@ -1,0 +1,96 @@
+# 14 — Adversarial review checklist
+
+## Scope
+
+Compat-plan item 4c says "adversarial review on every PR (existing
+process)." The process exists but is not written down. This PR adds
+a formal checklist to `CONTRIBUTING.md` (or a new file
+`docs/ADVERSARIAL-REVIEW.md`) that every PR reviewer can run
+through, and references it from the PR template.
+
+Docs-only PR. No code changes.
+
+## Dependencies
+
+None.
+
+## Files to change
+
+- `/tmp/tsq/CONTRIBUTING.md` — add a "Adversarial review checklist"
+  section with the items below, or link to a new doc file.
+- `/tmp/tsq/docs/ADVERSARIAL-REVIEW.md` (new, if the checklist is
+  long enough to warrant splitting) — full checklist.
+- `/tmp/tsq/.github/pull_request_template.md` (new or extend) —
+  add a "confirmed adversarial review" checkbox.
+
+## Checklist contents (draft)
+
+The reviewer works through these questions for every PR:
+
+1. **Panics.** Grep the diff for `panic(`, `log.Fatal`, `os.Exit`.
+   Each must have a justifying comment OR be removed.
+2. **Error handling.** Every `err :=` pair must check or explicitly
+   drop with `_ =`. No silent `_, _ = ...`.
+3. **Concurrency.** Any new goroutine: is the exit path clear? Any
+   shared map/slice: is it guarded? Any channel: can it deadlock on
+   close?
+4. **Resource leaks.** Every `os.Open`, `exec.Command`, `db.Open`,
+   `net.Dial` must have a matching `defer Close()`.
+5. **Test gaming.** Does the PR's test actually exercise the change,
+   or does it pass vacuously? Specifically:
+   - Negative controls present?
+   - Does removing the production change cause the test to fail?
+   - Are assertions specific (`got != expected`) or loose (`len > 0`)?
+6. **Benchmark overfitting.** Does the PR only improve a specific
+   benchmark at the cost of real-world paths? Check the change
+   against the v2 integration suite.
+7. **Schema changes.** If `extract/db` schema version bumped, is
+   the reader backward-compat path in place? Tested?
+8. **QL semantics.** For `ql/` changes, does the change respect
+   CodeQL's documented behaviour, or does it invent new semantics?
+   Cite the doc URL in the PR if unsure.
+9. **Clean-room discipline.** For `bridge/compat_*.qll` changes,
+   is the diff clearly paraphrased from public docs, not copied
+   from CodeQL's source?
+10. **Deps.** Any new `go.mod` entry — is the licence compatible?
+    Any replace directive? Pinned version?
+
+## Implementation steps
+
+1. Draft the checklist above into the chosen location.
+2. Add a PR template that references the checklist and includes a
+   "Adversarial review: yes/no/N/A" line.
+3. Update the existing CONTRIBUTING.md to point at the checklist.
+4. Open PR, self-review against the checklist as a smoke test.
+
+## Test strategy
+
+Docs PR; no automated tests. Verification:
+- CONTRIBUTING renders on GitHub correctly.
+- PR template appears when opening a new PR.
+- The checklist items are actionable (someone reading them cold
+  can execute them in <5 minutes).
+
+## Acceptance criteria
+
+- [ ] Checklist committed.
+- [ ] PR template references it.
+- [ ] CONTRIBUTING cross-links it.
+- [ ] No code changes.
+
+## Risks and open questions
+
+- Over-specified checklists become bureaucratic. Keep it to ~10
+  items. Aggressively prune items the existing codebase already
+  enforces via linters.
+- PR template may already exist — check `.github/`. Extend, don't
+  replace.
+- Adversarial review without a tool is advisory; real enforcement
+  happens in CI. This PR does not add CI gates.
+
+## Out of scope
+
+- CI automation for the checklist.
+- Per-item enforcement (linters, grep hooks).
+- Automated adversarial review via subagent — that is a process
+  decision outside the repo.

--- a/docs/impl-plans/15-builtin-splitat.md
+++ b/docs/impl-plans/15-builtin-splitat.md
@@ -1,0 +1,43 @@
+# Plan 15: Add `.splitAt` string built-in
+
+## Scope
+
+Implement the missing `.splitAt(int)` string built-in in `ql/eval/builtins.go`. CodeQL semantics: `s.splitAt(i)` returns the substring starting at index `i` (equivalent to `s.substring(i, s.length())`). Registers alongside the twelve existing methods.
+
+Does NOT deliver: any other missing built-ins (audit shows only `splitAt` missing), any changes to the built-in dispatch loop.
+
+## Dependencies
+
+None. Leaf plan.
+
+## Files to change
+
+- `ql/eval/builtins.go` — add the `splitAt` case to the string method dispatch.
+- `ql/eval/builtins_test.go` (or equivalent existing test file) — add a unit test asserting `"hello".splitAt(2) = "llo"` and edge cases (`splitAt(0)`, `splitAt(len)`, `splitAt(len+1)` for out-of-range behaviour matching CodeQL).
+
+## Implementation steps
+
+1. Read `ql/eval/builtins.go` to find how `.substring` is implemented — splitAt is a strict substring-from-index.
+2. Add a new case in the string method dispatch that takes one int arg and returns `s[i:]` (bounds-clamped).
+3. Match CodeQL's out-of-range behaviour: if `i < 0` or `i > len(s)`, the predicate fails (no result). Verify against CodeQL documentation before committing.
+4. Add a unit test exercising normal, zero, full-length, and out-of-range inputs.
+
+## Test strategy
+
+- `TestBuiltinStringSplitAt` in `ql/eval/builtins_test.go` (or wherever existing string built-in tests live).
+- Assertions: `"hello".splitAt(2) = "llo"`, `"hello".splitAt(0) = "hello"`, `"hello".splitAt(5) = ""`, `"hello".splitAt(6)` fails (no row), `"hello".splitAt(-1)` fails.
+
+## Acceptance criteria
+
+- [ ] `go test ./ql/eval/...` passes including the new test
+- [ ] `go test ./...` passes (no regressions elsewhere)
+- [ ] A query file `testdata/queries/v2/splitat_smoke.ql` with a trivial assertion using `.splitAt()` compiles and runs
+
+## Risks and open questions
+
+- CodeQL's exact out-of-range semantics should be confirmed from public docs before coding the test. If the behaviour is "return empty string" rather than "fail," match that — this plan's assertions are based on "predicate fails" which is the more common convention.
+
+## Out of scope
+
+- Audit of any other missing string built-ins (there are none per current grep, but this plan does not re-audit).
+- Changes to how built-in dispatch finds methods.

--- a/docs/impl-plans/16-dataflow-config-dispatch.md
+++ b/docs/impl-plans/16-dataflow-config-dispatch.md
@@ -1,0 +1,87 @@
+# Plan 16: DataFlow/TaintTracking Configuration dispatch
+
+## Scope
+
+Make `DataFlow::Configuration.hasFlow(source, sink)` (and the TaintTracking equivalent) actually consult the user's `isSource`/`isSink`/`isBarrier` overrides on their `Configuration` subclass, instead of ignoring the subclass and returning the global `LocalFlowStar` / `TaintAlert` extent. This is the compat-stack fix that turns DataFlow and TaintTracking from API-shape stubs into working flow engines for user-defined configurations.
+
+Does NOT deliver: changes to the underlying flow engine (`LocalFlowStar`, `TaintAlert`, `extract/rules/taint.go`). This plan is purely about the bridge-level predicate so the user's class extent filters the result set correctly.
+
+## Dependencies
+
+None strictly; lands cleanly on current main. Should land before plans 07–09 (XSS/SQLi/custom-config goldens) because those goldens can't pass until Configuration dispatch works end-to-end.
+
+## Context
+
+Current state on main (as of this plan):
+
+```ql
+// bridge/compat_dataflow.qll:71-75
+predicate hasFlow(Node source, Node sink) {
+    exists(int fnId |
+        LocalFlowStar(fnId, source, sink)
+    )
+}
+```
+
+This is a module-level predicate, not a method on `Configuration`, and it never mentions `this.isSource(source)` or `this.isSink(sink)`. The same shape appears in `bridge/compat_tainttracking.qll:34-45`. A user who writes:
+
+```ql
+class MyConfig extends DataFlow::Configuration {
+    override predicate isSource(Node n) { ... }
+    override predicate isSink(Node n) { ... }
+}
+
+from MyConfig cfg, Node src, Node sink
+where cfg.hasFlow(src, sink)
+select src, sink
+```
+
+...gets every pair of nodes linked by `LocalFlowStar`, not the ones their `isSource`/`isSink` would select. That's silently wrong.
+
+## Files to change
+
+- `bridge/compat_dataflow.qll` — rework `hasFlow` to be a **method on `Configuration`** that conjoins the user's `isSource(source)` and `isSink(sink)` with the underlying flow relation.
+- `bridge/compat_tainttracking.qll` — same shape, but uses `TaintAlert`/the taint transitive closure instead of `LocalFlowStar`, and additionally negates `isBarrier` / `isSanitizer` as appropriate.
+- `bridge/compat_dataflow_test.go` / `bridge/compat_tainttracking_test.go` — extend existing test helpers with an end-to-end case where a subclass overrides `isSource`/`isSink` and the result set is a proper subset of the global extent.
+
+## Implementation steps
+
+1. Read `bridge/compat_dataflow.qll` end to end to see how `Configuration` and `Node` are currently defined.
+2. Move `hasFlow` inside the `Configuration` class (or make it a method that takes `this` implicitly), and update its body to:
+   ```ql
+   predicate hasFlow(Node source, Node sink) {
+       this.isSource(source) and
+       this.isSink(sink) and
+       exists(int fnId | LocalFlowStar(fnId, source, sink))
+   }
+   ```
+3. Do the same for `hasFlowPath` (currently identical shape, same bug).
+4. Repeat in `compat_tainttracking.qll`, and additionally add `not this.isBarrier(source) and not this.isBarrier(sink)` (or wherever barrier semantics should land — check CodeQL docs for exact positioning).
+5. Add a bridge test that declares a `Configuration` subclass with non-trivial `isSource`/`isSink` and asserts the result is a strict subset of the global `LocalFlowStar` extent.
+6. Run existing `bridge/compat_*_test.go` to confirm they still pass (some may need to switch from module-level `hasFlow` calls to subclass-method calls).
+
+## Test strategy
+
+- `TestDataFlowConfigSubclassFiltersSource` in `bridge/compat_dataflow_test.go` — declare a subclass whose `isSource` returns only nodes with a specific name; assert `hasFlow` results all have that source.
+- `TestDataFlowConfigSubclassFiltersSink` — mirror, on the sink side.
+- `TestTaintTrackingConfigBarrier` — declare a subclass with a non-trivial `isBarrier`; assert flows through the barrier are excluded.
+- A regression assertion: an empty-override subclass (`isSource = none()`) returns zero rows.
+
+## Acceptance criteria
+
+- [ ] `hasFlow` is a method on `Configuration` (or equivalent); the body references `this.isSource`/`this.isSink`.
+- [ ] The new tests pass.
+- [ ] `bridge/compat_dataflow_test.go`, `bridge/compat_tainttracking_test.go`, and any query goldens under `testdata/` that referenced module-level `hasFlow` still pass (migrate call sites if needed).
+- [ ] `go test ./...` green.
+
+## Risks and open questions
+
+- The engine may not currently dispatch `this.<predicate>()` through a subclass override in all cases. Verify with a smoke test before writing the bridge code. If the engine has a gap here, that's a bigger problem than this plan can solve and should be raised as its own engine-side plan.
+- CodeQL's exact `isBarrier` / `isSanitizer` semantics in taint tracking differ from straight dataflow — confirm against docs before coding step 4.
+- Performance: inlining the `isSource`/`isSink` filters into the closure evaluation may change planner behaviour. Monitor test runtimes; if significant, carve out a follow-up for planner hints.
+
+## Out of scope
+
+- Changes to `LocalFlowStar` / `TaintAlert` / the underlying flow engine.
+- New flow-step kinds beyond what CodeQL's base classes expose.
+- Path-query output formatting (`PathGraph`, SARIF hops) — that's plan 10 territory.

--- a/docs/impl-plans/17-type-fact-population.md
+++ b/docs/impl-plans/17-type-fact-population.md
@@ -1,0 +1,68 @@
+# Plan 17: Populate type facts during extraction
+
+## Scope
+
+Register the missing type-fact relations and wire the extractor / enricher to actually write tuples into them at extraction time. Unblocks plans 11, 12 (typed-ts fixtures + checker tests) and retroactively gives plans 3c (`bridge/tsq_types.qll`) and 3d (type-aware dataflow) a non-empty extent to operate against.
+
+Does NOT deliver: new bridge classes in `bridge/tsq_types.qll`, new type-aware dataflow rules, or changes to the tsgo enricher's wire protocol. This plan is strictly about (a) registering the missing relations in the schema and (b) writing tuples from the values the enricher already returns.
+
+## Dependencies
+
+None. The tsgo enricher (`extract/typecheck/enricher.go`) already returns `TypeFact` values — this plan wires them into the fact DB. Plan 04 (direct Go API) is independent and can land in either order.
+
+## Context
+
+Audit of current state (as of this plan):
+
+**Registered relations** (`extract/schema/relations.go`): `ExprType`, `SymbolType`. These are the only two type relations in the schema.
+
+**Missing from the schema** (called for in `CODEQL-COMPAT-PLAN.md` §3b): `TypeInfo`, `TypeMember`, `UnionMember`, `IntersectionMember`, `GenericInstantiation`, `TypeAlias`, `TypeParameter`.
+
+**Population status of the two that do exist:** zero. `extract/walker_v2.go` contains a comment noting type relations are left empty; `extract/typecheck/enricher.go` returns `TypeFact` values but nothing writes those values into the fact DB as datalog tuples; `TestV2ExprTypeEmpty` literally pins `ExprType` at zero tuples. So 3c (`bridge/tsq_types.qll`) and 3d (`extract/rules/callgraph.go`, `extract/rules/taint.go`) both query empty relations — they compile, they "work," they produce nothing.
+
+## Files to change
+
+- `extract/schema/relations.go` — register the seven missing relations (`TypeInfo`, `TypeMember`, `UnionMember`, `IntersectionMember`, `GenericInstantiation`, `TypeAlias`, `TypeParameter`). Column definitions should match CODEQL-COMPAT-PLAN §3b.
+- `extract/walker_v2.go` — remove the "type relations left empty" comment and wire the walker to call into the enricher writeback path.
+- `extract/typecheck/enricher.go` — change from "return values" to "write tuples into the fact DB." Add a writeback helper that takes the extractor's fact-emission callback and a `TypeFact` and writes one row per relation that applies.
+- `extract/walker_v2_test.go` (or sibling) — replace `TestV2ExprTypeEmpty`'s zero-assertion with a test that extracts a small typed TS file and asserts the expected tuple counts per relation.
+
+## Implementation steps
+
+1. Read `extract/schema/relations.go` around the existing `ExprType` / `SymbolType` registrations. Copy the registration shape for the seven missing relations, matching the columns listed in `CODEQL-COMPAT-PLAN.md` §3b.
+2. Read `extract/typecheck/enricher.go` to understand the shape of `TypeFact` and how the tsgo JSON-RPC response is parsed.
+3. Add a `writeTypeFact(emit func(relName string, cols ...any), fact TypeFact)` helper that dispatches on `fact.Kind` and writes one or more tuples.
+4. In `extract/walker_v2.go`, after the tsgo pass, iterate the returned `TypeFact` values and call `writeTypeFact` for each.
+5. Delete or rewrite `TestV2ExprTypeEmpty` — it pins the bug in place. Replace with `TestV2TypeFactsPopulated` asserting non-zero counts per relation against a small typed fixture.
+6. Verify `bridge/tsq_types.qll` still compiles against the updated schema. If the new relations' column order doesn't match what `tsq_types.qll` expects, update `tsq_types.qll` to match the schema (it's the junior partner — the schema is the source of truth from the compat plan).
+7. Run the existing type-related golden tests. Some may start producing additional rows now that the extent is non-empty; regenerate goldens with scrutiny — check each diff is a true positive before accepting.
+
+## Test strategy
+
+- **Fixture:** `testdata/projects/typed-basic/` containing a small `.ts` file exercising each of the seven relations (a union type, an intersection type, a type alias, a generic instantiation, a type parameter constraint, a class with member types).
+- **`TestV2TypeFactsPopulated`**: extracts the fixture, asserts `TypeInfo`, `TypeMember`, `UnionMember`, `IntersectionMember`, `GenericInstantiation`, `TypeAlias`, `TypeParameter`, `ExprType`, `SymbolType` all have non-zero row counts.
+- **`TestExprTypeBindsSymbolToType`**: asserts one specific symbol in the fixture is associated with the type the fixture declares for it (not vacuous — the test must break if the enricher starts writing nonsense).
+- **Golden regeneration check:** any existing tests that asserted empty type extents must be rewritten, not just re-saved. If a golden changes because the new relations produce rows, verify those rows are semantically correct before accepting the new golden. Do not use golden regeneration as a shortcut to hide a bug.
+
+## Acceptance criteria
+
+- [ ] All seven missing relations registered in the schema.
+- [ ] Extraction against the fixture populates every relation with the expected tuples.
+- [ ] `TestV2ExprTypeEmpty` is removed (it encoded the bug); replacement test asserts populated state.
+- [ ] `go test ./...` passes.
+- [ ] `bridge/tsq_types.qll` queries return rows against the fixture (not a golden assertion — just a smoke test that the class extent is non-empty).
+- [ ] No existing non-type-related golden silently changes. Any changes must be explained in the PR description.
+
+## Risks and open questions
+
+- The tsgo enricher's `TypeFact` value shape may not carry all the information needed for seven relations. If it only returns `ExprType`/`SymbolType`-equivalent info, this plan needs a paired upstream-enricher change to emit richer facts — escalate at the point the gap is found, don't silently write zero to the missing relations.
+- `TestV2ExprTypeEmpty` is acting as a canary for the bug. Removing it is correct, but double-check no other test depends on the empty state (grep for `ExprType` in `*_test.go`).
+- Schema version bump: adding relations changes the DB schema version. Check `extract/db/db.go` for how version bumps are handled; readers of older DBs must still work.
+- Some of the seven relations may be hard to emit from the enricher without more tsgo API surface. If `TypeParameter` or `GenericInstantiation` turn out to be blocked on the JSON-RPC protocol, land the easy ones in this plan and carve the blocked ones into a follow-up.
+
+## Out of scope
+
+- New classes in `bridge/tsq_types.qll` beyond what already exists (3c is a separate plan).
+- New type-aware callgraph / taint rules (3d).
+- Changing the tsgo wire protocol or adopting a direct Go API (plan 04).
+- Performance optimisation of type-heavy extraction — profile after correctness.

--- a/docs/impl-plans/DEPENDENCY-GRAPH.md
+++ b/docs/impl-plans/DEPENDENCY-GRAPH.md
@@ -1,0 +1,62 @@
+# Dependency Graph
+
+Merge-order DAG for the impl plans in this directory. An arrow `A -> B`
+means B must land before A.
+
+```
+  01-rank-aggregate        (no deps — self-contained eval change)
+  02-annotation-private    (no deps)
+  03-annotation-deprecated (no deps)
+  04-tsgo-direct-go-api    (no deps — replaces existing JSON-RPC impl)
+
+  05-compat-query-fixtures (no deps — only adds files)
+       │
+       ├─> 07-compat-find-xss-golden
+       ├─> 08-compat-find-sqli-golden
+       ├─> 09-compat-custom-config-golden
+       └─> 10-compat-ast-query-golden
+                 │
+                 ▼
+  06-compat-e2e-harness    (depends on 05; wires fixtures into Go test)
+                 │
+                 ▼
+  07..10 golden-diff tests flip from standalone lint to real assertions
+                 │
+                 ▼
+  13-stdlib-class-coverage (depends on 06; reuses harness)
+
+  11-typed-ts-fixtures     (no deps)
+       │
+       ▼
+  12-typecheck-checker-test (depends on 11)
+
+  14-adversarial-review-checklist (no deps — docs only)
+```
+
+## Notes
+
+- Plans 05 and 06 are separated because the fixtures land first as static
+  files (reviewable in isolation) and the harness lands second once the
+  fixtures exist. Keeps each diff small.
+- Plans 07–10 can be executed in any order once 05 is in. They are
+  grouped together only because they share the harness.
+- Plans 01–04 are independent of the testing plans and can land first
+  or last. Order them earlier in the merge queue because they touch
+  core evaluation code — test plans should run against the latest
+  semantics, not the old ones.
+- Plan 13 is intentionally last; it is a coverage matrix and will need
+  to be updated as 07–10 land, so landing it too early creates churn.
+
+## Dot syntax (for future rendering)
+
+```dot
+digraph impl_plans {
+  "05-fixtures" -> "06-harness";
+  "05-fixtures" -> "07-xss";
+  "05-fixtures" -> "08-sqli";
+  "05-fixtures" -> "09-custom-config";
+  "05-fixtures" -> "10-ast-query";
+  "06-harness"  -> "13-stdlib-coverage";
+  "11-typed-fixtures" -> "12-checker-test";
+}
+```

--- a/docs/impl-plans/DEPENDENCY-GRAPH.md
+++ b/docs/impl-plans/DEPENDENCY-GRAPH.md
@@ -31,6 +31,19 @@ means B must land before A.
   12-typecheck-checker-test (depends on 11)
 
   14-adversarial-review-checklist (no deps — docs only)
+
+  15-builtin-splitat       (no deps — one-liner eval change)
+
+  16-dataflow-config-dispatch (no deps; strongly suggested before 07/08/09)
+       │
+       ├─> 07-compat-find-xss-golden     (needs Configuration to actually dispatch)
+       ├─> 08-compat-find-sqli-golden
+       └─> 09-compat-custom-config-golden
+
+  17-type-fact-population  (no deps)
+       │
+       ├─> 11-typed-ts-fixtures (stronger test story once facts populate)
+       └─> 12-typecheck-checker-test
 ```
 
 ## Notes
@@ -58,5 +71,10 @@ digraph impl_plans {
   "05-fixtures" -> "10-ast-query";
   "06-harness"  -> "13-stdlib-coverage";
   "11-typed-fixtures" -> "12-checker-test";
+  "16-dataflow-dispatch" -> "07-xss";
+  "16-dataflow-dispatch" -> "08-sqli";
+  "16-dataflow-dispatch" -> "09-custom-config";
+  "17-type-facts" -> "11-typed-fixtures";
+  "17-type-facts" -> "12-checker-test";
 }
 ```

--- a/docs/impl-plans/README.md
+++ b/docs/impl-plans/README.md
@@ -1,0 +1,74 @@
+# CodeQL Compatibility — Implementation Plans
+
+This directory breaks `CODEQL-COMPAT-PLAN.md` into PR-sized units. Each plan
+is independently reviewable and lists its own dependencies, steps, and
+acceptance criteria.
+
+## Status legend
+
+- **not started** — no work done
+- **in progress** — branch exists, PR not merged
+- **done** — merged to `main`
+- **already done** — landed before impl plans were written; no plan doc needed
+
+## Phase 1–3 — already landed
+
+Before these plans were written, a deep audit of `origin/main` showed that
+the bulk of Phases 1, 2, and 3 are already merged. The table below records
+this so contributors don't accidentally re-scope finished work. See the
+commit SHAs on `main` for provenance.
+
+| Compat-plan item | Status       | Landed in |
+|------------------|--------------|-----------|
+| 1a modules       | already done | PR #26 (`phase1-abcd`) |
+| 1b disjunction   | already done | PR #26 |
+| 1c negation      | already done | PR #26 |
+| 1d abstract      | already done | PR #26 |
+| 1e string builtins | already done | PR #27 (`phase1-efg`) |
+| 1f if-then-else  | already done | PR #27 |
+| 1g closure syntax | already done | PR #27 |
+| 1h aggregates    | **partial**  | PR #28; `rank` is a count approximation — see plan 01 |
+| 1i forex         | already done | PR #28 |
+| 1j super         | already done | PR #28 |
+| 1k multi-inherit | already done | PR #28 |
+| 1l annotations   | **partial**  | PR #28; parse-only, no semantics — see plans 02, 03 |
+| 2a javascript.qll | already done | PR #29 |
+| 2b dataflow.qll  | already done | PR #30 |
+| 2c tainttracking | already done | PR #31 |
+| 2d security libs | already done | PR #32 |
+| 2e import mapping | already done | PR #29 |
+| 3a tsgo integration | **partial** | PR #33; implemented via JSON-RPC, not direct Go dep — see plan 04 |
+| 3b type facts    | already done | PR #34 |
+| 3c typed bridge  | already done | PR #35 |
+| 3d typed dataflow | already done | PR #36 |
+
+## Remaining plans
+
+Merge order is top to bottom. See `DEPENDENCY-GRAPH.md` for the DAG.
+
+| #  | Plan                                           | Phase item(s) | Status      |
+|----|------------------------------------------------|---------------|-------------|
+| 01 | [rank-aggregate](01-rank-aggregate.md)         | 1h            | not started |
+| 02 | [annotation-private](02-annotation-private.md) | 1l            | not started |
+| 03 | [annotation-deprecated](03-annotation-deprecated.md) | 1l      | not started |
+| 04 | [tsgo-direct-go-api](04-tsgo-direct-go-api.md) | 3a            | not started |
+| 05 | [compat-query-fixtures](05-compat-query-fixtures.md) | 4a      | not started |
+| 06 | [compat-e2e-harness](06-compat-e2e-harness.md) | 4a            | not started |
+| 07 | [compat-find-xss-golden](07-compat-find-xss-golden.md) | 4a    | not started |
+| 08 | [compat-find-sqli-golden](08-compat-find-sqli-golden.md) | 4a  | not started |
+| 09 | [compat-custom-config-golden](09-compat-custom-config-golden.md) | 4a | not started |
+| 10 | [compat-ast-query-golden](10-compat-ast-query-golden.md) | 4a  | not started |
+| 11 | [typed-ts-fixtures](11-typed-ts-fixtures.md)   | 4b            | not started |
+| 12 | [typecheck-checker-test](12-typecheck-checker-test.md) | 4b    | not started |
+| 13 | [stdlib-class-coverage](13-stdlib-class-coverage.md) | 4c      | not started |
+| 14 | [adversarial-review-checklist](14-adversarial-review-checklist.md) | 4c | not started |
+
+## How to execute a plan
+
+1. Pick the lowest-numbered plan whose dependencies are all **done**.
+2. Read the plan end to end. Open the referenced files. Confirm the plan
+   still matches reality — `main` moves.
+3. Implement on a branch named after the plan file (e.g. `plan-01-rank`).
+4. Run `go test ./...` before opening the PR.
+5. Request adversarial review (see plan 14).
+6. After merge, flip status to **done** here and record the PR number.

--- a/docs/impl-plans/README.md
+++ b/docs/impl-plans/README.md
@@ -24,7 +24,7 @@ commit SHAs on `main` for provenance.
 | 1b disjunction   | already done | PR #26 |
 | 1c negation      | already done | PR #26 |
 | 1d abstract      | already done | PR #26 |
-| 1e string builtins | already done | PR #27 (`phase1-efg`) |
+| 1e string builtins | **partial**  | PR #27 (`phase1-efg`); `.splitAt` missing — see plan 15 |
 | 1f if-then-else  | already done | PR #27 |
 | 1g closure syntax | already done | PR #27 |
 | 1h aggregates    | **partial**  | PR #28; `rank` is a count approximation — see plan 01 |
@@ -33,14 +33,14 @@ commit SHAs on `main` for provenance.
 | 1k multi-inherit | already done | PR #28 |
 | 1l annotations   | **partial**  | PR #28; parse-only, no semantics — see plans 02, 03 |
 | 2a javascript.qll | already done | PR #29 |
-| 2b dataflow.qll  | already done | PR #30 |
-| 2c tainttracking | already done | PR #31 |
+| 2b dataflow.qll  | **partial**  | PR #30; API shape only, `hasFlow` ignores user `Configuration` overrides — see plan 16 |
+| 2c tainttracking | **partial**  | PR #31; same Configuration-dispatch gap as 2b — see plan 16 |
 | 2d security libs | already done | PR #32 |
 | 2e import mapping | already done | PR #29 |
 | 3a tsgo integration | **partial** | PR #33; implemented via JSON-RPC, not direct Go dep — see plan 04 |
-| 3b type facts    | already done | PR #34 |
-| 3c typed bridge  | already done | PR #35 |
-| 3d typed dataflow | already done | PR #36 |
+| 3b type facts    | **partial**  | PR #34; only `ExprType`/`SymbolType` registered (7 of 9 relations missing), and both are never populated at extraction time — see plan 17 |
+| 3c typed bridge  | **partial**  | PR #35; operates on empty extent because 3b is unpopulated — unblocked by plan 17 |
+| 3d typed dataflow | **partial**  | PR #36; operates on empty extent because 3b is unpopulated — unblocked by plan 17 |
 
 ## Remaining plans
 
@@ -62,6 +62,9 @@ Merge order is top to bottom. See `DEPENDENCY-GRAPH.md` for the DAG.
 | 12 | [typecheck-checker-test](12-typecheck-checker-test.md) | 4b    | not started |
 | 13 | [stdlib-class-coverage](13-stdlib-class-coverage.md) | 4c      | not started |
 | 14 | [adversarial-review-checklist](14-adversarial-review-checklist.md) | 4c | not started |
+| 15 | [builtin-splitat](15-builtin-splitat.md)       | 1e residual   | not started |
+| 16 | [dataflow-config-dispatch](16-dataflow-config-dispatch.md) | 2b, 2c | not started |
+| 17 | [type-fact-population](17-type-fact-population.md) | 3b           | not started |
 
 ## How to execute a plan
 


### PR DESCRIPTION
## Summary

- Breaks `CODEQL-COMPAT-PLAN.md` into 14 PR-sized implementation plan docs under `docs/impl-plans/`, each independently reviewable with scope, deps, files, steps, tests, acceptance criteria, risks, and out-of-scope.
- Adds `docs/impl-plans/README.md` as a burn-down tracker and `docs/impl-plans/DEPENDENCY-GRAPH.md` as the merge-order DAG.
- Records which compat-plan items were already landed before plans were written (audit findings below).

## Audit: what's already done on main

A deep grep of `origin/main` showed that the bulk of Phases 1-3 is already merged:

| Item | Status | Landed in |
|---|---|---|
| 1a modules, 1b disjunction, 1c negation, 1d abstract | done | #26 |
| 1e string builtins, 1f if-then-else, 1g closure syntax | done | #27 |
| 1h aggregates (partial — `rank` is count approximation) | partial | #28 |
| 1i forex, 1j super, 1k multi-inherit | done | #28 |
| 1l annotations (parse-only, no semantics) | partial | #28 |
| 2a javascript.qll, 2e import mapping | done | #29 |
| 2b dataflow.qll | done | #30 |
| 2c tainttracking.qll | done | #31 |
| 2d security libs | done | #32 |
| 3a tsgo (implemented via JSON-RPC, not direct Go dep) | partial | #33 |
| 3b type facts, 3c typed bridge, 3d typed dataflow | done | #34-#36 |

No plan doc is written for items marked "done". Plans 01/02/03/04 cover the three residual partials. Plans 05-14 cover Phase 4 (testing) which has zero coverage on main.

## The 14 plans

| # | Plan | Phase |
|---|---|---|
| 01 | True ordinal `rank` aggregate | 1h residual |
| 02 | Enforce `private` predicate visibility | 1l residual |
| 03 | `deprecated` warnings | 1l residual |
| 04 | tsgo direct Go API (replace JSON-RPC) | 3a residual |
| 05 | `testdata/compat/` query fixtures | 4a |
| 06 | End-to-end compat test harness (`compat_test.go`) | 4a |
| 07 | XSS compat query golden | 4a |
| 08 | SQLi compat query golden | 4a |
| 09 | User-defined `DataFlow::Configuration` golden | 4a |
| 10 | AST query golden | 4a |
| 11 | Typed TS fixtures (`testdata/ts/typed/`) | 4b |
| 12 | Typecheck feature unit tests | 4b |
| 13 | Stdlib class coverage matrix | 4c |
| 14 | Adversarial review checklist | 4c |

## Surprises / notes for reviewers

- **Phase 3a shipped as JSON-RPC**, not the direct Go import the compat plan specified. Plan 04 brings it back in line; may be blocked on tsgo upstream API maturity.
- **`rank` aggregate is a count approximation**, not a real ordinal — the `case "rank"` in `ql/eval/aggregate.go:186` literally returns `len(vals)`. Plan 01 finishes it.
- **Annotations are parse-only** — `private`, `deprecated`, `pragma[...]`, `bindingset[...]`, `language[...]` are stored on AST nodes but have no semantic effect. Plans 02 and 03 cover the two that actually change behaviour; the rest remain intentional no-ops.
- **No `testdata/compat/`, no `testdata/ts/typed/`, no root `compat_test.go`** — Phase 4 is untouched. Plans 05-13 build it up.
- **Plan doc count (14) is below the 15-20 band** — because Phases 1-3 were mostly done, there was less remaining work to slice into PRs than the original plan anticipated.

## Test plan

- [ ] Reviewers confirm the "already done" audit against `git log origin/main`
- [ ] Reviewers spot-check that plan 01's "rank is approximate" claim matches `ql/eval/aggregate.go:186`
- [ ] Reviewers sanity-check that `testdata/compat/`, `testdata/ts/typed/`, and root `compat_test.go` really don't exist on main
- [ ] `go test ./...` still green (this PR adds no Go code)