### PR TITLE
C3/C4/C6: Decorator, namespace, and type guard extraction

### DIFF
--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -147,6 +147,13 @@ func v2Manifest() *CapabilityManifest {
 			// C5: Optional chaining and nullish coalescing
 			{Name: "OptionalChain", Relation: "OptionalChain", File: "tsq_expressions.qll"},
 			{Name: "NullishCoalescing", Relation: "NullishCoalescing", File: "tsq_expressions.qll"},
+			// C3: Decorator extraction
+			{Name: "Decorator", Relation: "Decorator", File: "tsq_types.qll"},
+			// C4: Namespace/module declaration extraction
+			{Name: "NamespaceDecl", Relation: "NamespaceDecl", File: "tsq_types.qll"},
+			{Name: "NamespaceMember", Relation: "NamespaceMember", File: "tsq_types.qll"},
+			// C6: TypeScript type guards and assertion functions
+			{Name: "TypeGuard", Relation: "TypeGuard", File: "tsq_functions.qll"},
 			// v2 Phase 2b: CodeQL-compatible DataFlow module
 			{Name: "DataFlow::Node", Relation: "Symbol", File: "compat_dataflow.qll"},
 			{Name: "DataFlow::PathNode", Relation: "Symbol", File: "compat_dataflow.qll"},

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -15,8 +15,9 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	// Phase 2: +7 DOM/crypto/framework stubs + 1 ExprInFunction = 100
 	// Batch 2 Phase 2: +3 template + 2 enum + 2 optional/nullish = 107
 	// Phase E: +3 HTTP + 2 IO + 2 RegExp = 114
-	if got := len(m.Available); got != 114 {
-		t.Errorf("expected 114 available classes, got %d", got)
+	// C3/C4/C6: +1 Decorator + 2 Namespace + 1 TypeGuard = 118
+	if got := len(m.Available); got != 118 {
+		t.Errorf("expected 118 available classes, got %d", got)
 	}
 }
 

--- a/extract/schema/relations.go
+++ b/extract/schema/relations.go
@@ -446,6 +446,30 @@ func init() {
 		{Name: "rhs", Type: TypeEntityRef},
 	}})
 
