### PR TITLE
Add HTTP, IO, and RegExp bridge stubs (E1, E4, E5)

### DIFF
--- a/bridge/compat_http.qll
+++ b/bridge/compat_http.qll
@@ -1,0 +1,53 @@
+/**
+ * CodeQL-compatible HTTP abstraction layer stubs.
+ * Clean-room implementation providing request handler, server request,
+ * and response body classes for framework-agnostic HTTP analysis.
+ *
+ * This file is NOT derived from CodeQL source code.
+ * API surface documented from public CodeQL documentation.
+ */
+
+module HTTP {
+    /**
+     * An abstract HTTP request handler function.
+     * Matches functions detected as handlers by any supported framework
+     * (Express, Koa, Fastify, Next.js, Lambda, or generic HTTP).
+     */
+    abstract class RequestHandler extends @symbol {
+        RequestHandler() {
+            ExpressHandler(this) or
+            HttpHandler(this) or
+            KoaHandler(this) or
+            FastifyHandler(this) or
+            NextjsHandler(this) or
+            LambdaHandler(this)
+        }
+    }
+
+    /**
+     * A server request parameter — the first parameter of an HTTP handler function.
+     * Represents the incoming request object (e.g., req in Express, ctx in Koa).
+     */
+    class ServerRequest extends @symbol {
+        ServerRequest() {
+            exists(int fn |
+                Parameter(fn, 0, _, _, this, _) and
+                (ExpressHandler(fn) or HttpHandler(fn) or KoaHandler(fn) or FastifyHandler(fn) or NextjsHandler(fn) or LambdaHandler(fn))
+            )
+        }
+
+        /** Gets a textual representation. */
+        string toString() { Symbol(this, result, _, _) }
+    }
+
+    /**
+     * A response body that is a taint sink for XSS.
+     * Matches any TaintSink marked with the "xss" category.
+     */
+    class ResponseBody extends @taint_sink {
+        ResponseBody() { TaintSink(this, "xss") }
+
+        /** Gets a textual representation. */
+        string toString() { result = "response body" }
+    }
+}

--- a/bridge/compat_io.qll
+++ b/bridge/compat_io.qll
@@ -1,0 +1,33 @@
+/**
+ * CodeQL-compatible IO abstraction stubs.
+ * Clean-room implementation providing database access and
+ * file system access classes for IO-related security analysis.
+ *
+ * This file is NOT derived from CodeQL source code.
+ * API surface documented from public CodeQL documentation.
+ */
+
+/**
+ * A database access operation, detected via taint sinks.
+ * Matches SQL and NoSQL injection sinks.
+ */
+class DatabaseAccess extends @taint_sink {
+    DatabaseAccess() { TaintSink(this, "sql") or TaintSink(this, "nosql") }
+
+    /** Gets the kind of database query (sql or nosql). */
+    string getQueryKind() { TaintSink(this, result) and (result = "sql" or result = "nosql") }
+
+    /** Gets a textual representation. */
+    string toString() { result = "DatabaseAccess" }
+}
+
+/**
+ * A file system access operation.
+ * Stub — real detection would need import tracking for the "fs" module.
+ */
+class FileSystemAccess extends @symbol {
+    FileSystemAccess() { none() }
+
+    /** Gets a textual representation. */
+    string toString() { result = "FileSystemAccess" }
+}

--- a/bridge/compat_regexp.qll
+++ b/bridge/compat_regexp.qll
@@ -1,0 +1,30 @@
+/**
+ * CodeQL-compatible regular expression stubs.
+ * Clean-room implementation providing regex literal and
+ * regex term classes for ReDoS and regex injection analysis.
+ *
+ * This file is NOT derived from CodeQL source code.
+ * API surface documented from public CodeQL documentation.
+ */
+
+/**
+ * A regular expression literal.
+ * Stub for regex literal analysis — requires AST-level regex parsing.
+ */
+class RegExpLiteral extends @symbol {
+    RegExpLiteral() { none() }
+
+    /** Gets a textual representation. */
+    string toString() { result = "RegExpLiteral" }
+}
+
+/**
+ * A term within a regular expression.
+ * Stub for regex term analysis — requires regex parse tree.
+ */
+class RegExpTerm extends @symbol {
+    RegExpTerm() { none() }
+
+    /** Gets a textual representation. */
+    string toString() { result = "RegExpTerm" }
+}

--- a/bridge/embed.go
+++ b/bridge/embed.go
@@ -2,7 +2,7 @@ package bridge
 
 import "embed"
 
-//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll tsq_summaries.qll tsq_composition.qll tsq_taint.qll tsq_express.qll tsq_react.qll tsq_node.qll compat_javascript.qll compat_dataflow.qll compat_tainttracking.qll compat_security_xss.qll compat_security_cmdi.qll compat_security_sqli.qll compat_security_pathtraversal.qll compat_dom.qll compat_crypto.qll
+//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll tsq_summaries.qll tsq_composition.qll tsq_taint.qll tsq_express.qll tsq_react.qll tsq_node.qll compat_javascript.qll compat_dataflow.qll compat_tainttracking.qll compat_security_xss.qll compat_security_cmdi.qll compat_security_sqli.qll compat_security_pathtraversal.qll compat_dom.qll compat_crypto.qll compat_http.qll compat_io.qll compat_regexp.qll
 var bridgeFS embed.FS
 
 // LoadBridge returns all embedded .qll files as a map from filename to contents.
