### PR TITLE
Batch 2 Phase 2: taint fix, unique aggregate, AST extraction

### DIFF
--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -137,6 +137,16 @@ func v2Manifest() *CapabilityManifest {
 			{Name: "TypeParameter", Relation: "TypeParameter", File: "tsq_types.qll"},
 			// Phase F1: expression-in-function scoping
 			{Name: "ExprInFunction", Relation: "ExprInFunction", File: "tsq_functions.qll"},
+			// C1: Template literal extraction
+			{Name: "TemplateLiteral", Relation: "TemplateLiteral", File: "tsq_expressions.qll"},
+			{Name: "TemplateElement", Relation: "TemplateElement", File: "tsq_expressions.qll"},
+			{Name: "TemplateExpression", Relation: "TemplateExpression", File: "tsq_expressions.qll"},
+			// C2: Enum declaration extraction
+			{Name: "EnumDecl", Relation: "EnumDecl", File: "tsq_types.qll"},
+			{Name: "EnumMember", Relation: "EnumMember", File: "tsq_types.qll"},
+			// C5: Optional chaining and nullish coalescing
+			{Name: "OptionalChain", Relation: "OptionalChain", File: "tsq_expressions.qll"},
+			{Name: "NullishCoalescing", Relation: "NullishCoalescing", File: "tsq_expressions.qll"},
 			// v2 Phase 2b: CodeQL-compatible DataFlow module
 			{Name: "DataFlow::Node", Relation: "Symbol", File: "compat_dataflow.qll"},
 			{Name: "DataFlow::PathNode", Relation: "Symbol", File: "compat_dataflow.qll"},

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -13,8 +13,9 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	// v3 Phase 3d: +1 bridge class (NonTaintableType) = 85
 	// v3 Phase 17: +7 type-fact relations = 92
 	// Phase 2: +7 DOM/crypto/framework stubs + 1 ExprInFunction = 100
-	if got := len(m.Available); got != 100 {
-		t.Errorf("expected 100 available classes, got %d", got)
+	// Batch 2 Phase 2: +3 template + 2 enum + 2 optional/nullish = 107
+	if got := len(m.Available); got != 107 {
+		t.Errorf("expected 107 available classes, got %d", got)
 	}
 }
 

--- a/extract/kinds.go
+++ b/extract/kinds.go
@@ -59,6 +59,7 @@ var ExpressionKinds = []string{
 	"UpdateExpression",
 	"SequenceExpression",
 	"CommaExpression",
+	"OptionalChainExpression",
 }
 
 var expressionKindSet map[string]bool

--- a/extract/rules/taint.go
+++ b/extract/rules/taint.go
@@ -116,8 +116,13 @@ func TaintRules() []datalog.Rule {
 		// tainted (which respects sanitization via Rule 2's negation).
 		// The sink side is scoped by requiring a tainted symbol exists in
 		// the same function as the sink expression (via SymInFunction and
-		// ExprInFunction), preventing cross-product false positives across
-		// independent functions.
+		// ExprInFunction). This is an intentional over-approximation: we
+		// can't require ExprMayRef(sinkExpr, sinkSym) because the sink expr
+		// is typically a compound expression (e.g. concatenation) where
+		// the tainted identifier is a sub-expression, not the expr itself.
+		// Function-scoping prevents cross-function false positives while
+		// accepting intra-function over-approximation — the correct tradeoff
+		// for security analysis (false positives > false negatives).
 		rule("TaintAlert",
 			[]datalog.Term{v("srcExpr"), v("sinkExpr"), v("srcKind"), v("sinkKind")},
 			pos("TaintSource", v("srcExpr"), v("srcKind")),

--- a/extract/rules/taint.go
+++ b/extract/rules/taint.go
@@ -114,23 +114,18 @@ func TaintRules() []datalog.Rule {
 		// exist for it. This rule uses the VarDecl linkage to connect the
 		// source to a tainted symbol, then checks that the symbol is actually
 		// tainted (which respects sanitization via Rule 2's negation).
-		//
-		// Known precision limitation: the sink side is not constrained to
-		// the same function scope as the source, because we lack an
-		// ExprInFunction relation for sink expressions. In programs with
-		// multiple independent source/sink pairs across different functions,
-		// this produces cross-product false positives. Fix by adding an
-		// ExprInFunction relation to the schema (future work).
-		// TaintAlert(srcExpr, sinkExpr, srcKind, sinkKind) :-
-		//     TaintSource(srcExpr, srcKind),
-		//     VarDecl(_, sym, srcExpr, _),
-		//     TaintedSym(sym, srcKind),
-		//     TaintSink(sinkExpr, sinkKind).
+		// The sink side is scoped by requiring a tainted symbol exists in
+		// the same function as the sink expression (via SymInFunction and
+		// ExprInFunction), preventing cross-product false positives across
+		// independent functions.
 		rule("TaintAlert",
 			[]datalog.Term{v("srcExpr"), v("sinkExpr"), v("srcKind"), v("sinkKind")},
 			pos("TaintSource", v("srcExpr"), v("srcKind")),
 			pos("VarDecl", w(), v("sym"), v("srcExpr"), w()),
 			pos("TaintedSym", v("sym"), v("srcKind")),
+			pos("TaintedSym", v("sinkSym"), v("srcKind")),
+			pos("SymInFunction", v("sinkSym"), v("fnId")),
+			pos("ExprInFunction", v("sinkExpr"), v("fnId")),
 			pos("TaintSink", v("sinkExpr"), v("sinkKind")),
 		),
 	}

--- a/extract/rules/taint_test.go
+++ b/extract/rules/taint_test.go
@@ -497,10 +497,9 @@ func TestTaintAlert_VarDeclSource(t *testing.T) {
 	}
 }
 
-// TestTaintAlert_VarDeclSource_CrossProduct verifies that Rule 6b no longer
-// produces cross-product false positives. After the fix, unrelated sinks
-// in different functions are excluded because ExprInFunction scoping
-// prevents cross-function matching.
+// TestTaintAlert_VarDeclSource_CrossProduct verifies that Rule 6b does not
+// produce cross-product false positives across functions. Sinks in different
+// functions are excluded by SymInFunction/ExprInFunction scoping.
 func TestTaintAlert_VarDeclSource_CrossProduct(t *testing.T) {
 	// Source: TaintSource(100, "http_input") -> VarDecl sym 10 in fn 1
 	// Connected sink 200 (xss) is in fn 1 (same function as tainted sym)

--- a/extract/rules/taint_test.go
+++ b/extract/rules/taint_test.go
@@ -46,6 +46,8 @@ func taintBaseRels(overrides map[string]*eval.Relation) map[string]*eval.Relatio
 		// v3 Phase 3d: type-based sanitization
 		"SymbolType":       eval.NewRelation("SymbolType", 2),
 		"NonTaintableType": eval.NewRelation("NonTaintableType", 1),
+		// Expression-in-function scoping for Rule 6b
+		"ExprInFunction": eval.NewRelation("ExprInFunction", 2),
 	}
 	for k, v := range overrides {
 		base[k] = v
@@ -474,12 +476,14 @@ func TestTaintedSym_VarDeclInit(t *testing.T) {
 // when the source expression is a FieldRead without ExprMayRef.
 func TestTaintAlert_VarDeclSource(t *testing.T) {
 	// Source: TaintSource(100, "http_input") with VarDecl(_, 10, 100, _)
-	// Sink: TaintSink(200, "xss")
+	// Sink: TaintSink(200, "xss") in the same function (fn=1) as tainted sym 10.
 	// Rule 1b gives TaintedSym(10, "http_input"), Rule 6b gives TaintAlert.
 	baseRels := taintBaseRels(map[string]*eval.Relation{
-		"TaintSource": makeRel("TaintSource", 2, iv(100), sv("http_input")),
-		"VarDecl":     makeRel("VarDecl", 4, iv(50), iv(10), iv(100), iv(0)),
-		"TaintSink":   makeRel("TaintSink", 2, iv(200), sv("xss")),
+		"TaintSource":    makeRel("TaintSource", 2, iv(100), sv("http_input")),
+		"VarDecl":        makeRel("VarDecl", 4, iv(50), iv(10), iv(100), iv(0)),
+		"TaintSink":      makeRel("TaintSink", 2, iv(200), sv("xss")),
+		"SymInFunction":  makeRel("SymInFunction", 2, iv(10), iv(1)),
+		"ExprInFunction": makeRel("ExprInFunction", 2, iv(200), iv(1)),
 	})
 
 	query := &datalog.Query{
@@ -493,19 +497,27 @@ func TestTaintAlert_VarDeclSource(t *testing.T) {
 	}
 }
 
-// TestTaintAlert_VarDeclSource_CrossProduct documents the known precision
-// limitation of Rule 6b: independent source/sink pairs across functions
-// produce cross-product false positives because the sink side lacks function
-// scope constraints (no ExprInFunction relation exists yet).
+// TestTaintAlert_VarDeclSource_CrossProduct verifies that Rule 6b no longer
+// produces cross-product false positives. After the fix, unrelated sinks
+// in different functions are excluded because ExprInFunction scoping
+// prevents cross-function matching.
 func TestTaintAlert_VarDeclSource_CrossProduct(t *testing.T) {
-	// Source: TaintSource(100, "http_input") → VarDecl sym 10, sink 200 (xss)
-	// Unrelated sink 300 (sql) in a different part of the program
+	// Source: TaintSource(100, "http_input") -> VarDecl sym 10 in fn 1
+	// Connected sink 200 (xss) is in fn 1 (same function as tainted sym)
+	// Unrelated sink 300 (sql) is in fn 2 (different function)
 	baseRels := taintBaseRels(map[string]*eval.Relation{
 		"TaintSource": makeRel("TaintSource", 2, iv(100), sv("http_input")),
 		"VarDecl":     makeRel("VarDecl", 4, iv(50), iv(10), iv(100), iv(0)),
 		"TaintSink": makeRel("TaintSink", 2,
 			iv(200), sv("xss"),
-			iv(300), sv("sql"), // unrelated sink
+			iv(300), sv("sql"),
+		),
+		"SymInFunction": makeRel("SymInFunction", 2,
+			iv(10), iv(1),
+		),
+		"ExprInFunction": makeRel("ExprInFunction", 2,
+			iv(200), iv(1),
+			iv(300), iv(2),
 		),
 	})
 
@@ -516,19 +528,14 @@ func TestTaintAlert_VarDeclSource_CrossProduct(t *testing.T) {
 
 	rs := planAndEval(t, AllSystemRules(), query, baseRels)
 
-	// Known limitation: Rule 6b produces alerts for BOTH sinks, even though
-	// sink 300 is unrelated. This cross-product false positive will be fixed
-	// when ExprInFunction is added to the schema.
 	gotXss := resultContains(rs, iv(100), iv(200), sv("http_input"), sv("xss"))
 	gotSql := resultContains(rs, iv(100), iv(300), sv("http_input"), sv("sql"))
 
 	if !gotXss {
 		t.Errorf("expected TaintAlert for connected sink 200, got %v", rs.Rows)
 	}
-	if !gotSql {
-		// When this starts failing, the cross-product fix has landed —
-		// update this test to assert !gotSql instead.
-		t.Log("cross-product false positive for sink 300 is expected (known Rule 6b limitation)")
+	if gotSql {
+		t.Errorf("cross-product false positive: got TaintAlert for unrelated sink 300 in different function, got %v", rs.Rows)
 	}
 }
 

--- a/extract/schema/relations.go
+++ b/extract/schema/relations.go
@@ -407,6 +407,45 @@ func init() {
 		{Name: "constraintTypeId", Type: TypeEntityRef},
 	}})
 
+	// C1: Template literal extraction
+	RegisterRelation(RelationDef{Name: "TemplateLiteral", Version: 2, Columns: []ColumnDef{
+		{Name: "id", Type: TypeEntityRef},
+		{Name: "tag", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "TemplateElement", Version: 2, Columns: []ColumnDef{
+		{Name: "parentId", Type: TypeEntityRef},
+		{Name: "idx", Type: TypeInt32},
+		{Name: "rawText", Type: TypeString},
+	}})
+	RegisterRelation(RelationDef{Name: "TemplateExpression", Version: 2, Columns: []ColumnDef{
+		{Name: "parentId", Type: TypeEntityRef},
+		{Name: "idx", Type: TypeInt32},
+		{Name: "exprId", Type: TypeEntityRef},
+	}})
+
+	// C2: Enum declaration extraction
+	RegisterRelation(RelationDef{Name: "EnumDecl", Version: 2, Columns: []ColumnDef{
+		{Name: "id", Type: TypeEntityRef},
+		{Name: "name", Type: TypeString},
+		{Name: "file", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "EnumMember", Version: 2, Columns: []ColumnDef{
+		{Name: "enumId", Type: TypeEntityRef},
+		{Name: "memberName", Type: TypeString},
+		{Name: "initExpr", Type: TypeEntityRef},
+	}})
+
+	// C5: Optional chaining and nullish coalescing
+	RegisterRelation(RelationDef{Name: "OptionalChain", Version: 2, Columns: []ColumnDef{
+		{Name: "expr", Type: TypeEntityRef},
+		{Name: "baseExpr", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "NullishCoalescing", Version: 2, Columns: []ColumnDef{
+		{Name: "expr", Type: TypeEntityRef},
+		{Name: "lhs", Type: TypeEntityRef},
+		{Name: "rhs", Type: TypeEntityRef},
+	}})
+
 	// Diagnostics
 	RegisterRelation(RelationDef{Name: "ExtractError", Version: 1, Columns: []ColumnDef{
 		{Name: "file", Type: TypeEntityRef},

--- a/extract/schema/relations_test.go
+++ b/extract/schema/relations_test.go
@@ -22,6 +22,12 @@ func TestAllRelationsRegistered(t *testing.T) {
 		// v3 type-fact relations
 		"TypeInfo", "TypeMember", "UnionMember", "IntersectionMember",
 		"GenericInstantiation", "TypeAlias", "TypeParameter",
+		// C1: Template literals
+		"TemplateLiteral", "TemplateElement", "TemplateExpression",
+		// C2: Enum declarations
+		"EnumDecl", "EnumMember",
+		// C5: Optional chaining and nullish coalescing
+		"OptionalChain", "NullishCoalescing",
 		"ExtractError", "SchemaVersion",
 	}
 	for _, name := range expected {
@@ -37,8 +43,8 @@ func TestAllRelationsRegistered(t *testing.T) {
 }
 
 func TestRelationCount(t *testing.T) {
-	if len(Registry) != 80 {
-		t.Fatalf("expected 79 relations in registry, got %d", len(Registry))
+	if len(Registry) != 87 {
+		t.Fatalf("expected 87 relations in registry, got %d", len(Registry))
 	}
 }
 

--- a/extract/walker.go
+++ b/extract/walker.go
@@ -880,6 +880,73 @@ func (fw *FactWalker) emitJsxAttr(node ASTNode, elementID uint32) {
 	fw.emit("JsxAttribute", elementID, attrName, valueID)
 }
 
+// ---- Template Literals ----
+
+func (fw *FactWalker) emitTemplateLiteral(node ASTNode, id uint32, tagID uint32) {
+	fw.emit("TemplateLiteral", id, tagID)
+
+	// Walk children: TemplateSubstitution contains expressions,
+	// everything else is a string fragment.
+	idx := int32(0)
+	count := node.ChildCount()
+	for i := 0; i < count; i++ {
+		child := node.Child(i)
+		if child == nil {
+			continue
+		}
+		k := child.Kind()
+		switch k {
+		case "`", "${", "}":
+			continue
+		case "TemplateSubstitution":
+			// The expression is inside the substitution
+			cc := child.ChildCount()
+			for j := 0; j < cc; j++ {
+				gc := child.Child(j)
+				if gc == nil {
+					continue
+				}
+				gk := gc.Kind()
+				if gk == "${" || gk == "}" {
+					continue
+				}
+				fw.emit("TemplateExpression", id, idx, fw.nid(gc))
+				idx++
+				break
+			}
+		default:
+			// String fragment (TemplateChars or similar)
+			fw.emit("TemplateElement", id, idx, child.Text())
+			idx++
+		}
+	}
+}
+
+func (fw *FactWalker) emitTaggedTemplate(node ASTNode, id uint32) {
+	// TaggedTemplateExpression: tag `template`
+	var tagID uint32
+	tagNode := childByField(node, "function")
+	if tagNode == nil && node.ChildCount() > 0 {
+		tagNode = node.Child(0)
+	}
+	if tagNode != nil {
+		tagID = fw.nid(tagNode)
+	}
+
+	// Find the template string child
+	templateNode := childByField(node, "arguments")
+	if templateNode == nil {
+		// Fallback: find TemplateString child
+		templateNode = childByKind(node, "TemplateString")
+	}
+	if templateNode != nil {
+		fw.emitTemplateLiteral(templateNode, fw.nid(templateNode), tagID)
+	} else {
+		// Emit the tagged template itself as a TemplateLiteral with the tag
+		fw.emit("TemplateLiteral", id, tagID)
+	}
+}
+
 // ---- utilities ----
 
 func boolInt(b bool) int32 {

--- a/extract/walker.go
+++ b/extract/walker.go
@@ -173,6 +173,10 @@ func (fw *FactWalker) enterNode(node ASTNode) (bool, error) {
 		if len(fw.jsxElementStack) > 0 {
 			fw.emitJsxAttr(node, fw.jsxElementStack[len(fw.jsxElementStack)-1])
 		}
+	case "TemplateString":
+		fw.emitTemplateLiteral(node, id, 0)
+	case "TaggedTemplateExpression":
+		fw.emitTaggedTemplate(node, id)
 	case "Error":
 		fw.emitExtractError(fw.fileID, node.StartLine(), "parse",
 			fmt.Sprintf("syntax error at line %d col %d", node.StartLine(), node.StartCol()))

--- a/extract/walker_v2.go
+++ b/extract/walker_v2.go
@@ -143,6 +143,12 @@ func (tw *TypeAwareWalker) emitV2Facts(node ASTNode) {
 		tw.emitTypeDecl(node, id)
 	case "VariableDeclarator":
 		tw.emitSymbolFromVarDecl(node)
+	case "EnumDeclaration":
+		tw.emitEnumDecl(node, id)
+	case "OptionalChainExpression":
+		tw.emitOptionalChain(node, id)
+	case "BinaryExpression":
+		tw.emitNullishCoalescing(node, id)
 	case "Identifier":
 		tw.emitSymInFunction(node)
 	case "UnionType":
@@ -161,6 +167,11 @@ func (tw *TypeAwareWalker) emitV2Facts(node ASTNode) {
 	// re-emitting here for function kinds to avoid the self-row.
 	if !IsFunctionKind(kind) && len(tw.fnStack) > 0 {
 		tw.fw.emit("FunctionContains", tw.fnStack[len(tw.fnStack)-1], id)
+	}
+
+	// ExprInFunction: expression nodes inside a function body.
+	if isExpressionKind(kind) && len(tw.fnStack) > 0 {
+		tw.fw.emit("ExprInFunction", id, tw.fnStack[len(tw.fnStack)-1])
 	}
 }
 
@@ -658,6 +669,101 @@ func (tw *TypeAwareWalker) emitSymbolFromVarDecl(node ASTNode) {
 			tw.fw.emit("FunctionSymbol", symID, fnID)
 		}
 	}
+}
+
+// emitEnumDecl emits EnumDecl and EnumMember tuples for TypeScript enum declarations.
+func (tw *TypeAwareWalker) emitEnumDecl(node ASTNode, id uint32) {
+	name := ""
+	if nameNode := childByField(node, "name"); nameNode != nil {
+		name = nameNode.Text()
+	}
+	tw.fw.emit("EnumDecl", id, name, tw.fw.fileID)
+
+	// Walk children for enum members
+	bodyNode := childByField(node, "body")
+	if bodyNode == nil {
+		bodyNode = childByKind(node, "EnumBody")
+	}
+	if bodyNode == nil {
+		bodyNode = node
+	}
+
+	count := bodyNode.ChildCount()
+	for i := 0; i < count; i++ {
+		child := bodyNode.Child(i)
+		if child == nil {
+			continue
+		}
+		k := child.Kind()
+		if k == "{" || k == "}" || k == "," {
+			continue
+		}
+		memberName := ""
+		var initExprID uint32
+		switch k {
+		case "EnumAssignment":
+			if mn := childByField(child, "name"); mn != nil {
+				memberName = mn.Text()
+			}
+			if vn := childByField(child, "value"); vn != nil {
+				initExprID = tw.fw.nid(vn)
+			}
+		case "PropertyIdentifier", "Identifier":
+			memberName = child.Text()
+		default:
+			memberName = child.Text()
+		}
+		if memberName != "" {
+			tw.fw.emit("EnumMember", id, memberName, initExprID)
+		}
+	}
+}
+
+// emitOptionalChain emits OptionalChain for optional chaining expressions (obj?.prop).
+func (tw *TypeAwareWalker) emitOptionalChain(node ASTNode, id uint32) {
+	// OptionalChainExpression wraps the base expression
+	var baseID uint32
+	count := node.ChildCount()
+	for i := 0; i < count; i++ {
+		child := node.Child(i)
+		if child == nil {
+			continue
+		}
+		k := child.Kind()
+		if k != "?." && k != "?.[" {
+			baseID = tw.fw.nid(child)
+			break
+		}
+	}
+	tw.fw.emit("OptionalChain", id, baseID)
+}
+
+// emitNullishCoalescing emits NullishCoalescing for ?? binary expressions.
+func (tw *TypeAwareWalker) emitNullishCoalescing(node ASTNode, id uint32) {
+	// Check if this is a ?? operator
+	hasNullish := false
+	count := node.ChildCount()
+	for i := 0; i < count; i++ {
+		child := node.Child(i)
+		if child != nil && child.Text() == "??" {
+			hasNullish = true
+			break
+		}
+	}
+	if !hasNullish {
+		return
+	}
+
+	leftNode := childByField(node, "left")
+	rightNode := childByField(node, "right")
+	var leftID, rightID uint32
+	if leftNode != nil {
+		leftID = tw.fw.nid(leftNode)
+	}
+	if rightNode != nil {
+		rightID = tw.fw.nid(rightNode)
+	}
+	tw.fw.emit("NullishCoalescing", id, leftID, rightID)
 }
 
 // emitSymInFunction emits SymInFunction when an identifier reference appears inside a function.

--- a/extract/walker_v2.go
+++ b/extract/walker_v2.go
@@ -143,7 +143,7 @@ func (tw *TypeAwareWalker) emitV2Facts(node ASTNode) {
 		tw.emitTypeDecl(node, id)
 	case "VariableDeclarator":
 		tw.emitSymbolFromVarDecl(node)
-	case "EnumDeclaration":
+	case "EnumDeclaration", "ConstEnumDeclaration":
 		tw.emitEnumDecl(node, id)
 	case "OptionalChainExpression":
 		tw.emitOptionalChain(node, id)

--- a/extract/walker_v2_test.go
+++ b/extract/walker_v2_test.go
@@ -481,6 +481,51 @@ class C implements A, B {
 	}
 }
 
+// TestV2ExprInFunction verifies ExprInFunction tuples are emitted for expressions inside functions.
+func TestV2ExprInFunction(t *testing.T) {
+	src := `
+function foo() {
+  const x = 1;
+  const y = x + 2;
+  return y;
+}
+`
+	database := v2WalkerTestDB(t, src)
+	r := rel(t, database, "ExprInFunction")
+	if r.Tuples() == 0 {
+		t.Fatal("ExprInFunction: expected tuples for expressions inside foo()")
+	}
+	// Should contain multiple expression nodes (identifiers, binary expressions, numbers)
+	if r.Tuples() < 3 {
+		t.Errorf("ExprInFunction: expected >= 3 tuples, got %d", r.Tuples())
+	}
+}
+
+// TestV2EnumDecl verifies EnumDecl and EnumMember tuples.
+func TestV2EnumDecl(t *testing.T) {
+	src := `
+enum Direction {
+  Up,
+  Down,
+  Left,
+  Right
+}
+`
+	database := v2WalkerTestDB(t, src)
+	r := rel(t, database, "EnumDecl")
+	if r.Tuples() == 0 {
+		t.Fatal("EnumDecl: expected tuples for Direction enum")
+	}
+	if !hasString(t, database, r, 1, "Direction") {
+		t.Error("EnumDecl: expected name='Direction'")
+	}
+
+	mr := rel(t, database, "EnumMember")
+	if mr.Tuples() < 4 {
+		t.Errorf("EnumMember: expected >= 4 tuples (Up, Down, Left, Right), got %d", mr.Tuples())
+	}
+}
+
 // TestV2InterfaceExtends verifies interface extends interface.
 func TestV2InterfaceExtends(t *testing.T) {
 	src := `

--- a/ql/eval/aggregate.go
+++ b/ql/eval/aggregate.go
@@ -208,6 +208,9 @@ func computeAggregate(fn string, vals []Value, separator string) (Value, error) 
 	case "unique":
 		seen := make(map[string]Value)
 		for _, val := range vals {
+			if val == nil {
+				continue
+			}
 			k := fmt.Sprintf("%v", val)
 			seen[k] = val
 		}

--- a/ql/eval/aggregate.go
+++ b/ql/eval/aggregate.go
@@ -205,6 +205,19 @@ func computeAggregate(fn string, vals []Value, separator string) (Value, error) 
 	case "concat":
 		return concatValues(vals, separator), nil
 
+	case "unique":
+		seen := make(map[string]Value)
+		for _, val := range vals {
+			k := fmt.Sprintf("%v", val)
+			seen[k] = val
+		}
+		if len(seen) == 1 {
+			for _, val := range seen {
+				return val, nil
+			}
+		}
+		return nil, fmt.Errorf("unique: %d distinct values (need exactly 1)", len(seen))
+
 	case "rank":
 		// Rank is handled as a multi-tuple aggregate in Aggregate().
 		// This path should not be reached; if it is, return an error.

--- a/ql/eval/aggregate_test.go
+++ b/ql/eval/aggregate_test.go
@@ -279,6 +279,39 @@ func TestComputeRankAllTied(t *testing.T) {
 	}
 }
 
+func TestAggUniqueSingle(t *testing.T) {
+	rel := makeRelation("R", 2, IntVal{1}, IntVal{42}, IntVal{1}, IntVal{42}, IntVal{1}, IntVal{42})
+	rels := RelsOf(rel)
+	agg := makeAgg("R", "v", []string{"g"}, "unique", "uval")
+	result := Aggregate(agg, rels)
+	if result.Len() != 1 {
+		t.Fatalf("expected 1 group, got %d", result.Len())
+	}
+	if result.Tuples()[0][1].(IntVal).V != 42 {
+		t.Errorf("expected unique=42, got %v", result.Tuples()[0][1])
+	}
+}
+
+func TestAggUniqueMultiple(t *testing.T) {
+	rel := makeRelation("R", 2, IntVal{1}, IntVal{10}, IntVal{1}, IntVal{20})
+	rels := RelsOf(rel)
+	agg := makeAgg("R", "v", []string{"g"}, "unique", "uval")
+	result := Aggregate(agg, rels)
+	if result.Len() != 0 {
+		t.Errorf("expected 0 results for non-unique values, got %d", result.Len())
+	}
+}
+
+func TestAggUniqueEmpty(t *testing.T) {
+	rel := NewRelation("R", 2)
+	rels := RelsOf(rel)
+	agg := makeAgg("R", "v", []string{"g"}, "unique", "uval")
+	result := Aggregate(agg, rels)
+	if result.Len() != 0 {
+		t.Errorf("expected 0 results for empty unique, got %d", result.Len())
+	}
+}
+
 func TestComputeRankStableOrder(t *testing.T) {
 	vals := []Value{IntVal{30}, IntVal{20}, IntVal{20}, IntVal{10}}
 	ranks := computeRank(vals)

--- a/ql/parse/lexer.go
+++ b/ql/parse/lexer.go
@@ -76,6 +76,7 @@ const (
 	TokKwStrictcount
 	TokKwStrictsum
 	TokKwRank
+	TokKwUnique
 	TokKwForex
 	TokKwSuper
 	TokKwDeprecated
@@ -126,6 +127,7 @@ var keywords = map[string]TokenType{
 	"strictcount": TokKwStrictcount,
 	"strictsum":   TokKwStrictsum,
 	"rank":        TokKwRank,
+	"unique":      TokKwUnique,
 	"forex":       TokKwForex,
 	"super":       TokKwSuper,
 	"deprecated":  TokKwDeprecated,

--- a/ql/parse/parser.go
+++ b/ql/parse/parser.go
@@ -1243,7 +1243,7 @@ func (p *Parser) parsePrimary() (ast.Expr, error) {
 		}, nil
 
 	case TokKwCount, TokKwMin, TokKwMax, TokKwSum, TokKwAvg,
-		TokKwConcat, TokKwStrictcount, TokKwStrictsum, TokKwRank:
+		TokKwConcat, TokKwStrictcount, TokKwStrictsum, TokKwRank, TokKwUnique:
 		return p.parseAggregate()
 
 	case TokKwSuper:

--- a/stdlib_coverage_test.go
+++ b/stdlib_coverage_test.go
@@ -119,6 +119,19 @@ var stdlibCoverageAllowlist = map[string]string{
 	"CleartextLogging":       "cleartext logging sink; queried via security queries",
 	"SensitiveDataExpr":      "abstract sensitive data; user-extensible",
 
+	// C1: Template literal extraction
+	"TemplateLiteral":    "template literal structural extraction; not queried directly",
+	"TemplateElement":    "template string fragment; not queried directly",
+	"TemplateExpression": "template interpolation; not queried directly",
+
+	// C2: Enum declaration extraction
+	"EnumDecl":   "enum declaration; not queried directly in compat tests",
+	"EnumMember": "enum member; not queried directly in compat tests",
+
+	// C5: Optional chaining and nullish coalescing
+	"OptionalChain":     "optional chaining expression; not queried directly",
+	"NullishCoalescing": "nullish coalescing expression; not queried directly",
+
 	// Taint relations — some used in queries but as predicates, not class refs.
 	"TaintSink":     "internal taint plumbing",
 	"TaintSource":   "used as predicate in queries, not as class",


### PR DESCRIPTION
## Summary

- **F1: Fix Rule 6b cross-product** — Emit `ExprInFunction` facts from walker_v2 for expression nodes inside functions. Fix Rule 6b to use `SymInFunction + ExprInFunction` scoping on the sink side, eliminating cross-function false positive alerts while preserving correct intra-function detection.
- **D2: `unique` aggregate** — New aggregate keyword in the QL parser and evaluator. Returns the value when exactly 1 distinct value exists in a group; returns empty otherwise.
- **C1: Template literal extraction** — Register and emit `TemplateLiteral`, `TemplateElement`, `TemplateExpression` relations for template strings and tagged templates.
- **C2: Enum declaration extraction** — Register and emit `EnumDecl`, `EnumMember` relations for TypeScript enum declarations with member walking.
- **C5: Optional chaining and nullish coalescing** — Register and emit `OptionalChain`, `NullishCoalescing` relations for `?.` and `??` operators.

Schema count: 80 → 87. Manifest available: 100 → 107. All 17 packages pass.

## Test plan
- [x] `TestTaintAlert_VarDeclSource` — Rule 6b produces alerts for same-function sinks
- [x] `TestTaintAlert_VarDeclSource_CrossProduct` — Rule 6b no longer produces false positives for sinks in different functions
- [x] `TestAggUniqueSingle` / `TestAggUniqueMultiple` / `TestAggUniqueEmpty` — unique aggregate correctness
- [x] `TestV2ExprInFunction` — ExprInFunction facts emitted for expressions inside functions
- [x] `TestV2EnumDecl` — EnumDecl and EnumMember facts emitted
- [x] `TestCompat/find_xss` and `TestCompat/find_sqli` — integration tests still pass with updated Rule 6b
- [x] `TestRelationCount` — schema count updated to 87
- [x] `TestV1ManifestAvailableCount` — manifest count updated to 107
- [x] `TestAllRelationsCovered` — all new relations covered in manifest
- [x] `TestCompatStdlibCoverage` — all new classes in allowlist