+	// C3: Decorator extraction
+	RegisterRelation(RelationDef{Name: "Decorator", Version: 2, Columns: []ColumnDef{
+		{Name: "targetId", Type: TypeEntityRef},
+		{Name: "decoratorExpr", Type: TypeEntityRef},
+	}})
+
+	// C4: Namespace/module declaration extraction
+	RegisterRelation(RelationDef{Name: "NamespaceDecl", Version: 2, Columns: []ColumnDef{
+		{Name: "id", Type: TypeEntityRef},
+		{Name: "name", Type: TypeString},
+		{Name: "file", Type: TypeEntityRef},
+	}})
+	RegisterRelation(RelationDef{Name: "NamespaceMember", Version: 2, Columns: []ColumnDef{
+		{Name: "nsId", Type: TypeEntityRef},
+		{Name: "memberId", Type: TypeEntityRef},
+	}})
+
+	// C6: TypeScript type guards and assertion functions
+	RegisterRelation(RelationDef{Name: "TypeGuard", Version: 2, Columns: []ColumnDef{
+		{Name: "fnId", Type: TypeEntityRef},
+		{Name: "paramIdx", Type: TypeInt32},
+		{Name: "narrowedType", Type: TypeString},
+	}})
+
 	// Diagnostics
 	RegisterRelation(RelationDef{Name: "ExtractError", Version: 1, Columns: []ColumnDef{
 		{Name: "file", Type: TypeEntityRef},

--- a/extract/schema/relations_test.go
+++ b/extract/schema/relations_test.go
@@ -28,6 +28,12 @@ func TestAllRelationsRegistered(t *testing.T) {
 		"EnumDecl", "EnumMember",
 		// C5: Optional chaining and nullish coalescing
 		"OptionalChain", "NullishCoalescing",
+		// C3: Decorator extraction
+		"Decorator",
+		// C4: Namespace/module declaration extraction
+		"NamespaceDecl", "NamespaceMember",
+		// C6: TypeScript type guards and assertion functions
+		"TypeGuard",
 		"ExtractError", "SchemaVersion",
 	}
 	for _, name := range expected {
@@ -43,8 +49,8 @@ func TestAllRelationsRegistered(t *testing.T) {
 }
 
 func TestRelationCount(t *testing.T) {
-	if len(Registry) != 87 {
-		t.Fatalf("expected 87 relations in registry, got %d", len(Registry))
+	if len(Registry) != 91 {
+		t.Fatalf("expected 91 relations in registry, got %d", len(Registry))
 	}
 }
 

--- a/extract/walker_v2.go
+++ b/extract/walker_v2.go
@@ -40,6 +40,13 @@ type TypeAwareWalker struct {
 
 	// nsStack tracks the current namespace/module node IDs for NamespaceMember.
 	nsStack []uint32
+
+	// declStack tracks the current declaration node ID for decorator target resolution.
+	// Pushed on entering any node that can be decorated (class, method, property, accessor).
+	declStack []uint32
+
+	// fnNodeMap maps function node IDs to their ASTNode for parameter resolution.
+	fnNodeMap map[uint32]ASTNode
 }
 
 // NewTypeAwareWalker creates a TypeAwareWalker wrapping the given FactWalker.
@@ -47,6 +54,7 @@ func NewTypeAwareWalker(database *db.DB) *TypeAwareWalker {
 	return &TypeAwareWalker{
 		fw:            NewFactWalker(database),
 		tsgoAvailable: false,
+		fnNodeMap:     make(map[uint32]ASTNode),
 	}
 }
 
@@ -66,6 +74,7 @@ func (tw *TypeAwareWalker) EnterFile(path string) error {
 	tw.fnStack = tw.fnStack[:0]
 	tw.classOrIfaceStack = tw.classOrIfaceStack[:0]
 	tw.nsStack = tw.nsStack[:0]
+	tw.declStack = tw.declStack[:0]
 	return tw.fw.EnterFile(path)
 }
 
@@ -110,6 +119,16 @@ func (tw *TypeAwareWalker) Leave(node ASTNode) error {
 		}
 	}
 
+	// Pop declaration stack (decorator targets)
+	switch kind {
+	case "ClassDeclaration", "AbstractClassDeclaration", "ClassExpression",
+		"MethodDefinition", "PublicFieldDefinition", "PropertyDefinition",
+		"GetAccessor", "SetAccessor":
+		if len(tw.declStack) > 0 {
+			tw.declStack = tw.declStack[:len(tw.declStack)-1]
+		}
+	}
+
 	return tw.fw.Leave(node)
 }
 
@@ -136,6 +155,14 @@ func (tw *TypeAwareWalker) emitV2Facts(node ASTNode) {
 		}
 		tw.pushFunction(node, id)
 	}
+	// Track declaration-like nodes that can be decorator targets.
+	switch kind {
+	case "ClassDeclaration", "AbstractClassDeclaration", "ClassExpression",
+		"MethodDefinition", "PublicFieldDefinition", "PropertyDefinition",
+		"GetAccessor", "SetAccessor":
+		tw.declStack = append(tw.declStack, id)
+	}
+
 	switch kind {
 	case "ClassDeclaration", "AbstractClassDeclaration", "ClassExpression":
 		tw.emitClassDecl(node, id)
@@ -338,6 +365,7 @@ func (tw *TypeAwareWalker) emitInterfaceDecl(node ASTNode, id uint32) {
 // pushFunction pushes a function onto the function stack and emits v2 Symbol-related facts.
 func (tw *TypeAwareWalker) pushFunction(node ASTNode, id uint32) {
 	tw.fnStack = append(tw.fnStack, id)
+	tw.fnNodeMap[id] = node
 
 	kind := node.Kind()
 	// Emit FunctionSymbol for named functions
@@ -798,13 +826,14 @@ func (tw *TypeAwareWalker) emitDecorator(node ASTNode, id uint32) {
 		decoratorExprID = tw.fw.nid(child)
 		break
 	}
-	// The target is the class/interface/method that contains this decorator;
-	// use the top of the class stack if available, otherwise use parent context.
+	// The target is the decorated declaration (class, method, property).
+	// In tree-sitter, the decorator is a child of the declaration it decorates.
+	// We use declStack which tracks the enclosing declaration node.
 	var targetID uint32
-	if len(tw.classOrIfaceStack) > 0 {
-		targetID = tw.classOrIfaceStack[len(tw.classOrIfaceStack)-1]
+	if len(tw.declStack) > 0 {
+		targetID = tw.declStack[len(tw.declStack)-1]
 	} else {
-		// Fallback: emit with the decorator node itself as target so the row is still useful.
+		// Fallback: emit with the decorator node itself as target.
 		targetID = id
 	}
 	tw.fw.emit("Decorator", targetID, decoratorExprID)
@@ -864,6 +893,11 @@ func (tw *TypeAwareWalker) emitNamespaceDecl(node ASTNode, id uint32) {
 			if k == "{" || k == "}" || k == ";" {
 				continue
 			}
+			// Skip nested namespace declarations — they emit their own
+			// NamespaceMember via the nsStack check when they're visited.
+			if k == "ModuleDeclaration" || k == "InternalModule" {
+				continue
+			}
 			memberID := tw.fw.nid(child)
 			tw.fw.emit("NamespaceMember", id, memberID)
 		}
@@ -920,7 +954,13 @@ func (tw *TypeAwareWalker) emitTypeGuard(node ASTNode, id uint32) {
 	}
 
 	if hasAsserts {
-		narrowedType = "asserts"
+		if narrowedType != "" {
+			// asserts x is T → preserve both the assertion and the narrowed type
+			narrowedType = "asserts " + narrowedType
+		} else {
+			// asserts x (no is T) → just the assertion marker
+			narrowedType = "asserts"
+		}
 	}
 
 	// Find the parameter index by matching paramName to the enclosing function's parameters.
@@ -937,12 +977,52 @@ func (tw *TypeAwareWalker) emitTypeGuard(node ASTNode, id uint32) {
 	}
 }
 
-// resolveParamIdx attempts to find the parameter index matching paramName
-// in the enclosing function by scanning the scope. Returns 0 as fallback.
-func (tw *TypeAwareWalker) resolveParamIdx(_ uint32, _ string) int32 {
-	// Structural resolution without a full parameter map is complex.
-	// Return 0 as a conservative fallback — the TypeGuard row is still
-	// emitted with the correct narrowedType, which is the primary value.
+// resolveParamIdx finds the parameter index matching paramName in the
+// enclosing function by scanning the function node's formal parameters.
+// Returns 0 as fallback if the function node or parameter can't be found.
+func (tw *TypeAwareWalker) resolveParamIdx(fnID uint32, paramName string) int32 {
+	// Look up the function node from the fnNodeMap.
+	fnNode, ok := tw.fnNodeMap[fnID]
+	if !ok {
+		return 0
+	}
+	// Find FormalParameters child.
+	params := childByKind(fnNode, "FormalParameters")
+	if params == nil {
+		return 0
+	}
+	idx := int32(0)
+	count := params.ChildCount()
+	for i := 0; i < count; i++ {
+		child := params.Child(i)
+		if child == nil {
+			continue
+		}
+		k := child.Kind()
+		if k == "(" || k == ")" || k == "," {
+			continue
+		}
+		// The parameter might be a RequiredParameter, OptionalParameter, or Identifier.
+		name := ""
+		if nameNode := childByField(child, "pattern"); nameNode != nil {
+			name = nameNode.Text()
+		} else if k == "Identifier" {
+			name = child.Text()
+		} else {
+			// Try first Identifier child.
+			for j := 0; j < child.ChildCount(); j++ {
+				gc := child.Child(j)
+				if gc != nil && gc.Kind() == "Identifier" {
+					name = gc.Text()
+					break
+				}
+			}
+		}
+		if name == paramName {
+			return idx
+		}
+		idx++
+	}
 	return 0
 }
 

--- a/extract/walker_v2.go
+++ b/extract/walker_v2.go
@@ -37,6 +37,9 @@ type TypeAwareWalker struct {
 	// When false, ExprType and SymbolType relations are left empty (tsgo-dependent).
 	// Structural type relations (TypeInfo, UnionMember, etc.) are always populated from AST.
 	tsgoAvailable bool
+
+	// nsStack tracks the current namespace/module node IDs for NamespaceMember.
+	nsStack []uint32
 }
 
 // NewTypeAwareWalker creates a TypeAwareWalker wrapping the given FactWalker.
@@ -62,6 +65,7 @@ func (tw *TypeAwareWalker) Run(ctx context.Context, backend ExtractorBackend, cf
 func (tw *TypeAwareWalker) EnterFile(path string) error {
 	tw.fnStack = tw.fnStack[:0]
 	tw.classOrIfaceStack = tw.classOrIfaceStack[:0]
+	tw.nsStack = tw.nsStack[:0]
 	return tw.fw.EnterFile(path)
 }
 
@@ -99,6 +103,10 @@ func (tw *TypeAwareWalker) Leave(node ASTNode) error {
 	case "InterfaceDeclaration":
 		if len(tw.classOrIfaceStack) > 0 {
 			tw.classOrIfaceStack = tw.classOrIfaceStack[:len(tw.classOrIfaceStack)-1]
+		}
+	case "ModuleDeclaration", "InternalModule":
+		if len(tw.nsStack) > 0 {
+			tw.nsStack = tw.nsStack[:len(tw.nsStack)-1]
 		}
 	}
 
@@ -159,6 +167,12 @@ func (tw *TypeAwareWalker) emitV2Facts(node ASTNode) {
 		tw.emitGenericType(node, id)
 	case "TypeParameter":
 		tw.emitTypeParameter(node, id)
+	case "Decorator":
+		tw.emitDecorator(node, id)
+	case "ModuleDeclaration", "InternalModule":
+		tw.emitNamespaceDecl(node, id)
+	case "TypePredicate", "PredicateType":
+		tw.emitTypeGuard(node, id)
 	}
 
 	// FunctionContains: any node inside a function body. Function nodes
@@ -764,6 +778,172 @@ func (tw *TypeAwareWalker) emitNullishCoalescing(node ASTNode, id uint32) {
 		rightID = tw.fw.nid(rightNode)
 	}
 	tw.fw.emit("NullishCoalescing", id, leftID, rightID)
+}
+
+// emitDecorator emits Decorator(targetId, decoratorExpr) for decorator nodes.
+// In tree-sitter TypeScript, Decorator nodes appear as children of class declarations,
+// method definitions, and property declarations. The decorator's parent is the target.
+func (tw *TypeAwareWalker) emitDecorator(node ASTNode, id uint32) {
+	// The decorator's expression is the first child after the '@' token.
+	var decoratorExprID uint32
+	count := node.ChildCount()
+	for i := 0; i < count; i++ {
+		child := node.Child(i)
+		if child == nil {
+			continue
+		}
+		if child.Text() == "@" {
+			continue
+		}
+		decoratorExprID = tw.fw.nid(child)
+		break
+	}
+	// The target is the class/interface/method that contains this decorator;
+	// use the top of the class stack if available, otherwise use parent context.
+	var targetID uint32
+	if len(tw.classOrIfaceStack) > 0 {
+		targetID = tw.classOrIfaceStack[len(tw.classOrIfaceStack)-1]
+	} else {
+		// Fallback: emit with the decorator node itself as target so the row is still useful.
+		targetID = id
+	}
+	tw.fw.emit("Decorator", targetID, decoratorExprID)
+}
+
+// emitNamespaceDecl emits NamespaceDecl and NamespaceMember for TypeScript namespace/module declarations.
+// Handles ModuleDeclaration (namespace Foo {}) and InternalModule variants.
+func (tw *TypeAwareWalker) emitNamespaceDecl(node ASTNode, id uint32) {
+	name := ""
+	if nameNode := childByField(node, "name"); nameNode != nil {
+		name = nameNode.Text()
+	} else {
+		// Fallback: find first string or identifier child
+		count := node.ChildCount()
+		for i := 0; i < count; i++ {
+			child := node.Child(i)
+			if child == nil {
+				continue
+			}
+			k := child.Kind()
+			if k == "namespace" || k == "module" || k == "declare" {
+				continue
+			}
+			if k == "Identifier" || k == "String" || k == "StringFragment" {
+				name = child.Text()
+				break
+			}
+		}
+	}
+	tw.fw.emit("NamespaceDecl", id, name, tw.fw.fileID)
+
+	// If nested inside another namespace, emit NamespaceMember
+	if len(tw.nsStack) > 0 {
+		parentNS := tw.nsStack[len(tw.nsStack)-1]
+		tw.fw.emit("NamespaceMember", parentNS, id)
+	}
+
+	// Push onto namespace stack for children
+	tw.nsStack = append(tw.nsStack, id)
+
+	// Emit NamespaceMember for direct children in the body
+	bodyNode := childByField(node, "body")
+	if bodyNode == nil {
+		bodyNode = childByKind(node, "StatementBlock")
+		if bodyNode == nil {
+			bodyNode = childByKind(node, "NamespaceBody")
+		}
+	}
+	if bodyNode != nil {
+		count := bodyNode.ChildCount()
+		for i := 0; i < count; i++ {
+			child := bodyNode.Child(i)
+			if child == nil {
+				continue
+			}
+			k := child.Kind()
+			if k == "{" || k == "}" || k == ";" {
+				continue
+			}
+			memberID := tw.fw.nid(child)
+			tw.fw.emit("NamespaceMember", id, memberID)
+		}
+	}
+}
+
+// emitTypeGuard emits TypeGuard(fnId, paramIdx, narrowedType) for type predicate return types.
+// Handles `x is T` (TypePredicate) and `asserts x` patterns in function return annotations.
+func (tw *TypeAwareWalker) emitTypeGuard(node ASTNode, id uint32) {
+	if len(tw.fnStack) == 0 {
+		return
+	}
+	fnID := tw.fnStack[len(tw.fnStack)-1]
+
+	// Parse the TypePredicate / PredicateType node.
+	// For `x is T`: children are [paramName, "is", type]
+	// For `asserts x`: children are ["asserts", paramName]
+	count := node.ChildCount()
+
+	// Check for "asserts" pattern
+	hasAsserts := false
+	paramName := ""
+	narrowedType := ""
+
+	for i := 0; i < count; i++ {
+		child := node.Child(i)
+		if child == nil {
+			continue
+		}
+		text := child.Text()
+		k := child.Kind()
+		if text == "asserts" {
+			hasAsserts = true
+			continue
+		}
+		if text == "is" {
+			continue
+		}
+		if k == "Identifier" || k == "TypeIdentifier" {
+			if paramName == "" && !hasAsserts {
+				paramName = text
+			} else if paramName == "" && hasAsserts {
+				paramName = text
+			} else {
+				// This is the narrowed type
+				narrowedType = text
+			}
+		} else if k != "{" && k != "}" {
+			// Could be a complex type node
+			if narrowedType == "" && paramName != "" {
+				narrowedType = text
+			}
+		}
+	}
+
+	if hasAsserts {
+		narrowedType = "asserts"
+	}
+
+	// Find the parameter index by matching paramName to the enclosing function's parameters.
+	paramIdx := int32(0)
+	if paramName != "" {
+		// Walk the function node's parameters to find the matching index.
+		// fnStack holds IDs — look up the function node via the current context.
+		// We emit with index 0 as fallback if we can't resolve.
+		paramIdx = tw.resolveParamIdx(fnID, paramName)
+	}
+
+	if narrowedType != "" || hasAsserts {
+		tw.fw.emit("TypeGuard", fnID, paramIdx, narrowedType)
+	}
+}
+
+// resolveParamIdx attempts to find the parameter index matching paramName
+// in the enclosing function by scanning the scope. Returns 0 as fallback.
+func (tw *TypeAwareWalker) resolveParamIdx(_ uint32, _ string) int32 {
+	// Structural resolution without a full parameter map is complex.
+	// Return 0 as a conservative fallback — the TypeGuard row is still
+	// emitted with the correct narrowedType, which is the primary value.
+	return 0
 }
 
 // emitSymInFunction emits SymInFunction when an identifier reference appears inside a function.

--- a/stdlib_coverage_test.go
+++ b/stdlib_coverage_test.go
@@ -132,6 +132,16 @@ var stdlibCoverageAllowlist = map[string]string{
 	"OptionalChain":     "optional chaining expression; not queried directly",
 	"NullishCoalescing": "nullish coalescing expression; not queried directly",
 
+	// C3: Decorator extraction
+	"Decorator": "decorator structural extraction; not queried directly in compat tests",
+
+	// C4: Namespace/module declaration extraction
+	"NamespaceDecl":   "namespace declaration; not queried directly in compat tests",
+	"NamespaceMember": "namespace member; not queried directly in compat tests",
+
+	// C6: TypeScript type guards and assertion functions
+	"TypeGuard": "type guard/assertion function; not queried directly in compat tests",
+
 	// HTTP abstraction layer stubs — framework-agnostic HTTP classes.
 	"HTTP::RequestHandler": "abstract HTTP handler; queried via framework-specific handlers",
 	"HTTP::ServerRequest":  "server request parameter; queried via framework queries",


### PR DESCRIPTION
## Summary
- **C3 Decorators**: Extract `Decorator(targetId, decoratorExpr)` for class, method, and property decorators. Uses `declStack` to correctly resolve decorator targets at all levels (not just class-level).
- **C4 Namespaces**: Extract `NamespaceDecl(id, name, file)` and `NamespaceMember(nsId, memberId)` for TypeScript namespace/module declarations. Handles nesting via `nsStack` without duplicate emission.
- **C6 Type Guards**: Extract `TypeGuard(fnId, paramIdx, narrowedType)` for `x is T` and `asserts x` return type annotations. Parameter index resolution via function node parameter scanning. `asserts x is T` preserves the narrowed type.
- Schema 87→91, manifest 114→118

## Test plan
- [x] Schema count updated and passing
- [x] Manifest count updated and passing  
- [x] Stdlib coverage allowlist updated
- [x] Adversarial review: 4 MEDIUM issues fixed (decorator target, paramIdx, asserts narrowedType, duplicate NamespaceMember)
- [ ] CI passes