### PR TITLE
Add .splitAt(int) string built-in (plan 15)

### DIFF
--- a/ql/desugar/desugar.go
+++ b/ql/desugar/desugar.go
@@ -1171,6 +1171,7 @@ var stringBuiltins = map[string]bool{
 	"charAt":      true,
 	"toInt":       true,
 	"toString":    true,
+	"splitAt":     true,
 }
 
 // ---- Helpers ----

--- a/ql/eval/builtins.go
+++ b/ql/eval/builtins.go
@@ -28,6 +28,7 @@ var builtinRegistry = map[string]builtinFunc{
 	"__builtin_string_regexpMatch": builtinStringRegexpMatch,
 	"__builtin_string_toInt":       builtinStringToInt,
 	"__builtin_string_toString":    builtinStringToString,
+	"__builtin_string_splitAt":     builtinStringSplitAt,
 }
 
 // IsBuiltin returns true if the predicate name is a registered builtin.
@@ -364,6 +365,34 @@ func builtinStringToString(atom datalog.Atom, bindings []binding) []binding {
 			continue
 		}
 		nb, ok := bindResult(atom.Args[1], b, StrVal{V: s})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_string_splitAt(this, index, result) — result = this[index:]
+// Predicate fails (no result) if index < 0 or index > len(this).
+func builtinStringSplitAt(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 3 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		idx, ok := resolveIntArg(atom.Args[1], b)
+		if !ok {
+			continue
+		}
+		// Out-of-range: predicate fails (no result row).
+		if idx < 0 || int(idx) > len(s) {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[2], b, StrVal{V: s[idx:]})
 		if ok {
 			out = append(out, nb)
 		}

--- a/ql/eval/builtins_test.go
+++ b/ql/eval/builtins_test.go
@@ -396,6 +396,60 @@ func TestBuiltinStringToString(t *testing.T) {
 	}
 }
 
+// TestBuiltinStringSplitAt evaluates __builtin_string_splitAt.
+func TestBuiltinStringSplitAt(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		index    int64
+		wantRows int
+		want     string
+	}{
+		{"mid", "hello", 2, 1, "llo"},
+		{"zero", "hello", 0, 1, "hello"},
+		{"full_length", "hello", 5, 1, ""},
+		{"out_of_range", "hello", 6, 0, ""},
+		{"negative", "hello", -1, 0, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := makeRelation("Data", 1, StrVal{V: tt.input})
+			baseRels := map[string]*Relation{"Data": data}
+
+			ep := &plan.ExecutionPlan{
+				Strata: []plan.Stratum{{
+					Rules: []plan.PlannedRule{{
+						Head: head("Result", v("r")),
+						JoinOrder: []plan.JoinStep{
+							positiveStep("Data", v("s")),
+							positiveStep("__builtin_string_splitAt", v("s"), ic(tt.index), v("r")),
+						},
+					}},
+				}},
+				Query: &plan.PlannedQuery{
+					Select:    []datalog.Term{v("r")},
+					JoinOrder: []plan.JoinStep{positiveStep("Result", v("r"))},
+				},
+			}
+
+			rs, err := Evaluate(context.Background(), ep, baseRels)
+			if err != nil {
+				t.Fatalf("Evaluate: %v", err)
+			}
+			if len(rs.Rows) != tt.wantRows {
+				t.Fatalf("expected %d rows, got %d: %v", tt.wantRows, len(rs.Rows), rs.Rows)
+			}
+			if tt.wantRows > 0 {
+				got := rs.Rows[0][0].(StrVal).V
+				if got != tt.want {
+					t.Errorf("expected %q, got %q", tt.want, got)
+				}
+			}
+		})
+	}
+}
+
 // TestBuiltinIsBuiltin verifies IsBuiltin for known and unknown predicates.
 func TestBuiltinIsBuiltin(t *testing.T) {
 	if !IsBuiltin("__builtin_string_length") {


### PR DESCRIPTION
## Summary
- Implement `splitAt(int)` string built-in: `s.splitAt(i)` returns `s[i:]`
- Out-of-range indices (negative or > len) cause predicate failure (no result), matching CodeQL semantics
- Registered in both `builtinRegistry` (eval) and `stringBuiltins` (desugar)

## Test plan
- [x] `TestBuiltinStringSplitAt/mid` — `"hello".splitAt(2) = "llo"`
- [x] `TestBuiltinStringSplitAt/zero` — `"hello".splitAt(0) = "hello"`
- [x] `TestBuiltinStringSplitAt/full_length` — `"hello".splitAt(5) = ""`
- [x] `TestBuiltinStringSplitAt/out_of_range` — `"hello".splitAt(6)` fails
- [x] `TestBuiltinStringSplitAt/negative` — `"hello".splitAt(-1)` fails
- [x] Full `go test ./...` passes