@@ -35,6 +35,9 @@ func LoadBridge() map[string][]byte {
 		"compat_security_pathtraversal.qll",
 		"compat_dom.qll",
 		"compat_crypto.qll",
+		"compat_http.qll",
+		"compat_io.qll",
+		"compat_regexp.qll",
 	}
 	result := make(map[string][]byte, len(files))
 	for _, name := range files {
@@ -87,6 +90,10 @@ func ImportLoader(bridgeFiles map[string][]byte, parseFn func(src, file string) 
 		"semmle.javascript.security.dataflow.PathTraversalQuery":    "compat_security_pathtraversal.qll",
 		"semmle.javascript.security.dataflow.DomBasedXssQuery":      "compat_dom.qll",
 		"semmle.javascript.security.CryptoLibraries":                "compat_crypto.qll",
+		"semmle.javascript.frameworks.HTTP":                         "compat_http.qll",
+		"semmle.javascript.security.dataflow.DatabaseAccess":        "compat_io.qll",
+		"semmle.javascript.security.dataflow.FileSystemAccess":      "compat_io.qll",
+		"semmle.javascript.security.dataflow.RegExpInjectionQuery":  "compat_regexp.qll",
 	}
 	return func(path string) (interface{}, bool) {
 		filename, ok := pathToFile[path]

--- a/bridge/embed_test.go
+++ b/bridge/embed_test.go
@@ -34,6 +34,9 @@ func TestLoadBridgeReturnsAllFiles(t *testing.T) {
 		"compat_security_pathtraversal.qll",
 		"compat_dom.qll",
 		"compat_crypto.qll",
+		"compat_http.qll",
+		"compat_io.qll",
+		"compat_regexp.qll",
 	}
 	files := LoadBridge()
 	if len(files) != len(expected) {

--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -160,6 +160,16 @@ func v2Manifest() *CapabilityManifest {
 			{Name: "CryptographicOperation", Relation: "MethodCall", File: "compat_crypto.qll"},
 			{Name: "CleartextLogging", Relation: "MethodCall", File: "compat_crypto.qll"},
 			{Name: "SensitiveDataExpr", Relation: "Symbol", File: "compat_crypto.qll"},
+			// v3 Phase E1: HTTP abstraction layer
+			{Name: "HTTP::RequestHandler", Relation: "Symbol", File: "compat_http.qll"},
+			{Name: "HTTP::ServerRequest", Relation: "Symbol", File: "compat_http.qll"},
+			{Name: "HTTP::ResponseBody", Relation: "TaintSink", File: "compat_http.qll"},
+			// v3 Phase E4: IO stubs
+			{Name: "DatabaseAccess", Relation: "TaintSink", File: "compat_io.qll"},
+			{Name: "FileSystemAccess", Relation: "Symbol", File: "compat_io.qll"},
+			// v3 Phase E5: RegExp stubs
+			{Name: "RegExpLiteral", Relation: "Symbol", File: "compat_regexp.qll"},
+			{Name: "RegExpTerm", Relation: "Symbol", File: "compat_regexp.qll"},
 		},
 		Unavailable: []UnavailableClass{},
 	}

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -13,8 +13,9 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	// v3 Phase 3d: +1 bridge class (NonTaintableType) = 85
 	// v3 Phase 17: +7 type-fact relations = 92
 	// Phase 2: +7 DOM/crypto/framework stubs + 1 ExprInFunction = 100
-	if got := len(m.Available); got != 100 {
-		t.Errorf("expected 100 available classes, got %d", got)
+	// Phase E: +3 HTTP + 2 IO + 2 RegExp = 107
+	if got := len(m.Available); got != 107 {
+		t.Errorf("expected 107 available classes, got %d", got)
 	}
 }
 

--- a/stdlib_coverage_test.go
+++ b/stdlib_coverage_test.go
@@ -119,6 +119,19 @@ var stdlibCoverageAllowlist = map[string]string{
 	"CleartextLogging":       "cleartext logging sink; queried via security queries",
 	"SensitiveDataExpr":      "abstract sensitive data; user-extensible",
 
+	// HTTP abstraction layer stubs — framework-agnostic HTTP classes.
+	"HTTP::RequestHandler": "abstract HTTP handler; queried via framework-specific handlers",
+	"HTTP::ServerRequest":  "server request parameter; queried via framework queries",
+	"HTTP::ResponseBody":   "response body taint sink; queried via XSS queries",
+
+	// IO stubs — database and filesystem access.
+	"DatabaseAccess":   "database access sink; queried via SQL/NoSQL injection queries",
+	"FileSystemAccess": "stub — real detection deferred; requires fs import tracking",
+
+	// RegExp stubs — regex literal and term analysis.
+	"RegExpLiteral": "stub — regex literal analysis deferred; requires AST regex parsing",
+	"RegExpTerm":    "stub — regex term analysis deferred; requires regex parse tree",
+
 	// Taint relations — some used in queries but as predicates, not class refs.
 	"TaintSink":     "internal taint plumbing",
 	"TaintSource":   "used as predicate in queries, not as class",


### PR DESCRIPTION
## Summary
- **E1 — HTTP abstraction layer** (`compat_http.qll`): `HTTP::RequestHandler`, `HTTP::ServerRequest`, `HTTP::ResponseBody` classes backed by all six framework handler relations (Express, HTTP, Koa, Fastify, Next.js, Lambda)
- **E4 — IO stubs** (`compat_io.qll`): `DatabaseAccess` (sql/nosql taint sinks) and `FileSystemAccess` (stub, `none()`)
- **E5 — RegExp stubs** (`compat_regexp.qll`): `RegExpLiteral` and `RegExpTerm` (both `none()` stubs)
- All three files wired into embed.go, manifest.go (100 → 107 available classes), import loader, tests, and stdlib coverage allowlist

## Test plan
- [x] All 17 packages pass (`go test ./...`)
- [x] Bridge embed test passes with 30 files (was 27)
- [x] Manifest count test passes at 107
- [x] Stdlib coverage test passes with new allowlist entries