### PR TITLE
Phase 2 batch 1: framework models, builtins, stdlib stubs, DataFlow API

### DIFF
--- a/bridge/compat_crypto.qll
+++ b/bridge/compat_crypto.qll
@@ -1,0 +1,75 @@
+/**
+ * CodeQL-compatible cryptographic operation and cleartext logging stubs.
+ * Clean-room implementation providing detection of crypto API usage
+ * and logging of potentially sensitive data.
+ *
+ * This file is NOT derived from CodeQL source code.
+ * API surface documented from public CodeQL documentation.
+ */
+
+/**
+ * A call to a cryptographic operation from the Node.js crypto module
+ * or similar libraries. Matches calls to createHash, createCipher,
+ * createCipheriv, createDecipher, createDecipheriv, createHmac, createSign,
+ * createVerify, etc.
+ */
+class CryptographicOperation extends @method_call {
+    CryptographicOperation() {
+        MethodCall(this, _, "createHash") or
+        MethodCall(this, _, "createCipher") or
+        MethodCall(this, _, "createCipheriv") or
+        MethodCall(this, _, "createDecipher") or
+        MethodCall(this, _, "createDecipheriv") or
+        MethodCall(this, _, "createHmac") or
+        MethodCall(this, _, "createSign") or
+        MethodCall(this, _, "createVerify")
+    }
+
+    /** Gets the method name of this cryptographic operation. */
+    string getMethodName() { MethodCall(this, _, result) }
+
+    /** Gets the receiver expression. */
+    int getReceiver() { MethodCall(this, result, _) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "CryptographicOperation" }
+}
+
+/**
+ * A call to a logging function that may expose cleartext sensitive data.
+ * Matches console.log, console.error, console.warn, console.info,
+ * and common logging library methods (winston, pino, bunyan).
+ */
+class CleartextLogging extends @method_call {
+    CleartextLogging() {
+        MethodCall(this, _, "log") or
+        MethodCall(this, _, "error") or
+        MethodCall(this, _, "warn") or
+        MethodCall(this, _, "info") or
+        MethodCall(this, _, "debug") or
+        MethodCall(this, _, "trace")
+    }
+
+    /** Gets the method name. */
+    string getMethodName() { MethodCall(this, _, result) }
+
+    /** Gets the receiver expression. */
+    int getReceiver() { MethodCall(this, result, _) }
+
+    /** Gets a textual representation. */
+    string toString() { result = "CleartextLogging" }
+}
+
+/**
+ * An abstract class representing an expression that contains sensitive data.
+ * Users can extend this class to mark specific expressions as sensitive.
+ * This is a marker class — concrete subclasses must define the characteristic
+ * predicate to identify which expressions are sensitive.
+ */
+class SensitiveDataExpr extends @symbol {
+    /** Gets the kind of sensitive data (e.g., "password", "credential", "secret"). */
+    string getKind() { result = "sensitive" }
+
+    /** Gets a textual representation. */
+    string toString() { result = "SensitiveDataExpr" }
+}

--- a/bridge/compat_dataflow.qll
+++ b/bridge/compat_dataflow.qll
@@ -26,6 +26,24 @@ module DataFlow {
 
         /** Gets the name of the symbol this node represents. */
         string getName() { Symbol(this, result, _, _) }
+
+        /** Gets a successor node via local data flow. */
+        Node getASuccessor() { exists(int fnId | LocalFlow(fnId, this, result)) }
+
+        /** Gets a predecessor node via local data flow. */
+        Node getAPredecessor() { exists(int fnId | LocalFlow(fnId, result, this)) }
+
+        /** Gets a source node that flows to this node via transitive flow. */
+        Node getASourceNode() { FlowStar(result, this) }
+
+        /** Holds if data flows from this node to `other`. */
+        predicate flowsTo(Node other) { FlowStar(this, other) }
+
+        /** Holds if data flows from `other` to this node. */
+        predicate flowsFrom(Node other) { FlowStar(other, this) }
+
+        /** Holds if this node represents a function parameter. */
+        predicate isParameter() { Parameter(_, _, _, _, this, _) }
     }
 
     /**

--- a/bridge/compat_dataflow_test.go
+++ b/bridge/compat_dataflow_test.go
@@ -241,10 +241,16 @@ func TestDataFlowNodeMembers(t *testing.T) {
 	}
 
 	expectedMembers := map[string]bool{
-		"toString":    false,
-		"getLocation": false,
-		"asExpr":      false,
-		"getName":     false,
+		"toString":        false,
+		"getLocation":     false,
+		"asExpr":          false,
+		"getName":         false,
+		"getASourceNode":  false,
+		"getAPredecessor": false,
+		"getASuccessor":   false,
+		"flowsTo":         false,
+		"flowsFrom":       false,
+		"isParameter":     false,
 	}
 
 	for _, m := range nodeClass.Members {

--- a/bridge/compat_dom.qll
+++ b/bridge/compat_dom.qll
@@ -1,0 +1,84 @@
+/**
+ * CodeQL-compatible DOM standard library stubs.
+ * Clean-room implementation providing DOM element classes,
+ * innerHTML/outerHTML write sinks, document.write sinks,
+ * and attribute write detection.
+ *
+ * This file is NOT derived from CodeQL source code.
+ * API surface documented from public CodeQL documentation.
+ */
+
+module DOM {
+    /**
+     * A DOM element, backed by JsxElement relation.
+     * Provides access to element attributes and tag name.
+     */
+    class Element extends @jsx_element {
+        Element() { JsxElement(this, _, _) }
+
+        /** Gets an attribute of this element. */
+        int getAnAttribute() { JsxAttribute(this, _, result) }
+
+        /** Gets the tag node for this element. */
+        int getTagName() { JsxElement(this, result, _) }
+
+        /** Gets a textual representation. */
+        string toString() { result = "DOM::Element" }
+    }
+
+    /**
+     * A write to innerHTML or outerHTML property.
+     * This is a TaintSink("xss") — writing user-controlled data to
+     * innerHTML/outerHTML enables cross-site scripting.
+     */
+    class InnerHtmlWrite extends @field_write {
+        InnerHtmlWrite() {
+            FieldWrite(this, _, "innerHTML", _) or
+            FieldWrite(this, _, "outerHTML", _)
+        }
+
+        /** Gets the right-hand side expression being written. */
+        int getRhs() { FieldWrite(this, _, _, result) }
+
+        /** Gets a textual representation. */
+        string toString() { result = "DOM::InnerHtmlWrite" }
+    }
+
+    /**
+     * A call to document.write() or document.writeln().
+     * This is a TaintSink("xss") — passing user-controlled data to
+     * document.write enables cross-site scripting.
+     */
+    class DocumentWrite extends @method_call {
+        DocumentWrite() {
+            MethodCall(this, _, "write") or
+            MethodCall(this, _, "writeln")
+        }
+
+        /** Gets the receiver expression. */
+        int getReceiver() { MethodCall(this, result, _) }
+
+        /** Gets a textual representation. */
+        string toString() { result = "DOM::DocumentWrite" }
+    }
+
+    /**
+     * A write to a DOM element property (e.g., element.src = ...).
+     * Backed by FieldWrite relation on DOM element symbols.
+     */
+    class AttributeWrite extends @field_write {
+        AttributeWrite() { FieldWrite(this, _, _, _) }
+
+        /** Gets the base symbol. */
+        int getBaseSym() { FieldWrite(this, result, _, _) }
+
+        /** Gets the property name. */
+        string getPropertyName() { FieldWrite(this, _, result, _) }
+
+        /** Gets the right-hand side expression. */
+        int getRhs() { FieldWrite(this, _, _, result) }
+
+        /** Gets a textual representation. */
+        string toString() { result = "DOM::AttributeWrite" }
+    }
+}

--- a/bridge/embed.go
+++ b/bridge/embed.go
@@ -2,7 +2,7 @@ package bridge
 
 import "embed"
 
-//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll tsq_summaries.qll tsq_composition.qll tsq_taint.qll tsq_express.qll tsq_react.qll tsq_node.qll compat_javascript.qll compat_dataflow.qll compat_tainttracking.qll compat_security_xss.qll compat_security_cmdi.qll compat_security_sqli.qll compat_security_pathtraversal.qll
+//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll tsq_summaries.qll tsq_composition.qll tsq_taint.qll tsq_express.qll tsq_react.qll tsq_node.qll compat_javascript.qll compat_dataflow.qll compat_tainttracking.qll compat_security_xss.qll compat_security_cmdi.qll compat_security_sqli.qll compat_security_pathtraversal.qll compat_dom.qll compat_crypto.qll
 var bridgeFS embed.FS
 
 // LoadBridge returns all embedded .qll files as a map from filename to contents.
