### PR TITLE
docs: adversarial review checklist and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- What does this PR do and why? 1-3 sentences. -->
+
+## Test Plan
+
+<!-- How was this tested? List specific steps or commands. -->
+
+- [ ] All existing tests pass (`make test`)
+- [ ] New tests added for changed behaviour
+- [ ] Linter is clean (`make lint`)
+
+## Adversarial Review
+
+- [ ] Reviewed against the [adversarial review checklist](docs/ADVERSARIAL-REVIEW.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Every PR must:
 
 ### Adversarial Review
 
-For each PR, a separate review agent runs the standard review checklist (see implementation plans). The review must find and report any real problems before the PR merges. The implementing agent fixes issues found, then the reviewer re-checks.
+For each PR, a separate review agent runs the [adversarial review checklist](docs/ADVERSARIAL-REVIEW.md). The review must find and report any real problems before the PR merges. The implementing agent fixes issues found, then the reviewer re-checks.
 
 ### Handover Documents
 

--- a/docs/ADVERSARIAL-REVIEW.md
+++ b/docs/ADVERSARIAL-REVIEW.md
@@ -1,0 +1,60 @@
+# Adversarial Review Checklist
+
+Every PR to tsq must pass this checklist before merge. Each item is designed to be executable in under a minute by someone with no prior context on the change.
+
+---
+
+## 1. Panics
+
+Grep the diff for `panic(`, `log.Fatal`, `os.Exit`. Each occurrence must have a comment justifying why it is acceptable (e.g., truly unrecoverable init failure). If no justification exists, it must be replaced with error propagation.
+
+## 2. Error Handling
+
+Every `err :=` assignment in the diff must be followed by an `if err != nil` check or explicitly discarded with `_ =`. No unchecked errors.
+
+## 3. Concurrency
+
+Any new goroutine must have a clear exit path (context cancellation, channel close, or WaitGroup). Shared maps and slices must be guarded by a mutex or accessed only from a single goroutine. Channels must not be able to deadlock — verify send/receive pairs and buffer sizes.
+
+## 4. Resource Leaks
+
+Every `os.Open`, `exec.Command` (with `.Start()`), `db.Open`, `net.Dial`, or similar resource acquisition in the diff must have a matching `defer Close()` (or equivalent cleanup). Check that the defer is in the correct scope.
+
+## 5. Test Gaming
+
+For each new or modified test, verify:
+- The test actually exercises the production code being changed.
+- Negative controls are present (test fails when expected-bad input is given).
+- Removing the production change causes the test to fail.
+- Assertions are specific — no bare `err == nil` without checking the returned value.
+
+## 6. Benchmark Overfitting
+
+If the PR improves a specific benchmark, check whether the optimization is general-purpose or whether it only speeds up the benchmark's exact input shape at the cost of real-world code paths.
+
+## 7. Schema Changes
+
+If `extract/` or database schema versions are bumped:
+- Is there a migration path from the previous version?
+- Can the old schema still be read (backward compatibility)?
+- Is the version constant incremented, not just the schema definition?
+
+## 8. QL Semantics
+
+For changes under `ql/`:
+- Does the change respect documented CodeQL behaviour?
+- Are predicates tested with both positive and negative examples?
+- Do `.ql` test expectations match what CodeQL would actually produce?
+
+## 9. Clean-Room Discipline
+
+For changes under `bridge/compat_*.qll`:
+- Is the diff paraphrased from public documentation, not copied from CodeQL source?
+- Can the author point to a public doc URL justifying the implementation?
+
+## 10. Dependencies
+
+For any new entry in `go.mod`:
+- Is the licence compatible (MIT, Apache-2.0, BSD — flag anything else)?
+- Are there `replace` directives? If so, are they temporary and documented?
+- Is the version pinned (no floating tags or `latest`)?


### PR DESCRIPTION
## Summary

- Add `docs/ADVERSARIAL-REVIEW.md` with a 10-item checklist covering panics, error handling, concurrency, resource leaks, test gaming, benchmark overfitting, schema changes, QL semantics, clean-room discipline, and dependencies
- Add `.github/pull_request_template.md` with summary, test plan, and adversarial review checkbox
- Update `CONTRIBUTING.md` to link directly to the checklist

## Test plan

- [ ] Docs-only change — no code modified
- [ ] PR template renders correctly on new PRs
- [ ] Links between CONTRIBUTING.md and the checklist resolve correctly