### PR TITLE
Fix missing semmle.* import paths in CLI and test loaders

### DIFF
--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -595,6 +595,12 @@ func makeBridgeImportLoader(bridgeFiles map[string][]byte) func(path string) (*a
 		"semmle.javascript.security.dataflow.CommandInjectionQuery": "compat_security_cmdi.qll",
 		"semmle.javascript.security.dataflow.SqlInjectionQuery":     "compat_security_sqli.qll",
 		"semmle.javascript.security.dataflow.PathTraversalQuery":    "compat_security_pathtraversal.qll",
+		"semmle.javascript.security.dataflow.DomBasedXssQuery":      "compat_dom.qll",
+		"semmle.javascript.security.CryptoLibraries":                "compat_crypto.qll",
+		"semmle.javascript.frameworks.HTTP":                         "compat_http.qll",
+		"semmle.javascript.security.dataflow.DatabaseAccess":        "compat_io.qll",
+		"semmle.javascript.security.dataflow.FileSystemAccess":      "compat_io.qll",
+		"semmle.javascript.security.dataflow.RegExpInjectionQuery":  "compat_regexp.qll",
 	}
 	return func(path string) (*ast.Module, error) {
 		filename, ok := pathToFile[path]

--- a/compat_test.go
+++ b/compat_test.go
@@ -26,11 +26,19 @@ import (
 func makeCompatImportLoader(bridgeFiles map[string][]byte) func(string) (*ast.Module, error) {
 	pathToFile := map[string]string{
 		// CodeQL-compat paths
-		"javascript":                                            "compat_javascript.qll",
-		"DataFlow::PathGraph":                                   "compat_dataflow.qll",
-		"TaintTracking::PathGraph":                              "compat_tainttracking.qll",
-		"semmle.javascript.security.dataflow.XssQuery":          "compat_security_xss.qll",
-		"semmle.javascript.security.dataflow.SqlInjectionQuery": "compat_security_sqli.qll",
+		"javascript":                                                "compat_javascript.qll",
+		"DataFlow::PathGraph":                                       "compat_dataflow.qll",
+		"TaintTracking::PathGraph":                                  "compat_tainttracking.qll",
+		"semmle.javascript.security.dataflow.XssQuery":              "compat_security_xss.qll",
+		"semmle.javascript.security.dataflow.SqlInjectionQuery":     "compat_security_sqli.qll",
+		"semmle.javascript.security.dataflow.CommandInjectionQuery": "compat_security_cmdi.qll",
+		"semmle.javascript.security.dataflow.PathTraversalQuery":    "compat_security_pathtraversal.qll",
+		"semmle.javascript.security.dataflow.DomBasedXssQuery":      "compat_dom.qll",
+		"semmle.javascript.security.CryptoLibraries":                "compat_crypto.qll",
+		"semmle.javascript.frameworks.HTTP":                         "compat_http.qll",
+		"semmle.javascript.security.dataflow.DatabaseAccess":        "compat_io.qll",
+		"semmle.javascript.security.dataflow.FileSystemAccess":      "compat_io.qll",
+		"semmle.javascript.security.dataflow.RegExpInjectionQuery":  "compat_regexp.qll",
 
 		// tsq:: internal paths
 		"tsq::base":        "tsq_base.qll",


### PR DESCRIPTION
## Summary
- `embed.go`'s `ImportLoader` had 6 new compat entries added in PR #61 (DOM XSS, crypto, HTTP frameworks, database/filesystem access, regexp injection) that were never mirrored into the CLI's `makeBridgeImportLoader` or `compat_test.go`'s `makeCompatImportLoader`
- Any query importing `semmle.javascript.frameworks.HTTP`, `semmle.javascript.security.CryptoLibraries`, etc. through the CLI would fail with `unknown import`
- Also adds missing `CommandInjectionQuery` and `PathTraversalQuery` entries to `compat_test.go`

## Test plan
- [ ] All 17 test packages pass
- [ ] Verify `makeBridgeImportLoader` map matches `embed.go`'s `ImportLoader` map