@@ -33,6 +33,8 @@ func LoadBridge() map[string][]byte {
 		"compat_security_cmdi.qll",
 		"compat_security_sqli.qll",
 		"compat_security_pathtraversal.qll",
+		"compat_dom.qll",
+		"compat_crypto.qll",
 	}
 	result := make(map[string][]byte, len(files))
 	for _, name := range files {
@@ -83,6 +85,8 @@ func ImportLoader(bridgeFiles map[string][]byte, parseFn func(src, file string) 
 		"semmle.javascript.security.dataflow.CommandInjectionQuery": "compat_security_cmdi.qll",
 		"semmle.javascript.security.dataflow.SqlInjectionQuery":     "compat_security_sqli.qll",
 		"semmle.javascript.security.dataflow.PathTraversalQuery":    "compat_security_pathtraversal.qll",
+		"semmle.javascript.security.dataflow.DomBasedXssQuery":      "compat_dom.qll",
+		"semmle.javascript.security.CryptoLibraries":                "compat_crypto.qll",
 	}
 	return func(path string) (interface{}, bool) {
 		filename, ok := pathToFile[path]

--- a/bridge/embed_test.go
+++ b/bridge/embed_test.go
@@ -32,6 +32,8 @@ func TestLoadBridgeReturnsAllFiles(t *testing.T) {
 		"compat_security_cmdi.qll",
 		"compat_security_sqli.qll",
 		"compat_security_pathtraversal.qll",
+		"compat_dom.qll",
+		"compat_crypto.qll",
 	}
 	files := LoadBridge()
 	if len(files) != len(expected) {

--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -135,6 +135,8 @@ func v2Manifest() *CapabilityManifest {
 			{Name: "GenericInstantiation", Relation: "GenericInstantiation", File: "tsq_types.qll"},
 			{Name: "TypeAlias", Relation: "TypeAlias", File: "tsq_types.qll"},
 			{Name: "TypeParameter", Relation: "TypeParameter", File: "tsq_types.qll"},
+			// Phase F1: expression-in-function scoping
+			{Name: "ExprInFunction", Relation: "ExprInFunction", File: "tsq_functions.qll"},
 			// v2 Phase 2b: CodeQL-compatible DataFlow module
 			{Name: "DataFlow::Node", Relation: "Symbol", File: "compat_dataflow.qll"},
 			{Name: "DataFlow::PathNode", Relation: "Symbol", File: "compat_dataflow.qll"},
@@ -149,6 +151,15 @@ func v2Manifest() *CapabilityManifest {
 			{Name: "SqlInjection::SqlInjectionSink", Relation: "Symbol", File: "compat_security_sqli.qll"},
 			{Name: "PathTraversal::PathTraversalSource", Relation: "Symbol", File: "compat_security_pathtraversal.qll"},
 			{Name: "PathTraversal::PathTraversalSink", Relation: "Symbol", File: "compat_security_pathtraversal.qll"},
+			// v3 Phase E2: DOM class stubs
+			{Name: "DOM::Element", Relation: "JsxElement", File: "compat_dom.qll"},
+			{Name: "DOM::InnerHtmlWrite", Relation: "FieldWrite", File: "compat_dom.qll"},
+			{Name: "DOM::DocumentWrite", Relation: "MethodCall", File: "compat_dom.qll"},
+			{Name: "DOM::AttributeWrite", Relation: "FieldWrite", File: "compat_dom.qll"},
+			// v3 Phase E3: Crypto and logging stubs
+			{Name: "CryptographicOperation", Relation: "MethodCall", File: "compat_crypto.qll"},
+			{Name: "CleartextLogging", Relation: "MethodCall", File: "compat_crypto.qll"},
+			{Name: "SensitiveDataExpr", Relation: "Symbol", File: "compat_crypto.qll"},
 		},
 		Unavailable: []UnavailableClass{},
 	}

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -12,8 +12,9 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	// v3 Phase 3c: +2 bridge classes (Type, SymbolTypeBinding) = 84
 	// v3 Phase 3d: +1 bridge class (NonTaintableType) = 85
 	// v3 Phase 17: +7 type-fact relations = 92
-	if got := len(m.Available); got != 92 {
-		t.Errorf("expected 92 available classes, got %d", got)
+	// Phase 2: +7 DOM/crypto/framework stubs + 1 ExprInFunction = 100
+	if got := len(m.Available); got != 100 {
+		t.Errorf("expected 100 available classes, got %d", got)
 	}
 }
 

--- a/compat_test.go
+++ b/compat_test.go
@@ -169,6 +169,13 @@ func compatTestCases() []compatTestCase {
 			goldenFile: "testdata/compat/expected/custom_config.csv",
 			skip:       "Configuration.hasFlow requires LocalFlowStar which doesn't cover FieldRead-based sources yet",
 		},
+		{
+			name:       "dataflow_predicates",
+			projectDir: "testdata/compat/projects/basic",
+			queryFile:  "testdata/compat/dataflow_predicates.ql",
+			goldenFile: "testdata/compat/expected/dataflow_predicates.csv",
+			skip:       "DataFlow predicates need golden file generation after LocalFlow is verified on basic fixture",
+		},
 	}
 }
 

--- a/docs/IMPLEMENTATION_PLANS_V2.md
+++ b/docs/IMPLEMENTATION_PLANS_V2.md
@@ -1,0 +1,274 @@
+# tsq CodeQL Compatibility — Implementation Plans (Phase 2)
+
+Based on a comprehensive audit of gaps between tsq and CodeQL query compatibility.
+Organized into parallel work streams where possible.
+
+---
+
+## Work Stream A: DataFlow API Completion (Critical)
+
+Blocks ~50+ queries. The DataFlow/TaintTracking API is the backbone of all security queries.
+
+### Plan A1: DataFlow::Node predicate implementation
+**Files**: `bridge/compat_dataflow.qll`, `ql/desugar/desugar.go`
+**Goal**: Implement `DataFlow::Node.getASourceNode()`, `.getAPredecessor()`, `.getASuccessor()`, `.flowsTo()`, `.flowsFrom()`, `.asExpr()`, `.asParameter()`
+**Approach**: These predicates map to existing relations (FlowStar, LocalFlowStar, ExprMayRef, Parameter). Wire them as QL class methods that desugar to the right Datalog joins.
+**Est**: ~120 LoC
+**Depends on**: Nothing — can start immediately
+
+### Plan A2: DataFlow::Configuration user override support
+**Files**: `ql/desugar/desugar.go`, `bridge/compat_dataflow.qll`, `extract/rules/taint.go`
+**Goal**: Allow users to define custom `DataFlow::Configuration` subclasses with `isSource()`, `isSink()`, `isBarrier()` overrides that actually affect analysis.
+**Approach**: Desugar user `isSource`/`isSink`/`isBarrier` overrides into additional TaintSource/TaintSink/Sanitizer facts before evaluation. This is the key gap — currently Configuration is a skeleton.
+**Est**: ~200 LoC
+**Depends on**: A1
+
+### Plan A3: TaintTracking::Configuration.isAdditionalTaintStep()
+**Files**: `bridge/compat_tainttracking.qll`, `extract/rules/taint.go`
+**Goal**: Implement `isAdditionalTaintStep(src, sink)` override that adds custom FlowStar edges during taint propagation.
+**Approach**: Desugar user-defined additional steps into supplementary FlowStar facts. Needs a new derived relation `AdditionalTaintStep` that gets merged into FlowStar before fixpoint.
+**Est**: ~100 LoC
+**Depends on**: A2
+
+### Plan A4: DataFlow::PathGraph and path tracking
+**Files**: `bridge/compat_dataflow.qll`, `extract/rules/taint.go`
+**Goal**: Implement `DataFlow::PathNode` with actual source-to-sink paths (not just alerts). Support `edges(a, b)` predicate for path visualization.
+**Approach**: Implement TaintPath relation (deferred in Phase 1 due to needing arithmetic for step counting). Use bounded recursion with max depth.
+**Est**: ~150 LoC
+**Depends on**: A1
+
+---
+
+## Work Stream B: Framework Models (Critical)
+
+Blocks ~50+ queries. Each framework model is independent — maximally parallel.
+
+### Plan B1: Node.js HTTP module
+**Files**: `extract/rules/frameworks.go`
+**Goal**: Model `http.createServer()` handler detection, `req`/`res` sources and sinks.
+**Approach**: Add rules matching `CallCalleeSym` for `createServer` from `http`/`https` imports. Map callback parameters as sources/sinks like Express.
+**Est**: ~80 LoC
+**Depends on**: Nothing
+
+### Plan B2: Koa.js framework model
+**Files**: `extract/rules/frameworks.go`
+**Goal**: Model Koa middleware pattern (`ctx.request.body`, `ctx.body`, `ctx.query`), router handlers.
+**Approach**: Detect Koa `app.use()` middleware, map `ctx` parameter fields to TaintSource/TaintSink.
+**Est**: ~80 LoC
+**Depends on**: Nothing
+
+### Plan B3: Fastify framework model
+**Files**: `extract/rules/frameworks.go`
+**Goal**: Model Fastify route handlers (`request.body`, `request.query`, `reply.send()`).
+**Approach**: Detect `fastify.get/post/...()` patterns, map handler parameters.
+**Est**: ~70 LoC
+**Depends on**: Nothing
+
+### Plan B4: AWS Lambda handler model
+**Files**: `extract/rules/frameworks.go`
+**Goal**: Model Lambda handler `event` parameter as taint source.
+**Approach**: Detect `exports.handler = async (event, context)` pattern and common Lambda frameworks (Middy, SAM).
+**Est**: ~60 LoC
+**Depends on**: Nothing
+
+### Plan B5: Next.js API route model
+**Files**: `extract/rules/frameworks.go`
+**Goal**: Model Next.js API routes (`req.query`, `req.body`) and App Router handlers.
+**Approach**: Detect `export default function handler(req, res)` in `pages/api/` paths and App Router `GET/POST` exports.
+**Est**: ~70 LoC
+**Depends on**: Nothing
+
+### Plan B6: Database driver models (pg, mysql, mysql2, mongoose, sequelize)
+**Files**: `extract/rules/frameworks.go`
+**Goal**: Replace heuristic `.query()` matching with import-aware database sink detection.
+**Approach**: Track imports from `pg`, `mysql`, `mysql2`, `mongoose`, `sequelize`, `knex`. Map their query/exec methods to SQL sinks. Keep the heuristic `.query()` as fallback.
+**Est**: ~150 LoC
+**Depends on**: Nothing
+
+### Plan B7: Sanitizer library models
+**Files**: `extract/rules/frameworks.go`
+**Goal**: Model common sanitizer libraries (DOMPurify, xss, validator, escape-html, shell-escape, sqlstring).
+**Approach**: Track imports and map their sanitization functions to `Sanitizer(fn, kind)` facts by kind (xss, sql, command_injection).
+**Est**: ~120 LoC
+**Depends on**: Nothing
+
+---
+
+## Work Stream C: Extraction Completeness (High)
+
+Each extraction pattern is independent walker work.
+
+### Plan C1: Template literal extraction
+**Files**: `extract/walker.go`, `extract/schema/relations.go`
+**Goal**: Extract template literal parts and expressions. New relations: `TemplateLiteral(id, tag?)`, `TemplateElement(parentId, idx, rawText)`, `TemplateExpression(parentId, idx, exprId)`.
+**Approach**: Handle `TemplateLiteral` and `TaggedTemplateExpression` nodes in walker. Emit part/expression children.
+**Est**: ~100 LoC
+**Depends on**: Nothing
+
+### Plan C2: Enum declaration extraction
+**Files**: `extract/walker_v2.go`, `extract/schema/relations.go`
+**Goal**: New relations: `EnumDecl(id, name, file)`, `EnumMember(enumId, memberName, initExpr?)`.
+**Approach**: Handle `EnumDeclaration` and `EnumMember` nodes in v2 walker.
+**Est**: ~60 LoC
+**Depends on**: Nothing
+
+### Plan C3: Decorator extraction
+**Files**: `extract/walker_v2.go`, `extract/schema/relations.go`
+**Goal**: New relation: `Decorator(targetId, decoratorExpr)`.
+**Approach**: Handle `Decorator` nodes, link to their target declaration (class, method, property, parameter).
+**Est**: ~50 LoC
+**Depends on**: Nothing
+
+### Plan C4: Namespace/module declaration extraction
+**Files**: `extract/walker_v2.go`, `extract/schema/relations.go`
+**Goal**: New relations: `NamespaceDecl(id, name, file)`, `NamespaceMember(nsId, memberId)`.
+**Approach**: Handle `ModuleDeclaration`/`NamespaceDeclaration` nodes in tree-sitter TS grammar.
+**Est**: ~60 LoC
+**Depends on**: Nothing
+
+### Plan C5: Optional chaining and nullish coalescing flow
+**Files**: `extract/walker.go`, `extract/rules/local_flow.go`
+**Goal**: Model data flow through `?.` (short-circuit to undefined) and `??` (fallback).
+**Approach**: Extract `OptionalChain(expr, baseExpr)` and `NullishCoalescing(expr, lhs, rhs)`. Add local flow rules that propagate taint through both branches.
+**Est**: ~80 LoC
+**Depends on**: Nothing
+
+### Plan C6: TypeScript type guards and assertion functions
+**Files**: `extract/walker_v2.go`, `extract/schema/relations.go`
+**Goal**: New relation: `TypeGuard(fnId, paramIdx, narrowedType)` for `x is T` return types and `asserts x` patterns.
+**Approach**: Parse return type annotations in function declarations for `is` and `asserts` keywords.
+**Est**: ~70 LoC
+**Depends on**: Nothing
+
+---
+
+## Work Stream D: QL Language & Builtins (Medium)
+
+### Plan D1: Additional string/regex builtins
+**Files**: `ql/eval/builtins.go`
+**Goal**: Add `.regexpFind()`, `.regexpReplaceAll()`, `.splitAt()` (full), `.prefix()`, `.suffix()`.
+**Approach**: Implement as Go functions in the builtins dispatch table.
+**Est**: ~80 LoC
+**Depends on**: Nothing
+
+### Plan D2: `unique` aggregate
+**Files**: `ql/parse/parser.go`, `ql/ast/ast.go`, `ql/eval/aggregate.go`
+**Goal**: Support `unique(Type x | formula | result)` aggregate — returns the single value satisfying formula, or fails if 0 or 2+ values exist.
+**Approach**: Add to parser keyword list, AST node, and aggregate evaluator.
+**Est**: ~50 LoC
+**Depends on**: Nothing
+
+### Plan D3: Integer builtins
+**Files**: `ql/eval/builtins.go`
+**Goal**: Add `.abs()`, `.bitAnd()`, `.bitOr()`, `.bitXor()`, `.bitShiftLeft()`, `.bitShiftRight()`, `.toHexString()`.
+**Approach**: Direct Go implementations.
+**Est**: ~40 LoC
+**Depends on**: Nothing
+
+---
+
+## Work Stream E: CodeQL Standard Library Stubs (High)
+
+### Plan E1: HTTP abstraction layer
+**Files**: `bridge/compat_http.qll` (new)
+**Goal**: Implement `HTTP::ServerRequest`, `HTTP::ResponseBody`, `HTTP::HeaderDefinition`, `HTTP::CookieDefinition` as abstract classes that framework models contribute to.
+**Approach**: Create abstract bridge classes that Express, Koa, Fastify etc. extend. This decouples security queries from specific frameworks.
+**Est**: ~100 LoC
+**Depends on**: B1-B5 (framework models provide concrete implementations)
+
+### Plan E2: DOM class stubs
+**Files**: `bridge/compat_dom.qll` (new)
+**Goal**: Stub `DOM::Element`, `DOM::DocumentNode`, `DOM::InnerHtmlWrite`, `DOM::AttributeWrite` for DOM XSS queries.
+**Approach**: Map to JsxAttribute and FieldWrite patterns that target innerHTML, outerHTML, document.write.
+**Est**: ~80 LoC
+**Depends on**: Nothing
+
+### Plan E3: CryptographicOperation and sensitive data classes
+**Files**: `bridge/compat_crypto.qll` (new)
+**Goal**: Stub `CryptographicOperation`, `CleartextLogging`, `SensitiveDataExpr` for crypto/logging queries.
+**Approach**: Pattern-match on crypto library imports (crypto, bcrypt, argon2) and logging calls (console.log, winston, pino).
+**Est**: ~100 LoC
+**Depends on**: Nothing
+
+### Plan E4: DatabaseAccess and FileSystemAccess stubs
+**Files**: `bridge/compat_io.qll` (new)
+**Goal**: Abstract `DatabaseAccess`, `FileSystemAccess` classes.
+**Approach**: Map to existing SQL sink facts and add file system sink patterns (fs.readFile, fs.writeFile, path operations).
+**Est**: ~80 LoC
+**Depends on**: B6
+
+### Plan E5: RegExp class
+**Files**: `bridge/compat_regexp.qll` (new)
+**Goal**: Stub `RegExp::Term`, `RegExp::Quantifier`, `RegExp::Group` for regex analysis queries.
+**Approach**: Extract regex literals from AST, parse regex syntax into component terms.
+**Est**: ~150 LoC (regex parsing is inherently complex)
+**Depends on**: C1 (template literals may contain regex)
+
+---
+
+## Work Stream F: Rule 6b Cross-Product Fix (Critical, targeted)
+
+### Plan F1: Add ExprInFunction relation and fix Rule 6b
+**Files**: `extract/schema/relations.go`, `extract/walker_v2.go`, `extract/rules/taint.go`
+**Goal**: Fix the known cross-product false positive in Rule 6b by adding an `ExprInFunction` relation that scopes sink expressions to functions.
+**Approach**: 
+1. Register `ExprInFunction(exprId, fnId)` relation
+2. Emit it in walker for all expression nodes inside functions
+3. Constrain Rule 6b: `ExprInFunction(srcExpr, fn), ExprInFunction(sinkExpr, fn)` or use FlowStar linkage on the sink side
+**Est**: ~60 LoC
+**Depends on**: Nothing
+
+---
+
+## Parallel Execution Plan
+
+```
+Phase 2a (can all start immediately, fully parallel):
+  Stream B: B1, B2, B3, B4, B5, B6, B7  (7 independent framework models)
+  Stream C: C1, C2, C3, C4, C5, C6       (6 independent extraction patterns)
+  Stream D: D1, D2, D3                    (3 independent language features)
+  Plan A1                                  (DataFlow predicates)
+  Plan F1                                  (Rule 6b fix)
+  Plan E2                                  (DOM stubs)
+  Plan E3                                  (Crypto stubs)
+
+Phase 2b (depends on 2a completions):
+  Plan A2  (depends on A1)
+  Plan E1  (depends on B1-B5)
+  Plan E4  (depends on B6)
+  Plan E5  (depends on C1)
+
+Phase 2c (depends on 2b):
+  Plan A3  (depends on A2)
+  Plan A4  (depends on A1)
+
+Total: 25 plans
+  Phase 2a: 20 plans (fully parallel)
+  Phase 2b: 4 plans
+  Phase 2c: 2 plans
+```
+
+## Priority Order (if serializing)
+
+1. **F1** — Rule 6b fix (correctness bug, 60 LoC)
+2. **A1** — DataFlow::Node predicates (unlocks A2-A4)
+3. **A2** — Configuration override support (unlocks custom queries)
+4. **B6** — Database driver models (highest-value framework gap)
+5. **B7** — Sanitizer library models (precision improvement)
+6. **B1** — Node.js HTTP module
+7. **B4** — AWS Lambda (common in production)
+8. **B5** — Next.js API routes (common in modern apps)
+9. **C1** — Template literals (blocks string analysis)
+10. **E1** — HTTP abstraction layer
+11. **A3** — Additional taint steps
+12. **B2, B3** — Koa, Fastify
+13. **C2-C6** — Remaining extraction patterns
+14. **D1-D3** — Language features
+15. **E2-E5** — Remaining stdlib stubs
+16. **A4** — Path tracking (nice-to-have)
+
+## Estimated Total Effort
+
+~3100 LoC across 25 plans. With parallel execution, the critical path is:
+A1 (120) -> A2 (200) -> A3 (100) = 420 LoC serial dependency.
+Everything else can execute in parallel around that chain.

--- a/extract/kinds.go
+++ b/extract/kinds.go
@@ -25,3 +25,52 @@ func init() {
 func IsFunctionKind(kind string) bool {
 	return functionKindSet[kind]
 }
+
+// ExpressionKinds lists tree-sitter node kinds that represent expressions.
+// Used to emit ExprInFunction for taint analysis scope constraints.
+var ExpressionKinds = []string{
+	"Identifier",
+	"MemberExpression",
+	"CallExpression",
+	"NewExpression",
+	"BinaryExpression",
+	"UnaryExpression",
+	"AssignmentExpression",
+	"ConditionalExpression",
+	"TemplateString",
+	"TaggedTemplateExpression",
+	"AwaitExpression",
+	"YieldExpression",
+	"ArrowFunction",
+	"FunctionExpression",
+	"ParenthesizedExpression",
+	"ArrayExpression",
+	"ObjectExpression",
+	"SpreadElement",
+	"AsExpression",
+	"NonNullExpression",
+	"SubscriptExpression",
+	"String",
+	"Number",
+	"True",
+	"False",
+	"Null",
+	"Undefined",
+	"UpdateExpression",
+	"SequenceExpression",
+	"CommaExpression",
+}
+
+var expressionKindSet map[string]bool
+
+func init() {
+	expressionKindSet = make(map[string]bool, len(ExpressionKinds))
+	for _, k := range ExpressionKinds {
+		expressionKindSet[k] = true
+	}
+}
+
+// isExpressionKind returns true if kind is an expression node kind.
+func isExpressionKind(kind string) bool {
+	return expressionKindSet[kind]
+}

--- a/extract/rules/frameworks.go
+++ b/extract/rules/frameworks.go
@@ -7,111 +7,80 @@ import (
 // s returns a StringConst term.
 func s(val string) datalog.StringConst { return datalog.StringConst{Value: val} }
 
+// intc returns an IntConst term (shorthand for datalog.IntConst{Value: n}).
+func intc(n int64) datalog.IntConst { return datalog.IntConst{Value: n} }
+
 // FrameworkRules returns the system Datalog rules for framework-specific
 // taint source/sink identification (Phase F). These are pattern-based
 // heuristics that match on function names and method names to populate
-// TaintSource, TaintSink, and ExpressHandler relations.
+// TaintSource, TaintSink, Sanitizer, and handler relations.
 func FrameworkRules() []datalog.Rule {
-	return []datalog.Rule{
-		// ─── Express handler detection ───────────────────────────────────
-		// ExpressHandler(fn) :-
-		//   MethodCall(call, recv, "get"), CallArg(call, _, cbExpr),
-		//   ExprMayRef(cbExpr, cbSym), FunctionSymbol(cbSym, fn).
-		// (Also for "post", "put", "delete", "use", "patch")
-		expressHandlerRule("get"),
-		expressHandlerRule("post"),
-		expressHandlerRule("put"),
-		expressHandlerRule("delete"),
-		expressHandlerRule("use"),
-		expressHandlerRule("patch"),
+	var rules []datalog.Rule
 
-		// ─── Express sources: req.query ──────────────────────────────────
-		// TaintSource(callExpr, "http_input") :-
-		//   MethodCall(call, recv, "query"), ExprMayRef(recv, reqSym),
-		//   Parameter(fn, 0, "req", _, reqSym, _), ExpressHandler(fn),
-		//   ExprMayRef(call, callExpr).
-		// Note: MethodCall here represents property access like req.query.
-		// Since we match on FieldRead instead (req.query is a field read, not method call):
-		// TaintSource(expr, "http_input") :-
-		//   FieldRead(expr, reqSym, "query"),
-		//   Parameter(fn, 0, _, _, reqSym, _), ExpressHandler(fn).
-		rule("TaintSource",
-			[]datalog.Term{v("expr"), s("http_input")},
-			pos("FieldRead", v("expr"), v("reqSym"), s("query")),
-			pos("Parameter", v("fn"), datalog.IntConst{Value: 0}, w(), w(), v("reqSym"), w()),
-			pos("ExpressHandler", v("fn")),
-		),
+	rules = append(rules, expressRules()...)
+	rules = append(rules, httpHandlerRules()...)
+	rules = append(rules, koaRules()...)
+	rules = append(rules, fastifyRules()...)
+	rules = append(rules, lambdaRules()...)
+	rules = append(rules, nextjsRules()...)
+	rules = append(rules, databaseRules()...)
+	rules = append(rules, sanitizerRules()...)
 
-		// TaintSource(expr, "http_input") :- FieldRead(expr, reqSym, "params"), ...
-		rule("TaintSource",
-			[]datalog.Term{v("expr"), s("http_input")},
-			pos("FieldRead", v("expr"), v("reqSym"), s("params")),
-			pos("Parameter", v("fn"), datalog.IntConst{Value: 0}, w(), w(), v("reqSym"), w()),
-			pos("ExpressHandler", v("fn")),
-		),
+	// ─── Node.js sinks: child_process.exec ──────────────────────────
+	rules = append(rules, rule("TaintSink",
+		[]datalog.Term{v("argExpr"), s("command_injection")},
+		pos("CallCalleeSym", v("call"), v("execSym")),
+		pos("FunctionSymbol", v("execSym"), v("execFn")),
+		pos("Function", v("execFn"), s("exec"), w(), w(), w(), w()),
+		pos("CallArg", v("call"), intc(0), v("argExpr")),
+	))
 
-		// TaintSource(expr, "http_input") :- FieldRead(expr, reqSym, "body"), ...
-		rule("TaintSource",
-			[]datalog.Term{v("expr"), s("http_input")},
-			pos("FieldRead", v("expr"), v("reqSym"), s("body")),
-			pos("Parameter", v("fn"), datalog.IntConst{Value: 0}, w(), w(), v("reqSym"), w()),
-			pos("ExpressHandler", v("fn")),
-		),
+	// ─── React XSS: dangerouslySetInnerHTML ─────────────────────────
+	rules = append(rules, rule("TaintSink",
+		[]datalog.Term{v("valueExpr"), s("xss")},
+		pos("JsxAttribute", w(), s("dangerouslySetInnerHTML"), v("valueExpr")),
+	))
 
-		// ─── Express sinks: res.send ─────────────────────────────────────
-		// TaintSink(argExpr, "xss") :-
-		//   MethodCall(call, recv, "send"), ExprMayRef(recv, resSym),
-		//   Parameter(fn, 1, _, _, resSym, _), ExpressHandler(fn),
-		//   CallArg(call, 0, argExpr).
-		rule("TaintSink",
-			[]datalog.Term{v("argExpr"), s("xss")},
-			pos("MethodCall", v("call"), v("recv"), s("send")),
-			pos("ExprMayRef", v("recv"), v("resSym")),
-			pos("Parameter", v("fn"), datalog.IntConst{Value: 1}, w(), w(), v("resSym"), w()),
-			pos("ExpressHandler", v("fn")),
-			pos("CallArg", v("call"), datalog.IntConst{Value: 0}, v("argExpr")),
-		),
+	// ─── SQL sinks: *.query() (heuristic fallback) ──────────────────
+	rules = append(rules, rule("TaintSink",
+		[]datalog.Term{v("argExpr"), s("sql")},
+		pos("MethodCall", v("call"), w(), s("query")),
+		pos("CallArg", v("call"), intc(0), v("argExpr")),
+	))
 
-		// ─── Node.js sinks: child_process.exec ──────────────────────────
-		// TaintSink(argExpr, "command_injection") :-
-		//   CallCalleeSym(call, execSym), FunctionSymbol(execSym, execFn),
-		//   Function(execFn, "exec", _, _, _, _), CallArg(call, 0, argExpr).
-		rule("TaintSink",
-			[]datalog.Term{v("argExpr"), s("command_injection")},
-			pos("CallCalleeSym", v("call"), v("execSym")),
-			pos("FunctionSymbol", v("execSym"), v("execFn")),
-			pos("Function", v("execFn"), s("exec"), w(), w(), w(), w()),
-			pos("CallArg", v("call"), datalog.IntConst{Value: 0}, v("argExpr")),
-		),
-
-		// ─── React XSS: dangerouslySetInnerHTML ─────────────────────────
-		// TaintSink(valueExpr, "xss") :-
-		//   JsxAttribute(elem, "dangerouslySetInnerHTML", valueExpr).
-		rule("TaintSink",
-			[]datalog.Term{v("valueExpr"), s("xss")},
-			pos("JsxAttribute", w(), s("dangerouslySetInnerHTML"), v("valueExpr")),
-		),
-
-		// ─── SQL sinks: *.query() ───────────────────────────────────────
-		// Heuristic: any .query() call is treated as a SQL sink. This matches
-		// db.query(), pool.query(), connection.query(), etc. Known false-positive
-		// risk for non-DB .query() methods (URLSearchParams, jQuery, etc.).
-		// Future: constrain receiver to known DB client types or import sources.
-		// TaintSink(argExpr, "sql") :-
-		//   MethodCall(call, _, "query"), CallArg(call, 0, argExpr).
-		rule("TaintSink",
-			[]datalog.Term{v("argExpr"), s("sql")},
-			pos("MethodCall", v("call"), w(), s("query")),
-			pos("CallArg", v("call"), datalog.IntConst{Value: 0}, v("argExpr")),
-		),
-	}
+	return rules
 }
 
-// expressHandlerRule generates:
-//
-//	ExpressHandler(fn) :-
-//	  MethodCall(call, _, methodName), CallArg(call, _, cbExpr),
-//	  ExprMayRef(cbExpr, cbSym), FunctionSymbol(cbSym, fn).
+// ─── Express (existing) ─────────────────────────────────────────────────────
+
+func expressRules() []datalog.Rule {
+	var rules []datalog.Rule
+
+	for _, method := range []string{"get", "post", "put", "delete", "use", "patch"} {
+		rules = append(rules, expressHandlerRule(method))
+	}
+
+	for _, field := range []string{"query", "params", "body"} {
+		rules = append(rules, rule("TaintSource",
+			[]datalog.Term{v("expr"), s("http_input")},
+			pos("FieldRead", v("expr"), v("reqSym"), s(field)),
+			pos("Parameter", v("fn"), intc(0), w(), w(), v("reqSym"), w()),
+			pos("ExpressHandler", v("fn")),
+		))
+	}
+
+	rules = append(rules, rule("TaintSink",
+		[]datalog.Term{v("argExpr"), s("xss")},
+		pos("MethodCall", v("call"), v("recv"), s("send")),
+		pos("ExprMayRef", v("recv"), v("resSym")),
+		pos("Parameter", v("fn"), intc(1), w(), w(), v("resSym"), w()),
+		pos("ExpressHandler", v("fn")),
+		pos("CallArg", v("call"), intc(0), v("argExpr")),
+	))
+
+	return rules
+}
+
 func expressHandlerRule(methodName string) datalog.Rule {
 	return rule("ExpressHandler",
 		[]datalog.Term{v("fn")},
@@ -120,4 +89,272 @@ func expressHandlerRule(methodName string) datalog.Rule {
 		pos("ExprMayRef", v("cbExpr"), v("cbSym")),
 		pos("FunctionSymbol", v("cbSym"), v("fn")),
 	)
+}
+
+// ─── B1: Node.js HTTP module ────────────────────────────────────────────────
+
+func httpHandlerRules() []datalog.Rule {
+	var rules []datalog.Rule
+
+	for _, mod := range []string{"http", "https"} {
+		rules = append(rules, rule("HttpHandler",
+			[]datalog.Term{v("fn")},
+			pos("CallCalleeSym", v("call"), v("calleeSym")),
+			pos("ImportBinding", v("calleeSym"), s(mod), s("createServer")),
+			pos("CallArg", v("call"), w(), v("cbExpr")),
+			pos("ExprMayRef", v("cbExpr"), v("cbSym")),
+			pos("FunctionSymbol", v("cbSym"), v("fn")),
+		))
+	}
+
+	for _, field := range []string{"url", "headers", "method"} {
+		rules = append(rules, rule("TaintSource",
+			[]datalog.Term{v("expr"), s("http_input")},
+			pos("FieldRead", v("expr"), v("reqSym"), s(field)),
+			pos("Parameter", v("fn"), intc(0), w(), w(), v("reqSym"), w()),
+			pos("HttpHandler", v("fn")),
+		))
+	}
+
+	for _, method := range []string{"write", "end"} {
+		rules = append(rules, rule("TaintSink",
+			[]datalog.Term{v("argExpr"), s("xss")},
+			pos("MethodCall", v("call"), v("recv"), s(method)),
+			pos("ExprMayRef", v("recv"), v("resSym")),
+			pos("Parameter", v("fn"), intc(1), w(), w(), v("resSym"), w()),
+			pos("HttpHandler", v("fn")),
+			pos("CallArg", v("call"), intc(0), v("argExpr")),
+		))
+	}
+
+	return rules
+}
+
+// ─── B2: Koa.js ─────────────────────────────────────────────────────────────
+
+func koaRules() []datalog.Rule {
+	var rules []datalog.Rule
+
+	rules = append(rules, rule("KoaHandler",
+		[]datalog.Term{v("fn")},
+		pos("MethodCall", v("call"), w(), s("use")),
+		pos("CallArg", v("call"), w(), v("cbExpr")),
+		pos("ExprMayRef", v("cbExpr"), v("cbSym")),
+		pos("FunctionSymbol", v("cbSym"), v("fn")),
+	))
+
+	rules = append(rules, rule("TaintSource",
+		[]datalog.Term{v("expr"), s("http_input")},
+		pos("FieldRead", v("expr"), v("ctxSym"), s("query")),
+		pos("Parameter", v("fn"), intc(0), w(), w(), v("ctxSym"), w()),
+		pos("KoaHandler", v("fn")),
+	))
+
+	for _, field := range []string{"body", "query"} {
+		rules = append(rules, rule("TaintSource",
+			[]datalog.Term{v("expr"), s("http_input")},
+			pos("FieldRead", v("reqExpr"), v("ctxSym"), s("request")),
+			pos("FieldRead", v("expr"), v("reqExpr"), s(field)),
+			pos("Parameter", v("fn"), intc(0), w(), w(), v("ctxSym"), w()),
+			pos("KoaHandler", v("fn")),
+		))
+	}
+
+	rules = append(rules, rule("TaintSink",
+		[]datalog.Term{v("rhsExpr"), s("xss")},
+		pos("FieldWrite", w(), v("ctxSym"), s("body"), v("rhsExpr")),
+		pos("Parameter", v("fn"), intc(0), w(), w(), v("ctxSym"), w()),
+		pos("KoaHandler", v("fn")),
+	))
+
+	return rules
+}
+
+// ─── B3: Fastify ────────────────────────────────────────────────────────────
+
+func fastifyRules() []datalog.Rule {
+	var rules []datalog.Rule
+
+	for _, method := range []string{"get", "post", "put", "delete", "patch", "head", "options"} {
+		rules = append(rules, rule("FastifyHandler",
+			[]datalog.Term{v("fn")},
+			pos("MethodCall", v("call"), w(), s(method)),
+			pos("CallArg", v("call"), w(), v("cbExpr")),
+			pos("ExprMayRef", v("cbExpr"), v("cbSym")),
+			pos("FunctionSymbol", v("cbSym"), v("fn")),
+		))
+	}
+
+	for _, field := range []string{"body", "query", "params"} {
+		rules = append(rules, rule("TaintSource",
+			[]datalog.Term{v("expr"), s("http_input")},
+			pos("FieldRead", v("expr"), v("reqSym"), s(field)),
+			pos("Parameter", v("fn"), intc(0), w(), w(), v("reqSym"), w()),
+			pos("FastifyHandler", v("fn")),
+		))
+	}
+
+	rules = append(rules, rule("TaintSink",
+		[]datalog.Term{v("argExpr"), s("xss")},
+		pos("MethodCall", v("call"), v("recv"), s("send")),
+		pos("ExprMayRef", v("recv"), v("replySym")),
+		pos("Parameter", v("fn"), intc(1), w(), w(), v("replySym"), w()),
+		pos("FastifyHandler", v("fn")),
+		pos("CallArg", v("call"), intc(0), v("argExpr")),
+	))
+
+	return rules
+}
+
+// ─── B4: AWS Lambda ─────────────────────────────────────────────────────────
+
+func lambdaRules() []datalog.Rule {
+	var rules []datalog.Rule
+
+	rules = append(rules, rule("LambdaHandler",
+		[]datalog.Term{v("fn")},
+		pos("ExportBinding", s("handler"), v("localSym"), w()),
+		pos("FunctionSymbol", v("localSym"), v("fn")),
+	))
+
+	rules = append(rules, rule("TaintSource",
+		[]datalog.Term{v("expr"), s("http_input")},
+		pos("FieldRead", v("expr"), v("eventSym"), w()),
+		pos("Parameter", v("fn"), intc(0), w(), w(), v("eventSym"), w()),
+		pos("LambdaHandler", v("fn")),
+	))
+
+	return rules
+}
+
+// ─── B5: Next.js API routes ─────────────────────────────────────────────────
+
+func nextjsRules() []datalog.Rule {
+	var rules []datalog.Rule
+
+	rules = append(rules, rule("NextjsHandler",
+		[]datalog.Term{v("fn")},
+		pos("ExportBinding", s("default"), v("localSym"), w()),
+		pos("FunctionSymbol", v("localSym"), v("fn")),
+	))
+
+	for _, field := range []string{"query", "body"} {
+		rules = append(rules, rule("TaintSource",
+			[]datalog.Term{v("expr"), s("http_input")},
+			pos("FieldRead", v("expr"), v("reqSym"), s(field)),
+			pos("Parameter", v("fn"), intc(0), w(), w(), v("reqSym"), w()),
+			pos("NextjsHandler", v("fn")),
+		))
+	}
+
+	for _, method := range []string{"send", "json"} {
+		rules = append(rules, rule("TaintSink",
+			[]datalog.Term{v("argExpr"), s("xss")},
+			pos("MethodCall", v("call"), v("recv"), s(method)),
+			pos("ExprMayRef", v("recv"), v("resSym")),
+			pos("Parameter", v("fn"), intc(1), w(), w(), v("resSym"), w()),
+			pos("NextjsHandler", v("fn")),
+			pos("CallArg", v("call"), intc(0), v("argExpr")),
+		))
+	}
+
+	return rules
+}
+
+// ─── B6: Database drivers ───────────────────────────────────────────────────
+
+func databaseRules() []datalog.Rule {
+	var rules []datalog.Rule
+
+	for _, mod := range []string{"pg", "mysql", "mysql2", "better-sqlite3"} {
+		for _, method := range []string{"query", "execute"} {
+			rules = append(rules, rule("TaintSink",
+				[]datalog.Term{v("argExpr"), s("sql")},
+				pos("ImportBinding", v("dbSym"), s(mod), w()),
+				pos("MethodCall", v("call"), v("recv"), s(method)),
+				pos("ExprMayRef", v("recv"), v("dbSym")),
+				pos("CallArg", v("call"), intc(0), v("argExpr")),
+			))
+		}
+	}
+
+	for _, method := range []string{"find", "findOne", "aggregate"} {
+		rules = append(rules, rule("TaintSink",
+			[]datalog.Term{v("argExpr"), s("sql")},
+			pos("ImportBinding", v("dbSym"), s("mongoose"), w()),
+			pos("MethodCall", v("call"), v("recv"), s(method)),
+			pos("ExprMayRef", v("recv"), v("dbSym")),
+			pos("CallArg", v("call"), intc(0), v("argExpr")),
+		))
+	}
+
+	rules = append(rules, rule("TaintSink",
+		[]datalog.Term{v("argExpr"), s("sql")},
+		pos("ImportBinding", v("dbSym"), s("sequelize"), w()),
+		pos("MethodCall", v("call"), v("recv"), s("query")),
+		pos("ExprMayRef", v("recv"), v("dbSym")),
+		pos("CallArg", v("call"), intc(0), v("argExpr")),
+	))
+
+	return rules
+}
+
+// ─── B7: Sanitizer libraries ────────────────────────────────────────────────
+
+func sanitizerRules() []datalog.Rule {
+	var rules []datalog.Rule
+
+	xssSanitizers := []struct {
+		module string
+		name   string
+	}{
+		{"dompurify", "sanitize"},
+		{"xss", "default"},
+		{"escape-html", "default"},
+		{"he", "encode"},
+		{"he", "escape"},
+		{"sanitize-html", "default"},
+	}
+
+	for _, san := range xssSanitizers {
+		rules = append(rules, rule("Sanitizer",
+			[]datalog.Term{v("fn"), s("xss")},
+			pos("ImportBinding", v("localSym"), s(san.module), s(san.name)),
+			pos("FunctionSymbol", v("localSym"), v("fn")),
+		))
+	}
+
+	sqlSanitizers := []struct {
+		module string
+		name   string
+	}{
+		{"sqlstring", "escape"},
+		{"sqlstring", "format"},
+	}
+
+	for _, san := range sqlSanitizers {
+		rules = append(rules, rule("Sanitizer",
+			[]datalog.Term{v("fn"), s("sql")},
+			pos("ImportBinding", v("localSym"), s(san.module), s(san.name)),
+			pos("FunctionSymbol", v("localSym"), v("fn")),
+		))
+	}
+
+	cmdSanitizers := []struct {
+		module string
+		name   string
+	}{
+		{"shell-escape", "default"},
+		{"shell-quote", "quote"},
+	}
+
+	for _, san := range cmdSanitizers {
+		rules = append(rules, rule("Sanitizer",
+			[]datalog.Term{v("fn"), s("command_injection")},
+			pos("ImportBinding", v("localSym"), s(san.module), s(san.name)),
+			pos("FunctionSymbol", v("localSym"), v("fn")),
+		))
+	}
+
+	return rules
 }

--- a/extract/rules/frameworks.go
+++ b/extract/rules/frameworks.go
@@ -150,11 +150,15 @@ func koaRules() []datalog.Rule {
 		pos("KoaHandler", v("fn")),
 	))
 
+	// ctx.request.body / ctx.request.query — chain through ExprMayRef to
+	// bridge from FieldRead's expr (AST node ID) to the next FieldRead's
+	// baseSym (symbol ID).
 	for _, field := range []string{"body", "query"} {
 		rules = append(rules, rule("TaintSource",
 			[]datalog.Term{v("expr"), s("http_input")},
 			pos("FieldRead", v("reqExpr"), v("ctxSym"), s("request")),
-			pos("FieldRead", v("expr"), v("reqExpr"), s(field)),
+			pos("ExprMayRef", v("reqExpr"), v("reqSym")),
+			pos("FieldRead", v("expr"), v("reqSym"), s(field)),
 			pos("Parameter", v("fn"), intc(0), w(), w(), v("ctxSym"), w()),
 			pos("KoaHandler", v("fn")),
 		))
@@ -278,12 +282,14 @@ func databaseRules() []datalog.Rule {
 		}
 	}
 
+	// Mongoose: .find()/.findOne()/.aggregate() are NoSQL query methods.
+	// We use a heuristic: any .find/.findOne/.aggregate call is a potential
+	// NoSQL injection sink. This is similar to the .query() heuristic for SQL.
+	// We can't easily constrain to mongoose models without type resolution.
 	for _, method := range []string{"find", "findOne", "aggregate"} {
 		rules = append(rules, rule("TaintSink",
-			[]datalog.Term{v("argExpr"), s("sql")},
-			pos("ImportBinding", v("dbSym"), s("mongoose"), w()),
-			pos("MethodCall", v("call"), v("recv"), s(method)),
-			pos("ExprMayRef", v("recv"), v("dbSym")),
+			[]datalog.Term{v("argExpr"), s("nosql")},
+			pos("MethodCall", v("call"), w(), s(method)),
 			pos("CallArg", v("call"), intc(0), v("argExpr")),
 		))
 	}

--- a/extract/rules/frameworks_test.go
+++ b/extract/rules/frameworks_test.go
@@ -14,9 +14,12 @@ func frameworkBaseRels(overrides map[string]*eval.Relation) map[string]*eval.Rel
 	base := taintBaseRels(nil)
 	// Add framework-specific base relations
 	base["FieldRead"] = eval.NewRelation("FieldRead", 3)
+	base["FieldWrite"] = eval.NewRelation("FieldWrite", 4)
 	base["Function"] = eval.NewRelation("Function", 6)
 	base["JsxElement"] = eval.NewRelation("JsxElement", 3)
 	base["JsxAttribute"] = eval.NewRelation("JsxAttribute", 3)
+	base["ImportBinding"] = eval.NewRelation("ImportBinding", 3)
+	base["ExportBinding"] = eval.NewRelation("ExportBinding", 3)
 	for k, v := range overrides {
 		base[k] = v
 	}
@@ -161,5 +164,288 @@ func TestFrameworkRulesStratify(t *testing.T) {
 	_, errs := plan.Plan(prog, nil)
 	if len(errs) > 0 {
 		t.Fatalf("all system rules (including frameworks) failed to plan: %v", errs)
+	}
+}
+
+// TestFrameworkRuleCount verifies the expected number of framework rules.
+func TestFrameworkRuleCount(t *testing.T) {
+	rules := FrameworkRules()
+	// Count breakdown:
+	// Express: 6 handler + 3 source + 1 sink = 10
+	// Node.js sinks: exec=1, dangerouslySetInnerHTML=1, heuristic .query()=1 = 3
+	// HTTP: 2 handler + 3 source + 2 sink = 7
+	// Koa: 1 handler + 1 ctx.query + 2 ctx.request.{body,query} + 1 sink = 5
+	// Fastify: 7 handler + 3 source + 1 sink = 11
+	// Lambda: 1 handler + 1 source = 2
+	// Next.js: 1 handler + 2 source + 2 sink = 5
+	// Database: 4 mods × 2 methods = 8, mongoose 3, sequelize 1 = 12
+	// Sanitizers: XSS 6 + SQL 2 + CMD 2 = 10
+	// Total: 10 + 3 + 7 + 5 + 11 + 2 + 5 + 12 + 10 = 65
+	expected := 65
+	if len(rules) != expected {
+		t.Errorf("expected %d framework rules, got %d", expected, len(rules))
+	}
+}
+
+// ─── B1: Node HTTP handler tests ─────────────────────────────────────────
+
+func TestHttpHandler_CreateServer(t *testing.T) {
+	// http.createServer(callback)
+	// ImportBinding(calleeSym=50, "http", "createServer"),
+	// CallCalleeSym(call=500, calleeSym=50),
+	// CallArg(500, 0, cbExpr=600), ExprMayRef(600, cbSym=60), FunctionSymbol(60, fn=7).
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		"ImportBinding":  makeRel("ImportBinding", 3, iv(50), sv("http"), sv("createServer")),
+		"CallCalleeSym":  makeRel("CallCalleeSym", 2, iv(500), iv(50)),
+		"CallArg":        makeRel("CallArg", 3, iv(500), iv(0), iv(600)),
+		"ExprMayRef":     makeRel("ExprMayRef", 2, iv(600), iv(60)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(60), iv(7)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn")},
+		Body:   []datalog.Literal{pos("HttpHandler", v("fn"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(7)) {
+		t.Errorf("expected HttpHandler(7), got %v", rs.Rows)
+	}
+}
+
+func TestHttpSource_ReqUrl(t *testing.T) {
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		"ImportBinding":  makeRel("ImportBinding", 3, iv(50), sv("http"), sv("createServer")),
+		"CallCalleeSym":  makeRel("CallCalleeSym", 2, iv(500), iv(50)),
+		"CallArg":        makeRel("CallArg", 3, iv(500), iv(0), iv(600)),
+		"ExprMayRef":     makeRel("ExprMayRef", 2, iv(600), iv(60)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(60), iv(7)),
+		"Parameter":      makeRel("Parameter", 6, iv(7), iv(0), sv("req"), iv(80), iv(10), sv("")),
+		"FieldRead":      makeRel("FieldRead", 3, iv(100), iv(10), sv("url")),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("expr"), v("kind")},
+		Body:   []datalog.Literal{pos("TaintSource", v("expr"), v("kind"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(100), sv("http_input")) {
+		t.Errorf("expected TaintSource(100, http_input) from req.url, got %v", rs.Rows)
+	}
+}
+
+// ─── B2: Koa tests ──────────────────────────────────────────────────────
+
+func TestKoaSource_CtxQuery(t *testing.T) {
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		"MethodCall":     makeRel("MethodCall", 3, iv(500), iv(400), sv("use")),
+		"CallArg":        makeRel("CallArg", 3, iv(500), iv(0), iv(600)),
+		"ExprMayRef":     makeRel("ExprMayRef", 2, iv(600), iv(60)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(60), iv(7)),
+		"Parameter":      makeRel("Parameter", 6, iv(7), iv(0), sv("ctx"), iv(80), iv(10), sv("")),
+		"FieldRead":      makeRel("FieldRead", 3, iv(100), iv(10), sv("query")),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("expr"), v("kind")},
+		Body:   []datalog.Literal{pos("TaintSource", v("expr"), v("kind"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(100), sv("http_input")) {
+		t.Errorf("expected TaintSource(100, http_input) from ctx.query, got %v", rs.Rows)
+	}
+}
+
+func TestKoaSink_CtxBodyAssign(t *testing.T) {
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		"MethodCall":     makeRel("MethodCall", 3, iv(500), iv(400), sv("use")),
+		"CallArg":        makeRel("CallArg", 3, iv(500), iv(0), iv(600)),
+		"ExprMayRef":     makeRel("ExprMayRef", 2, iv(600), iv(60)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(60), iv(7)),
+		"Parameter":      makeRel("Parameter", 6, iv(7), iv(0), sv("ctx"), iv(80), iv(10), sv("")),
+		"FieldWrite":     makeRel("FieldWrite", 4, iv(200), iv(10), sv("body"), iv(300)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("expr"), v("kind")},
+		Body:   []datalog.Literal{pos("TaintSink", v("expr"), v("kind"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(300), sv("xss")) {
+		t.Errorf("expected TaintSink(300, xss) from ctx.body assignment, got %v", rs.Rows)
+	}
+}
+
+// ─── B3: Fastify tests ─────────────────────────────────────────────────
+
+func TestFastifyHandler_Post(t *testing.T) {
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		"MethodCall":     makeRel("MethodCall", 3, iv(500), iv(400), sv("post")),
+		"CallArg":        makeRel("CallArg", 3, iv(500), iv(1), iv(600)),
+		"ExprMayRef":     makeRel("ExprMayRef", 2, iv(600), iv(60)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(60), iv(7)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn")},
+		Body:   []datalog.Literal{pos("FastifyHandler", v("fn"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(7)) {
+		t.Errorf("expected FastifyHandler(7), got %v", rs.Rows)
+	}
+}
+
+// ─── B4: Lambda tests ──────────────────────────────────────────────────
+
+func TestLambdaHandler_ExportHandler(t *testing.T) {
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		"ExportBinding":  makeRel("ExportBinding", 3, sv("handler"), iv(50), iv(1)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(50), iv(7)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn")},
+		Body:   []datalog.Literal{pos("LambdaHandler", v("fn"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(7)) {
+		t.Errorf("expected LambdaHandler(7), got %v", rs.Rows)
+	}
+}
+
+func TestLambdaSource_EventField(t *testing.T) {
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		"ExportBinding":  makeRel("ExportBinding", 3, sv("handler"), iv(50), iv(1)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(50), iv(7)),
+		"Parameter":      makeRel("Parameter", 6, iv(7), iv(0), sv("event"), iv(80), iv(10), sv("")),
+		"FieldRead":      makeRel("FieldRead", 3, iv(100), iv(10), sv("body")),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("expr"), v("kind")},
+		Body:   []datalog.Literal{pos("TaintSource", v("expr"), v("kind"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(100), sv("http_input")) {
+		t.Errorf("expected TaintSource(100, http_input) from event field, got %v", rs.Rows)
+	}
+}
+
+// ─── B5: Next.js tests ─────────────────────────────────────────────────
+
+func TestNextjsHandler_DefaultExport(t *testing.T) {
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		"ExportBinding":  makeRel("ExportBinding", 3, sv("default"), iv(50), iv(1)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(50), iv(7)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn")},
+		Body:   []datalog.Literal{pos("NextjsHandler", v("fn"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(7)) {
+		t.Errorf("expected NextjsHandler(7), got %v", rs.Rows)
+	}
+}
+
+// ─── B6: Database driver tests ──────────────────────────────────────────
+
+func TestDatabaseSink_PgQuery(t *testing.T) {
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		"ImportBinding": makeRel("ImportBinding", 3, iv(50), sv("pg"), sv("default")),
+		"MethodCall":    makeRel("MethodCall", 3, iv(500), iv(400), sv("query")),
+		"ExprMayRef":    makeRel("ExprMayRef", 2, iv(400), iv(50)),
+		"CallArg":       makeRel("CallArg", 3, iv(500), iv(0), iv(800)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("expr"), v("kind")},
+		Body:   []datalog.Literal{pos("TaintSink", v("expr"), v("kind"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(800), sv("sql")) {
+		t.Errorf("expected TaintSink(800, sql) from pg .query(), got %v", rs.Rows)
+	}
+}
+
+func TestDatabaseSink_MongooseFind(t *testing.T) {
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		"ImportBinding": makeRel("ImportBinding", 3, iv(50), sv("mongoose"), sv("default")),
+		"MethodCall":    makeRel("MethodCall", 3, iv(500), iv(400), sv("find")),
+		"ExprMayRef":    makeRel("ExprMayRef", 2, iv(400), iv(50)),
+		"CallArg":       makeRel("CallArg", 3, iv(500), iv(0), iv(800)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("expr"), v("kind")},
+		Body:   []datalog.Literal{pos("TaintSink", v("expr"), v("kind"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(800), sv("sql")) {
+		t.Errorf("expected TaintSink(800, sql) from mongoose .find(), got %v", rs.Rows)
+	}
+}
+
+// ─── B7: Sanitizer tests ───────────────────────────────────────────────
+
+func TestSanitizer_DomPurify(t *testing.T) {
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		"ImportBinding":  makeRel("ImportBinding", 3, iv(50), sv("dompurify"), sv("sanitize")),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(50), iv(7)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("kind")},
+		Body:   []datalog.Literal{pos("Sanitizer", v("fn"), v("kind"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(7), sv("xss")) {
+		t.Errorf("expected Sanitizer(7, xss) from dompurify, got %v", rs.Rows)
+	}
+}
+
+func TestSanitizer_SqlString(t *testing.T) {
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		"ImportBinding":  makeRel("ImportBinding", 3, iv(50), sv("sqlstring"), sv("escape")),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(50), iv(7)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("kind")},
+		Body:   []datalog.Literal{pos("Sanitizer", v("fn"), v("kind"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(7), sv("sql")) {
+		t.Errorf("expected Sanitizer(7, sql) from sqlstring, got %v", rs.Rows)
+	}
+}
+
+func TestSanitizer_ShellQuote(t *testing.T) {
+	baseRels := frameworkBaseRels(map[string]*eval.Relation{
+		"ImportBinding":  makeRel("ImportBinding", 3, iv(50), sv("shell-quote"), sv("quote")),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(50), iv(7)),
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("fn"), v("kind")},
+		Body:   []datalog.Literal{pos("Sanitizer", v("fn"), v("kind"))},
+	}
+
+	rs := planAndEval(t, AllSystemRules(), query, baseRels)
+	if !resultContains(rs, iv(7), sv("command_injection")) {
+		t.Errorf("expected Sanitizer(7, command_injection) from shell-quote, got %v", rs.Rows)
 	}
 }

--- a/extract/rules/frameworks_test.go
+++ b/extract/rules/frameworks_test.go
@@ -379,11 +379,10 @@ func TestDatabaseSink_PgQuery(t *testing.T) {
 }
 
 func TestDatabaseSink_MongooseFind(t *testing.T) {
+	// Mongoose uses heuristic: any .find() call is a NoSQL sink
 	baseRels := frameworkBaseRels(map[string]*eval.Relation{
-		"ImportBinding": makeRel("ImportBinding", 3, iv(50), sv("mongoose"), sv("default")),
-		"MethodCall":    makeRel("MethodCall", 3, iv(500), iv(400), sv("find")),
-		"ExprMayRef":    makeRel("ExprMayRef", 2, iv(400), iv(50)),
-		"CallArg":       makeRel("CallArg", 3, iv(500), iv(0), iv(800)),
+		"MethodCall": makeRel("MethodCall", 3, iv(500), iv(400), sv("find")),
+		"CallArg":    makeRel("CallArg", 3, iv(500), iv(0), iv(800)),
 	})
 
 	query := &datalog.Query{
@@ -392,8 +391,8 @@ func TestDatabaseSink_MongooseFind(t *testing.T) {
 	}
 
 	rs := planAndEval(t, AllSystemRules(), query, baseRels)
-	if !resultContains(rs, iv(800), sv("sql")) {
-		t.Errorf("expected TaintSink(800, sql) from mongoose .find(), got %v", rs.Rows)
+	if !resultContains(rs, iv(800), sv("nosql")) {
+		t.Errorf("expected TaintSink(800, nosql) from .find() heuristic, got %v", rs.Rows)
 	}
 }
 

--- a/extract/schema/relations.go
+++ b/extract/schema/relations.go
@@ -222,6 +222,10 @@ func init() {
 		{Name: "sym", Type: TypeEntityRef},
 		{Name: "fnId", Type: TypeEntityRef},
 	}})
+	RegisterRelation(RelationDef{Name: "ExprInFunction", Version: 2, Columns: []ColumnDef{
+		{Name: "exprId", Type: TypeEntityRef},
+		{Name: "fnId", Type: TypeEntityRef},
+	}})
 
 	// v2 Phase C1: Return value symbol (synthetic per-function return symbol)
 	RegisterRelation(RelationDef{Name: "ReturnSym", Version: 2, Columns: []ColumnDef{

--- a/extract/schema/relations_test.go
+++ b/extract/schema/relations_test.go
@@ -37,7 +37,7 @@ func TestAllRelationsRegistered(t *testing.T) {
 }
 
 func TestRelationCount(t *testing.T) {
-	if len(Registry) != 79 {
+	if len(Registry) != 80 {
 		t.Fatalf("expected 79 relations in registry, got %d", len(Registry))
 	}
 }

--- a/ql/eval/builtins.go
+++ b/ql/eval/builtins.go
@@ -2,6 +2,7 @@ package eval
 
 import (
 	"fmt"
+	"math"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -556,6 +557,9 @@ func builtinIntAbs(atom datalog.Atom, bindings []binding) []binding {
 			continue
 		}
 		if n < 0 {
+			if n == math.MinInt64 {
+				continue // overflow: abs(MinInt64) not representable in int64
+			}
 			n = -n
 		}
 		nb, ok := bindResult(atom.Args[1], b, IntVal{V: n})

--- a/ql/eval/builtins.go
+++ b/ql/eval/builtins.go
@@ -29,6 +29,20 @@ var builtinRegistry = map[string]builtinFunc{
 	"__builtin_string_toInt":       builtinStringToInt,
 	"__builtin_string_toString":    builtinStringToString,
 	"__builtin_string_splitAt":     builtinStringSplitAt,
+
+	// D1: regex/string builtins
+	"__builtin_string_regexpFind":       builtinStringRegexpFind,
+	"__builtin_string_regexpReplaceAll": builtinStringRegexpReplaceAll,
+	"__builtin_string_prefix":           builtinStringPrefix,
+	"__builtin_string_suffix":           builtinStringSuffix,
+
+	// D3: integer builtins
+	"__builtin_int_abs":           builtinIntAbs,
+	"__builtin_int_bitAnd":        builtinIntBitAnd,
+	"__builtin_int_bitOr":         builtinIntBitOr,
+	"__builtin_int_bitXor":        builtinIntBitXor,
+	"__builtin_int_bitShiftLeft":  builtinIntBitShiftLeft,
+	"__builtin_int_bitShiftRight": builtinIntBitShiftRight,
 }
 
 // IsBuiltin returns true if the predicate name is a registered builtin.
@@ -393,6 +407,273 @@ func builtinStringSplitAt(atom datalog.Atom, bindings []binding) []binding {
 			continue
 		}
 		nb, ok := bindResult(atom.Args[2], b, StrVal{V: s[idx:]})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// ---- D1: String/regex builtins ----
+
+// __builtin_string_regexpFind(this, pattern, index, offset, result)
+// Find the index-th match of pattern starting at offset; return the match string.
+func builtinStringRegexpFind(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 5 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		pattern, ok := resolveStringArg(atom.Args[1], b)
+		if !ok {
+			continue
+		}
+		index, ok := resolveIntArg(atom.Args[2], b)
+		if !ok {
+			continue
+		}
+		offset, ok := resolveIntArg(atom.Args[3], b)
+		if !ok {
+			continue
+		}
+		if offset < 0 || int(offset) > len(s) {
+			continue
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			continue
+		}
+		matches := re.FindAllString(s[offset:], -1)
+		if index < 0 || int(index) >= len(matches) {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[4], b, StrVal{V: matches[index]})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_string_regexpReplaceAll(this, pattern, replacement, result)
+func builtinStringRegexpReplaceAll(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 4 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		pattern, ok := resolveStringArg(atom.Args[1], b)
+		if !ok {
+			continue
+		}
+		replacement, ok := resolveStringArg(atom.Args[2], b)
+		if !ok {
+			continue
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[3], b, StrVal{V: re.ReplaceAllString(s, replacement)})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_string_prefix(this, n, result) — return first n characters
+func builtinStringPrefix(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 3 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		n, ok := resolveIntArg(atom.Args[1], b)
+		if !ok {
+			continue
+		}
+		if n < 0 || int(n) > len(s) {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[2], b, StrVal{V: s[:n]})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_string_suffix(this, n, result) — return last n characters
+func builtinStringSuffix(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 3 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		s, ok := resolveStringArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		n, ok := resolveIntArg(atom.Args[1], b)
+		if !ok {
+			continue
+		}
+		if n < 0 || int(n) > len(s) {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[2], b, StrVal{V: s[len(s)-int(n):]})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// ---- D3: Integer builtins ----
+
+// __builtin_int_abs(this, result)
+func builtinIntAbs(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 2 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		n, ok := resolveIntArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		if n < 0 {
+			n = -n
+		}
+		nb, ok := bindResult(atom.Args[1], b, IntVal{V: n})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_int_bitAnd(this, other, result)
+func builtinIntBitAnd(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 3 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		a, ok := resolveIntArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		other, ok := resolveIntArg(atom.Args[1], b)
+		if !ok {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[2], b, IntVal{V: a & other})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_int_bitOr(this, other, result)
+func builtinIntBitOr(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 3 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		a, ok := resolveIntArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		other, ok := resolveIntArg(atom.Args[1], b)
+		if !ok {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[2], b, IntVal{V: a | other})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_int_bitXor(this, other, result)
+func builtinIntBitXor(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 3 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		a, ok := resolveIntArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		other, ok := resolveIntArg(atom.Args[1], b)
+		if !ok {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[2], b, IntVal{V: a ^ other})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_int_bitShiftLeft(this, n, result)
+func builtinIntBitShiftLeft(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 3 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		a, ok := resolveIntArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		n, ok := resolveIntArg(atom.Args[1], b)
+		if !ok || n < 0 {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[2], b, IntVal{V: a << uint(n)})
+		if ok {
+			out = append(out, nb)
+		}
+	}
+	return out
+}
+
+// __builtin_int_bitShiftRight(this, n, result) — arithmetic right shift
+func builtinIntBitShiftRight(atom datalog.Atom, bindings []binding) []binding {
+	if len(atom.Args) != 3 {
+		return nil
+	}
+	var out []binding
+	for _, b := range bindings {
+		a, ok := resolveIntArg(atom.Args[0], b)
+		if !ok {
+			continue
+		}
+		n, ok := resolveIntArg(atom.Args[1], b)
+		if !ok || n < 0 {
+			continue
+		}
+		nb, ok := bindResult(atom.Args[2], b, IntVal{V: a >> uint(n)})
 		if ok {
 			out = append(out, nb)
 		}

--- a/stdlib_coverage_test.go
+++ b/stdlib_coverage_test.go
@@ -87,6 +87,7 @@ var stdlibCoverageAllowlist = map[string]string{
 	"ReturnStmt":       "coverage_probe.ql added",
 	"FunctionContains": "coverage_probe.ql added",
 	"ReturnSym":        "coverage_probe.ql added",
+	"ExprInFunction":   "internal expression scoping for taint analysis",
 
 	// Dataflow relations — queried indirectly via DataFlow module.
 	"LocalFlow":     "internal dataflow plumbing",
@@ -106,6 +107,17 @@ var stdlibCoverageAllowlist = map[string]string{
 
 	// Framework model relations.
 	"ExpressHandler": "coverage_probe.ql added",
+
+	// DOM stubs — framework-specific, not queried directly in compat tests.
+	"DOM::Element":        "DOM element class; queried via DOM security queries",
+	"DOM::InnerHtmlWrite": "DOM innerHTML sink; internal taint plumbing",
+	"DOM::DocumentWrite":  "document.write sink; internal taint plumbing",
+	"DOM::AttributeWrite": "DOM attribute write; internal taint plumbing",
+
+	// Crypto/logging stubs — not queried directly in compat tests.
+	"CryptographicOperation": "crypto operation detection; queried via security queries",
+	"CleartextLogging":       "cleartext logging sink; queried via security queries",
+	"SensitiveDataExpr":      "abstract sensitive data; user-extensible",
 
 	// Taint relations — some used in queries but as predicates, not class refs.
 	"TaintSink":     "internal taint plumbing",

--- a/testdata/compat/dataflow_predicates.ql
+++ b/testdata/compat/dataflow_predicates.ql
@@ -1,0 +1,16 @@
+/**
+ * Test DataFlow::Node predicate methods: flowsTo, getASuccessor, getAPredecessor.
+ *
+ * Clean-room query written from scratch against public CodeQL API
+ * documentation (https://codeql.github.com/docs/). Not derived from
+ * CodeQL source code.
+ *
+ * Selects pairs of DataFlow::Node where src has a direct flow successor,
+ * restricted to nodes with a non-empty name.
+ */
+import javascript
+import DataFlow::PathGraph
+
+from DataFlow::Node src, DataFlow::Node succ
+where succ = src.getASuccessor() and not src.getName() = "" and not succ.getName() = ""
+select src, succ


### PR DESCRIPTION
## Summary
- **Framework models (B1-B7)**: Node HTTP, Koa, Fastify, AWS Lambda, Next.js, database drivers (pg/mysql/mysql2/sequelize + mongoose heuristic), sanitizer libraries (DOMPurify, xss, escape-html, shell-escape, sqlstring)
- **QL builtins (D1, D3)**: String (regexpFind, regexpReplaceAll, prefix, suffix) and integer (abs, bitAnd/Or/Xor, bitShift) builtins
- **Stdlib stubs (E2, E3)**: DOM classes (Element, InnerHtmlWrite, DocumentWrite, AttributeWrite), crypto/logging (CryptographicOperation, CleartextLogging, SensitiveDataExpr)
- **DataFlow API (A1)**: Node predicates (getASuccessor, getAPredecessor, getASourceNode, flowsTo, flowsFrom, isParameter)
- **Infrastructure**: ExprInFunction relation registered, bridge manifest (92->100), schema relations (79->80)

## Adversarial review
Ran adversarial review. Fixed:
- **CRITICAL**: Koa ctx.request.body chain rule was dead (AST node ID used as symbol ID). Fixed with ExprMayRef bridge.
- **MEDIUM**: Mongoose find/findOne/aggregate can't constrain receiver to mongoose model. Switched to heuristic matching with "nosql" sink kind.
- **MEDIUM**: abs(MinInt64) overflow. Added guard to skip unrepresentable values.

Accepted as-is (documented limitations):
- KoaHandler/FastifyHandler match any .use()/.get() without receiver constraint (known heuristic trade-off)
- DOM::AttributeWrite matches all FieldWrite (needs DOM element constraint — future work)
- SensitiveDataExpr matches all symbols (abstract class, meant to be subclassed)

## Test plan
- [x] All 17 test packages pass
- [x] Framework rule count test (65 rules)
- [x] Individual framework model tests (Express, HTTP, Koa, Fastify, Lambda, Next.js, DB drivers, sanitizers)
- [x] Builtin tests for string and integer operations
- [x] Bridge manifest and embed tests updated
- [x] Stdlib coverage allowlist updated