### PR TITLE
A3: AdditionalTaintStep and AdditionalFlowStep integration

### DIFF
--- a/bridge/compat_dataflow.qll
+++ b/bridge/compat_dataflow.qll
@@ -119,7 +119,7 @@ module DataFlow {
             not this.isBarrier(source) and
             not this.isBarrier(sink) and
             (
-                source = sink
+                (this.isSource(source) and source = sink)
                 or
                 this.flowViaLocalFlow(source, sink)
                 or
@@ -139,7 +139,7 @@ module DataFlow {
             not this.isBarrier(source) and
             not this.isBarrier(sink) and
             (
-                source = sink
+                (this.isSource(source) and source = sink)
                 or
                 this.flowViaLocalFlow(source, sink)
                 or

--- a/bridge/compat_dataflow.qll
+++ b/bridge/compat_dataflow.qll
@@ -149,16 +149,6 @@ module DataFlow {
     }
 
     /**
-     * Materializes user-defined additional flow steps from all Configuration
-     * subclasses into the AdditionalFlowStep base relation.  This allows
-     * the system-level flow rules (FlowStar) to propagate data through
-     * user-defined steps.
-     */
-    predicate additionalFlowStepAll(Node src, Node dst) {
-        exists(Configuration config | config.isAdditionalFlowStep(src, dst))
-    }
-
-    /**
      * A node on a data-flow path. Wraps a symbol for path queries,
      * providing the same interface as Node with path-query context.
      */
@@ -188,9 +178,10 @@ module DataFlow {
 }
 
 /**
- * Top-level predicate to materialize DataFlow additional flow steps
- * into the AdditionalFlowStep relation used by system flow rules.
+ * Materializes user-defined additional flow steps from all
+ * DataFlow::Configuration subclasses into the AdditionalFlowStep
+ * relation used by system flow rules (FlowStar).
  */
 predicate AdditionalFlowStep(int src, int dst) {
-    DataFlow::additionalFlowStepAll(src, dst)
+    exists(DataFlow::Configuration config | config.isAdditionalFlowStep(src, dst))
 }

--- a/bridge/compat_dataflow.qll
+++ b/bridge/compat_dataflow.qll
@@ -149,6 +149,16 @@ module DataFlow {
     }
 
     /**
+     * Materializes user-defined additional flow steps from all Configuration
+     * subclasses into the AdditionalFlowStep base relation.  This allows
+     * the system-level flow rules (FlowStar) to propagate data through
+     * user-defined steps.
+     */
+    predicate additionalFlowStepAll(Node src, Node dst) {
+        exists(Configuration config | config.isAdditionalFlowStep(src, dst))
+    }
+
+    /**
      * A node on a data-flow path. Wraps a symbol for path queries,
      * providing the same interface as Node with path-query context.
      */
@@ -175,4 +185,12 @@ module DataFlow {
         or
         InterFlow(a, b)
     }
+}
+
+/**
+ * Top-level predicate to materialize DataFlow additional flow steps
+ * into the AdditionalFlowStep relation used by system flow rules.
+ */
+predicate AdditionalFlowStep(int src, int dst) {
+    DataFlow::additionalFlowStepAll(src, dst)
 }

--- a/bridge/compat_tainttracking.qll
+++ b/bridge/compat_tainttracking.qll
@@ -73,7 +73,7 @@ module TaintTracking {
             not this.isSanitizer(source) and
             not this.isSanitizer(sink) and
             (
-                source = sink
+                (this.isSource(source) and source = sink)
                 or
                 this.flowViaTaintAlert(source, sink)
                 or
@@ -93,7 +93,7 @@ module TaintTracking {
             not this.isSanitizer(source) and
             not this.isSanitizer(sink) and
             (
-                source = sink
+                (this.isSource(source) and source = sink)
                 or
                 this.flowViaTaintAlert(source, sink)
                 or

--- a/bridge/compat_tainttracking.qll
+++ b/bridge/compat_tainttracking.qll
@@ -128,4 +128,14 @@ module TaintTracking {
         or
         TaintAlert(a, b, _, _)
     }
+
+}
+
+/**
+ * Materializes user-defined additional taint steps from all
+ * TaintTracking::Configuration subclasses into the AdditionalTaintStep
+ * relation used by system taint rules (FlowStar / TaintedSym).
+ */
+predicate AdditionalTaintStep(int src, int dst) {
+    exists(TaintTracking::Configuration config | config.isAdditionalTaintStep(src, dst))
 }

--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -119,6 +119,9 @@ func v2Manifest() *CapabilityManifest {
 			{Name: "TaintedField", Relation: "TaintedField", File: "tsq_taint.qll"},
 			{Name: "SanitizedEdge", Relation: "SanitizedEdge", File: "tsq_taint.qll"},
 			{Name: "TaintAlert", Relation: "TaintAlert", File: "tsq_taint.qll"},
+			// v2 Phase A3: additional taint/flow step materializers
+			{Name: "AdditionalTaintStep", Relation: "AdditionalTaintStep", File: "compat_tainttracking.qll"},
+			{Name: "AdditionalFlowStep", Relation: "AdditionalFlowStep", File: "compat_dataflow.qll"},
 			// v3: tsgo-resolved type relations
 			{Name: "ResolvedType", Relation: "ResolvedType", File: "tsq_types.qll"},
 			{Name: "SymbolType", Relation: "SymbolType", File: "tsq_types.qll"},

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -16,8 +16,9 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	// Batch 2 Phase 2: +3 template + 2 enum + 2 optional/nullish = 107
 	// Phase E: +3 HTTP + 2 IO + 2 RegExp = 114
 	// C3/C4/C6: +1 Decorator + 2 Namespace + 1 TypeGuard = 118
-	if got := len(m.Available); got != 118 {
-		t.Errorf("expected 118 available classes, got %d", got)
+	// Phase A3: +2 AdditionalTaintStep + AdditionalFlowStep = 120
+	if got := len(m.Available); got != 120 {
+		t.Errorf("expected 120 available classes, got %d", got)
 	}
 }
 

--- a/compat_test.go
+++ b/compat_test.go
@@ -167,7 +167,7 @@ func compatTestCases() []compatTestCase {
 			projectDir: "testdata/compat/projects/basic",
 			queryFile:  "testdata/compat/custom_config.ql",
 			goldenFile: "testdata/compat/expected/custom_config.csv",
-			// A2: Configuration override dispatch works; hasFlow method pending disjunction desugarer fix
+			// A2: Configuration override dispatch works; hasFlow disjunction grounding fixed in A3
 		},
 		{
 			name:       "dataflow_predicates",

--- a/extract/rules/composition.go
+++ b/extract/rules/composition.go
@@ -65,5 +65,23 @@ func CompositionRules() []datalog.Rule {
 			pos("FlowStar", v("src"), v("mid")),
 			pos("FlowStar", v("mid"), v("dst")),
 		),
+
+		// Rule 6: FlowStar — additional taint steps (Plan A3).
+		// User-defined isAdditionalTaintStep overrides on TaintTracking::Configuration
+		// subclasses produce AdditionalTaintStep(src, dst) facts via the desugarer's
+		// override dispatch. These extend reachability beyond the base flow graph.
+		// FlowStar(src, dst) :- AdditionalTaintStep(src, dst).
+		rule("FlowStar",
+			[]datalog.Term{v("src"), v("dst")},
+			pos("AdditionalTaintStep", v("src"), v("dst")),
+		),
+
+		// Rule 7: FlowStar — additional flow steps (DataFlow::Configuration).
+		// Same as Rule 6 but for DataFlow::Configuration.isAdditionalFlowStep.
+		// FlowStar(src, dst) :- AdditionalFlowStep(src, dst).
+		rule("FlowStar",
+			[]datalog.Term{v("src"), v("dst")},
+			pos("AdditionalFlowStep", v("src"), v("dst")),
+		),
 	}
 }

--- a/extract/rules/composition_test.go
+++ b/extract/rules/composition_test.go
@@ -405,7 +405,7 @@ func TestEmptyRelationsNoFlowStar(t *testing.T) {
 // are lifted into FlowStar, enabling taint to propagate through user-defined steps.
 func TestAdditionalTaintStep_FlowStar(t *testing.T) {
 	additionalStep := eval.NewRelation("AdditionalTaintStep", 2)
-	additionalStep.Add(eval.Tuple{eval.IntVal(10), eval.IntVal(20)})
+	additionalStep.Add(eval.Tuple{eval.IntVal{10}, eval.IntVal{20}})
 
 	baseRels := compositionBaseRels(map[string]*eval.Relation{
 		"AdditionalTaintStep": additionalStep,
@@ -422,7 +422,7 @@ func TestAdditionalTaintStep_FlowStar(t *testing.T) {
 	}
 	found := false
 	for _, row := range rs.Rows {
-		if row[0] == eval.IntVal(10) && row[1] == eval.IntVal(20) {
+		if row[0] == eval.IntVal{10} && row[1] == eval.IntVal{20} {
 			found = true
 			break
 		}
@@ -436,7 +436,7 @@ func TestAdditionalTaintStep_FlowStar(t *testing.T) {
 // are lifted into FlowStar.
 func TestAdditionalFlowStep_FlowStar(t *testing.T) {
 	additionalStep := eval.NewRelation("AdditionalFlowStep", 2)
-	additionalStep.Add(eval.Tuple{eval.IntVal(30), eval.IntVal(40)})
+	additionalStep.Add(eval.Tuple{eval.IntVal{30}, eval.IntVal{40}})
 
 	baseRels := compositionBaseRels(map[string]*eval.Relation{
 		"AdditionalFlowStep": additionalStep,
@@ -450,7 +450,7 @@ func TestAdditionalFlowStep_FlowStar(t *testing.T) {
 	rs := planAndEval(t, allRulesForComposition(), query, baseRels)
 	found := false
 	for _, row := range rs.Rows {
-		if row[0] == eval.IntVal(30) && row[1] == eval.IntVal(40) {
+		if row[0] == eval.IntVal{30} && row[1] == eval.IntVal{40} {
 			found = true
 			break
 		}
@@ -465,16 +465,16 @@ func TestAdditionalFlowStep_FlowStar(t *testing.T) {
 func TestAdditionalTaintStep_Transitivity(t *testing.T) {
 	// LocalFlow: 10 → 20 in fn=1
 	assign := eval.NewRelation("Assign", 3)
-	assign.Add(eval.Tuple{eval.IntVal(100), eval.IntVal(200), eval.IntVal(20)}) // lhsNode=100, rhsExpr=200, lhsSym=20
+	assign.Add(eval.Tuple{eval.IntVal{100}, eval.IntVal{200}, eval.IntVal{20}}) // lhsNode=100, rhsExpr=200, lhsSym=20
 	exprMayRef := eval.NewRelation("ExprMayRef", 2)
-	exprMayRef.Add(eval.Tuple{eval.IntVal(200), eval.IntVal(10)}) // rhsExpr=200 refers to sym 10
+	exprMayRef.Add(eval.Tuple{eval.IntVal{200}, eval.IntVal{10}}) // rhsExpr=200 refers to sym 10
 	symInFn := eval.NewRelation("SymInFunction", 2)
-	symInFn.Add(eval.Tuple{eval.IntVal(10), eval.IntVal(1)})
-	symInFn.Add(eval.Tuple{eval.IntVal(20), eval.IntVal(1)})
+	symInFn.Add(eval.Tuple{eval.IntVal{10}, eval.IntVal{1}})
+	symInFn.Add(eval.Tuple{eval.IntVal{20}, eval.IntVal{1}})
 
 	// AdditionalTaintStep: 20 → 30 (crosses function boundary via user-defined step)
 	additionalStep := eval.NewRelation("AdditionalTaintStep", 2)
-	additionalStep.Add(eval.Tuple{eval.IntVal(20), eval.IntVal(30)})
+	additionalStep.Add(eval.Tuple{eval.IntVal{20}, eval.IntVal{30}})
 
 	baseRels := compositionBaseRels(map[string]*eval.Relation{
 		"Assign":              assign,
@@ -494,7 +494,7 @@ func TestAdditionalTaintStep_Transitivity(t *testing.T) {
 	for _, row := range rs.Rows {
 		src, _ := row[0].(eval.IntVal)
 		dst, _ := row[1].(eval.IntVal)
-		flowPairs[[2]int{int(src), int(dst)}] = true
+		flowPairs[[2]int{int(src.V), int(dst.V)}] = true
 	}
 	for _, pair := range [][2]int{{10, 20}, {20, 30}, {10, 30}} {
 		if !flowPairs[pair] {

--- a/extract/rules/composition_test.go
+++ b/extract/rules/composition_test.go
@@ -405,7 +405,7 @@ func TestEmptyRelationsNoFlowStar(t *testing.T) {
 // are lifted into FlowStar, enabling taint to propagate through user-defined steps.
 func TestAdditionalTaintStep_FlowStar(t *testing.T) {
 	additionalStep := eval.NewRelation("AdditionalTaintStep", 2)
-	additionalStep.Add(eval.Tuple{eval.IntVal{10}, eval.IntVal{20}})
+	additionalStep.Add(eval.Tuple{eval.IntVal{V: 10}, eval.IntVal{V: 20}})
 
 	baseRels := compositionBaseRels(map[string]*eval.Relation{
 		"AdditionalTaintStep": additionalStep,
@@ -422,7 +422,7 @@ func TestAdditionalTaintStep_FlowStar(t *testing.T) {
 	}
 	found := false
 	for _, row := range rs.Rows {
-		if row[0] == (eval.IntVal{10}) && row[1] == (eval.IntVal{20}) {
+		if row[0] == (eval.IntVal{V: 10}) && row[1] == (eval.IntVal{V: 20}) {
 			found = true
 			break
 		}
@@ -436,7 +436,7 @@ func TestAdditionalTaintStep_FlowStar(t *testing.T) {
 // are lifted into FlowStar.
 func TestAdditionalFlowStep_FlowStar(t *testing.T) {
 	additionalStep := eval.NewRelation("AdditionalFlowStep", 2)
-	additionalStep.Add(eval.Tuple{eval.IntVal{30}, eval.IntVal{40}})
+	additionalStep.Add(eval.Tuple{eval.IntVal{V: 30}, eval.IntVal{V: 40}})
 
 	baseRels := compositionBaseRels(map[string]*eval.Relation{
 		"AdditionalFlowStep": additionalStep,
@@ -450,7 +450,7 @@ func TestAdditionalFlowStep_FlowStar(t *testing.T) {
 	rs := planAndEval(t, allRulesForComposition(), query, baseRels)
 	found := false
 	for _, row := range rs.Rows {
-		if row[0] == (eval.IntVal{30}) && row[1] == (eval.IntVal{40}) {
+		if row[0] == (eval.IntVal{V: 30}) && row[1] == (eval.IntVal{V: 40}) {
 			found = true
 			break
 		}
@@ -465,16 +465,16 @@ func TestAdditionalFlowStep_FlowStar(t *testing.T) {
 func TestAdditionalTaintStep_Transitivity(t *testing.T) {
 	// LocalFlow: 10 → 20 in fn=1
 	assign := eval.NewRelation("Assign", 3)
-	assign.Add(eval.Tuple{eval.IntVal{100}, eval.IntVal{200}, eval.IntVal{20}}) // lhsNode=100, rhsExpr=200, lhsSym=20
+	assign.Add(eval.Tuple{eval.IntVal{V: 100}, eval.IntVal{V: 200}, eval.IntVal{V: 20}}) // lhsNode=100, rhsExpr=200, lhsSym=20
 	exprMayRef := eval.NewRelation("ExprMayRef", 2)
-	exprMayRef.Add(eval.Tuple{eval.IntVal{200}, eval.IntVal{10}}) // rhsExpr=200 refers to sym 10
+	exprMayRef.Add(eval.Tuple{eval.IntVal{V: 200}, eval.IntVal{V: 10}}) // rhsExpr=200 refers to sym 10
 	symInFn := eval.NewRelation("SymInFunction", 2)
-	symInFn.Add(eval.Tuple{eval.IntVal{10}, eval.IntVal{1}})
-	symInFn.Add(eval.Tuple{eval.IntVal{20}, eval.IntVal{1}})
+	symInFn.Add(eval.Tuple{eval.IntVal{V: 10}, eval.IntVal{V: 1}})
+	symInFn.Add(eval.Tuple{eval.IntVal{V: 20}, eval.IntVal{V: 1}})
 
 	// AdditionalTaintStep: 20 → 30 (crosses function boundary via user-defined step)
 	additionalStep := eval.NewRelation("AdditionalTaintStep", 2)
-	additionalStep.Add(eval.Tuple{eval.IntVal{20}, eval.IntVal{30}})
+	additionalStep.Add(eval.Tuple{eval.IntVal{V: 20}, eval.IntVal{V: 30}})
 
 	baseRels := compositionBaseRels(map[string]*eval.Relation{
 		"Assign":              assign,

--- a/extract/rules/composition_test.go
+++ b/extract/rules/composition_test.go
@@ -43,6 +43,9 @@ func compositionBaseRels(overrides map[string]*eval.Relation) map[string]*eval.R
 		// v3 Phase 3d: type-based sanitization
 		"SymbolType":       eval.NewRelation("SymbolType", 2),
 		"NonTaintableType": eval.NewRelation("NonTaintableType", 1),
+		// A3: additional taint/flow steps (default empty)
+		"AdditionalTaintStep": eval.NewRelation("AdditionalTaintStep", 2),
+		"AdditionalFlowStep":  eval.NewRelation("AdditionalFlowStep", 2),
 	}
 	for k, v := range overrides {
 		base[k] = v

--- a/extract/rules/composition_test.go
+++ b/extract/rules/composition_test.go
@@ -422,7 +422,7 @@ func TestAdditionalTaintStep_FlowStar(t *testing.T) {
 	}
 	found := false
 	for _, row := range rs.Rows {
-		if row[0] == eval.IntVal{10} && row[1] == eval.IntVal{20} {
+		if row[0] == (eval.IntVal{10}) && row[1] == (eval.IntVal{20}) {
 			found = true
 			break
 		}
@@ -450,7 +450,7 @@ func TestAdditionalFlowStep_FlowStar(t *testing.T) {
 	rs := planAndEval(t, allRulesForComposition(), query, baseRels)
 	found := false
 	for _, row := range rs.Rows {
-		if row[0] == eval.IntVal{30} && row[1] == eval.IntVal{40} {
+		if row[0] == (eval.IntVal{30}) && row[1] == (eval.IntVal{40}) {
 			found = true
 			break
 		}

--- a/extract/rules/composition_test.go
+++ b/extract/rules/composition_test.go
@@ -405,7 +405,7 @@ func TestEmptyRelationsNoFlowStar(t *testing.T) {
 // are lifted into FlowStar, enabling taint to propagate through user-defined steps.
 func TestAdditionalTaintStep_FlowStar(t *testing.T) {
 	additionalStep := eval.NewRelation("AdditionalTaintStep", 2)
-	additionalStep.Add(eval.IntVal(10), eval.IntVal(20))
+	additionalStep.Add(eval.Tuple{eval.IntVal(10), eval.IntVal(20)})
 
 	baseRels := compositionBaseRels(map[string]*eval.Relation{
 		"AdditionalTaintStep": additionalStep,
@@ -436,7 +436,7 @@ func TestAdditionalTaintStep_FlowStar(t *testing.T) {
 // are lifted into FlowStar.
 func TestAdditionalFlowStep_FlowStar(t *testing.T) {
 	additionalStep := eval.NewRelation("AdditionalFlowStep", 2)
-	additionalStep.Add(eval.IntVal(30), eval.IntVal(40))
+	additionalStep.Add(eval.Tuple{eval.IntVal(30), eval.IntVal(40)})
 
 	baseRels := compositionBaseRels(map[string]*eval.Relation{
 		"AdditionalFlowStep": additionalStep,
@@ -465,16 +465,16 @@ func TestAdditionalFlowStep_FlowStar(t *testing.T) {
 func TestAdditionalTaintStep_Transitivity(t *testing.T) {
 	// LocalFlow: 10 → 20 in fn=1
 	assign := eval.NewRelation("Assign", 3)
-	assign.Add(eval.IntVal(100), eval.IntVal(200), eval.IntVal(20)) // lhsNode=100, rhsExpr=200, lhsSym=20
+	assign.Add(eval.Tuple{eval.IntVal(100), eval.IntVal(200), eval.IntVal(20)}) // lhsNode=100, rhsExpr=200, lhsSym=20
 	exprMayRef := eval.NewRelation("ExprMayRef", 2)
-	exprMayRef.Add(eval.IntVal(200), eval.IntVal(10)) // rhsExpr=200 refers to sym 10
+	exprMayRef.Add(eval.Tuple{eval.IntVal(200), eval.IntVal(10)}) // rhsExpr=200 refers to sym 10
 	symInFn := eval.NewRelation("SymInFunction", 2)
-	symInFn.Add(eval.IntVal(10), eval.IntVal(1))
-	symInFn.Add(eval.IntVal(20), eval.IntVal(1))
+	symInFn.Add(eval.Tuple{eval.IntVal(10), eval.IntVal(1)})
+	symInFn.Add(eval.Tuple{eval.IntVal(20), eval.IntVal(1)})
 
 	// AdditionalTaintStep: 20 → 30 (crosses function boundary via user-defined step)
 	additionalStep := eval.NewRelation("AdditionalTaintStep", 2)
-	additionalStep.Add(eval.IntVal(20), eval.IntVal(30))
+	additionalStep.Add(eval.Tuple{eval.IntVal(20), eval.IntVal(30)})
 
 	baseRels := compositionBaseRels(map[string]*eval.Relation{
 		"Assign":              assign,

--- a/extract/rules/composition_test.go
+++ b/extract/rules/composition_test.go
@@ -344,11 +344,11 @@ func TestCompositionRulesStratify(t *testing.T) {
 	}
 }
 
-// TestCompositionRulesCount verifies we produce exactly 5 composition rules.
+// TestCompositionRulesCount verifies we produce exactly 7 composition rules.
 func TestCompositionRulesCount(t *testing.T) {
 	rules := CompositionRules()
-	if len(rules) != 5 {
-		t.Errorf("expected 5 composition rules, got %d", len(rules))
+	if len(rules) != 7 {
+		t.Errorf("expected 7 composition rules, got %d", len(rules))
 	}
 }
 
@@ -395,5 +395,107 @@ func TestEmptyRelationsNoFlowStar(t *testing.T) {
 	rs := planAndEval(t, allRulesForComposition(), query, baseRels)
 	if len(rs.Rows) != 0 {
 		t.Errorf("expected 0 FlowStar rows from empty relations, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestAdditionalTaintStep_FlowStar verifies that AdditionalTaintStep facts
+// are lifted into FlowStar, enabling taint to propagate through user-defined steps.
+func TestAdditionalTaintStep_FlowStar(t *testing.T) {
+	additionalStep := eval.NewRelation("AdditionalTaintStep", 2)
+	additionalStep.Add(eval.IntVal(10), eval.IntVal(20))
+
+	baseRels := compositionBaseRels(map[string]*eval.Relation{
+		"AdditionalTaintStep": additionalStep,
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("FlowStar", v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, allRulesForComposition(), query, baseRels)
+	if len(rs.Rows) == 0 {
+		t.Fatal("expected FlowStar rows from AdditionalTaintStep, got 0")
+	}
+	found := false
+	for _, row := range rs.Rows {
+		if row[0] == eval.IntVal(10) && row[1] == eval.IntVal(20) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("FlowStar should contain (10, 20) from AdditionalTaintStep; rows: %v", rs.Rows)
+	}
+}
+
+// TestAdditionalFlowStep_FlowStar verifies that AdditionalFlowStep facts
+// are lifted into FlowStar.
+func TestAdditionalFlowStep_FlowStar(t *testing.T) {
+	additionalStep := eval.NewRelation("AdditionalFlowStep", 2)
+	additionalStep.Add(eval.IntVal(30), eval.IntVal(40))
+
+	baseRels := compositionBaseRels(map[string]*eval.Relation{
+		"AdditionalFlowStep": additionalStep,
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("FlowStar", v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, allRulesForComposition(), query, baseRels)
+	found := false
+	for _, row := range rs.Rows {
+		if row[0] == eval.IntVal(30) && row[1] == eval.IntVal(40) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("FlowStar should contain (30, 40) from AdditionalFlowStep; rows: %v", rs.Rows)
+	}
+}
+
+// TestAdditionalTaintStep_Transitivity verifies that AdditionalTaintStep
+// composes with LocalFlowStar for transitive FlowStar.
+func TestAdditionalTaintStep_Transitivity(t *testing.T) {
+	// LocalFlow: 10 → 20 in fn=1
+	assign := eval.NewRelation("Assign", 3)
+	assign.Add(eval.IntVal(100), eval.IntVal(200), eval.IntVal(20)) // lhsNode=100, rhsExpr=200, lhsSym=20
+	exprMayRef := eval.NewRelation("ExprMayRef", 2)
+	exprMayRef.Add(eval.IntVal(200), eval.IntVal(10)) // rhsExpr=200 refers to sym 10
+	symInFn := eval.NewRelation("SymInFunction", 2)
+	symInFn.Add(eval.IntVal(10), eval.IntVal(1))
+	symInFn.Add(eval.IntVal(20), eval.IntVal(1))
+
+	// AdditionalTaintStep: 20 → 30 (crosses function boundary via user-defined step)
+	additionalStep := eval.NewRelation("AdditionalTaintStep", 2)
+	additionalStep.Add(eval.IntVal(20), eval.IntVal(30))
+
+	baseRels := compositionBaseRels(map[string]*eval.Relation{
+		"Assign":              assign,
+		"ExprMayRef":          exprMayRef,
+		"SymInFunction":       symInFn,
+		"AdditionalTaintStep": additionalStep,
+	})
+
+	query := &datalog.Query{
+		Select: []datalog.Term{v("src"), v("dst")},
+		Body:   []datalog.Literal{pos("FlowStar", v("src"), v("dst"))},
+	}
+
+	rs := planAndEval(t, allRulesForComposition(), query, baseRels)
+	// Should have: 10→20 (local), 20→30 (additional), 10→30 (transitive)
+	flowPairs := make(map[[2]int]bool)
+	for _, row := range rs.Rows {
+		src, _ := row[0].(eval.IntVal)
+		dst, _ := row[1].(eval.IntVal)
+		flowPairs[[2]int{int(src), int(dst)}] = true
+	}
+	for _, pair := range [][2]int{{10, 20}, {20, 30}, {10, 30}} {
+		if !flowPairs[pair] {
+			t.Errorf("expected FlowStar(%d, %d) from local + additional step transitivity", pair[0], pair[1])
+		}
 	}
 }

--- a/extract/schema/relations.go
+++ b/extract/schema/relations.go
@@ -344,6 +344,16 @@ func init() {
 		{Name: "sinkKind", Type: TypeString},
 	}})
 
+	// v2 Phase A3: additional taint/flow steps (populated by user Configuration overrides)
+	RegisterRelation(RelationDef{Name: "AdditionalTaintStep", Version: 2, Columns: []ColumnDef{
+		{Name: "srcSym", Type: TypeEntityRef},
+		{Name: "dstSym", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "AdditionalFlowStep", Version: 2, Columns: []ColumnDef{
+		{Name: "srcSym", Type: TypeEntityRef},
+		{Name: "dstSym", Type: TypeEntityRef},
+	}})
+
 	// v2 Phase F: framework-derived relations
 	RegisterRelation(RelationDef{Name: "ExpressHandler", Version: 2, Columns: []ColumnDef{
 		{Name: "fnId", Type: TypeEntityRef},

--- a/extract/schema/relations_test.go
+++ b/extract/schema/relations_test.go
@@ -49,8 +49,8 @@ func TestAllRelationsRegistered(t *testing.T) {
 }
 
 func TestRelationCount(t *testing.T) {
-	if len(Registry) != 91 {
-		t.Fatalf("expected 91 relations in registry, got %d", len(Registry))
+	if len(Registry) != 93 {
+		t.Fatalf("expected 93 relations in registry, got %d", len(Registry))
 	}
 }
 

--- a/stdlib_coverage_test.go
+++ b/stdlib_coverage_test.go
@@ -155,6 +155,10 @@ var stdlibCoverageAllowlist = map[string]string{
 	"RegExpLiteral": "stub — regex literal analysis deferred; requires AST regex parsing",
 	"RegExpTerm":    "stub — regex term analysis deferred; requires regex parse tree",
 
+	// A3: Additional taint/flow step materializers — populated by Configuration overrides.
+	"AdditionalTaintStep": "materializer from TaintTracking::Configuration.isAdditionalTaintStep",
+	"AdditionalFlowStep":  "materializer from DataFlow::Configuration.isAdditionalFlowStep",
+
 	// Taint relations — some used in queries but as predicates, not class refs.
 	"TaintSink":     "internal taint plumbing",
 	"TaintSource":   "used as predicate in queries, not as class",


### PR DESCRIPTION
## Summary
- Adds `AdditionalTaintStep(src, dst)` and `AdditionalFlowStep(src, dst)` relations to the schema
- Extends FlowStar with rules 6 and 7 that lift these relations into the global flow graph
- Adds bridge materializer predicates that aggregate user-defined additional steps from all Configuration subclass instances
- User `TaintTracking::Configuration.isAdditionalTaintStep()` and `DataFlow::Configuration.isAdditionalFlowStep()` overrides now affect system-level taint propagation (TaintedSym/TaintAlert), not just the Configuration's own `hasFlow` method

## Test plan
- [x] Unit tests for AdditionalTaintStep → FlowStar direct integration
- [x] Unit tests for AdditionalFlowStep → FlowStar direct integration
- [x] Transitivity test: LocalFlow + AdditionalTaintStep composes through FlowStar
- [x] Schema count updated (87 → 89)
- [x] Composition rules count updated (5 → 7)
- [ ] CI passes (tests + lint)