### PR TITLE
Add implementation plans 18-23 for remaining gaps

### DIFF
--- a/docs/impl-plans/18-sanitizer-function-symbol.md
+++ b/docs/impl-plans/18-sanitizer-function-symbol.md
@@ -1,0 +1,53 @@
+# Plan 18 — FunctionSymbol for Import Bindings (Sanitizer Fix)
+
+**Status:** not started
+**Phase:** Fixes sanitizer pipeline (blocking E2E sanitizer-bypass test)
+**Dependencies:** none
+
+## Problem
+
+`Sanitizer(fn, kind)` is derived from `ImportBinding(localSym, module, name)` +
+`FunctionSymbol(localSym, fn)`. However, `FunctionSymbol` is only emitted for
+locally-defined functions (arrow functions and function expressions assigned to
+variables). Import bindings like `const escapeHtml = require('escape-html')` or
+`import escapeHtml from 'escape-html'` never produce `FunctionSymbol` facts.
+
+Result: the `Sanitizer` relation is always empty, `SanitizedEdge` never fires,
+and all taint flows through sanitizer calls unchecked.
+
+## Scope
+
+Extend `FunctionSymbol` emission in the extraction pipeline so that:
+
+1. CJS default imports: `const x = require('mod')` → `FunctionSymbol(sym(x), fn_id)`
+2. CJS named imports: `const { escape } = require('sqlstring')` → `FunctionSymbol(sym(escape), fn_id)`
+3. ESM default imports: `import x from 'mod'` → `FunctionSymbol(sym(x), fn_id)`
+4. ESM named imports: `import { escape } from 'mod'` → `FunctionSymbol(sym(escape), fn_id)`
+
+The `fn_id` for imported functions should be a synthetic ID derived from the
+import binding, since there is no local function definition to reference.
+
+## Files to modify
+
+- `extract/walker.go` or `extract/type_aware_walker.go` — add FunctionSymbol
+  emission for import bindings during extraction
+- `extract/rules/frameworks.go` — verify sanitizer rules work once FunctionSymbol
+  is populated (may need no changes)
+
+## Acceptance criteria
+
+- `go test -run TestCompat/sanitizer_bypass -update` produces a golden with
+  fewer rows (routes 2 and 5 should no longer alert)
+- Existing tests still pass
+- Add a unit test in `extract/` that verifies FunctionSymbol is emitted for
+  each import pattern
+
+## Verification
+
+After implementing, regenerate the sanitizer-bypass golden:
+```bash
+go test -run TestCompat/sanitizer_bypass -update -count=1 ./...
+git diff testdata/compat/expected/find_sanitizer_bypass.csv
+```
+
+The diff should show routes with correct-kind sanitizers disappearing from the golden.

--- a/docs/impl-plans/19-command-injection-sinks.md
+++ b/docs/impl-plans/19-command-injection-sinks.md
@@ -1,0 +1,36 @@
+# Plan 19 — Command Injection Sink Extraction
+
+**Status:** not started
+**Phase:** Extends taint sink coverage
+**Dependencies:** Plan 18 (FunctionSymbol for imports — needed for destructured imports)
+
+## Problem
+
+`command_injection` sinks are defined in `extract/rules/frameworks.go` but
+require `FunctionSymbol` resolution through destructured imports like
+`const { exec } = require('child_process')`. Since FunctionSymbol is not
+emitted for import bindings (Plan 18), these sinks never fire.
+
+## Scope
+
+Once Plan 18 lands, verify that command injection sinks work for:
+
+1. `const { exec } = require('child_process'); exec(tainted)` → sink
+2. `const { execSync } = require('child_process'); execSync(tainted)` → sink
+3. `const { spawn } = require('child_process'); spawn(tainted)` → sink
+4. `const cp = require('child_process'); cp.exec(tainted)` → sink (method call pattern)
+
+Pattern 4 may require additional work: `MethodCall` + `ImportBinding` join
+rather than `FunctionSymbol`.
+
+## Files to modify
+
+- `extract/rules/frameworks.go` — verify/extend command injection rules
+- `testdata/compat/projects/multi-vuln/` — update golden if cmd injection
+  sinks start firing
+
+## Acceptance criteria
+
+- Multi-vuln golden includes `command_injection` sink kind for exec calls
+- Add a targeted compat test: `find_cmdi.ql` with a fixture containing
+  child_process usage patterns

--- a/docs/impl-plans/20-path-traversal-sinks.md
+++ b/docs/impl-plans/20-path-traversal-sinks.md
@@ -1,0 +1,37 @@
+# Plan 20 — Path Traversal Sink Extraction
+
+**Status:** not started
+**Phase:** Extends taint sink coverage
+**Dependencies:** Plan 18 (FunctionSymbol for imports)
+
+## Problem
+
+No extraction rule exists for `path_traversal` sinks. The `frameworks.go`
+file defines sanitizer rules for command injection and SQL injection but has
+no `TaintSink` rules for file system operations.
+
+## Scope
+
+Add `TaintSink(expr, "path_traversal")` rules for:
+
+1. `fs.readFile(path)` — first argument
+2. `fs.readFileSync(path)` — first argument
+3. `fs.writeFile(path, data)` — first argument
+4. `fs.writeFileSync(path, data)` — first argument
+5. `fs.unlink(path)` — first argument
+6. `fs.access(path)` — first argument
+7. `path.join(...)` when result flows to fs operations (transitive — may be
+   covered by FlowStar once the direct sinks are defined)
+
+These require matching `ImportBinding` for the `fs` module and `MethodCall`
+for the specific method.
+
+## Files to modify
+
+- `extract/rules/frameworks.go` — add path traversal sink rules
+- Add corresponding sanitizer rules for `path.normalize`, `path.resolve`
+
+## Acceptance criteria
+
+- Multi-vuln golden includes `path_traversal` sink kind for fs.readFile calls
+- Targeted compat test with fs operations

--- a/docs/impl-plans/21-field-sensitive-taint.md
+++ b/docs/impl-plans/21-field-sensitive-taint.md
@@ -1,0 +1,61 @@
+# Plan 21 — Field-Sensitive Taint Chaining (Rule 6b)
+
+**Status:** not started
+**Phase:** Improves taint precision
+**Dependencies:** none
+
+## Problem
+
+Rule 6b in `extract/rules/taint.go` chains taint through `VarDecl` assignments:
+when `const q = req.query`, `q` becomes tainted. However, `req.query.id`
+produces a `FieldRead` expression, not a `VarDecl`, so
+`const id = req.query.id` does not chain taint to `id`.
+
+This forces all fixtures to use `const q = req.query` (whole-object access)
+instead of the more realistic `const id = req.query.id` (field access).
+
+## Scope
+
+Extend taint propagation so that:
+
+1. `const x = req.query.id` — FieldRead on a tainted base taints `x`
+2. `const { id } = req.query` — destructuring a tainted object taints `id`
+3. `obj.field = tainted; use(obj.field)` — field write + read propagation
+4. `const { a, b } = req.body` — multiple destructured bindings
+
+## Approach
+
+Add a new taint propagation rule:
+
+```
+TaintedSym(dstSym, kind) :-
+    FieldRead(expr, baseSym, fieldName),
+    VarDecl(_, dstSym, expr, _),
+    TaintedSym(baseSym, kind).
+```
+
+And for destructuring:
+
+```
+TaintedSym(dstSym, kind) :-
+    DestructuredBinding(dstSym, baseSym, fieldName),
+    TaintedSym(baseSym, kind).
+```
+
+## Files to modify
+
+- `extract/rules/taint.go` — add FieldRead/destructuring taint rules
+- Update existing fixtures to use more realistic `req.query.id` patterns
+  once this works
+
+## Acceptance criteria
+
+- New test fixture with `const id = req.query.id; db.query('...' + id)` produces
+  a taint alert
+- Existing tests still pass (the `req.query` whole-object pattern should
+  continue to work)
+
+## E2E test plan reference
+
+This corresponds to `testdata/compat/projects/field-sensitive/` from the E2E
+test plan (Phase 3).

--- a/docs/impl-plans/22-e2e-phase3-fixtures.md
+++ b/docs/impl-plans/22-e2e-phase3-fixtures.md
@@ -1,0 +1,58 @@
+# Plan 22 — E2E Phase 3 Fixtures
+
+**Status:** not started
+**Phase:** E2E test coverage expansion
+**Dependencies:** Plan 21 (field-sensitive taint) for field-sensitive fixture;
+Plans 18-20 for full sink coverage in deep-call-chain fixture
+
+## Scope
+
+Create three new compat fixture projects and corresponding queries/goldens:
+
+### 22a. `testdata/compat/projects/deep-call-chain/`
+
+Stress test inter-procedural taint flow through nested call chains.
+
+```
+src/
+  entry.ts    — Express handler, reads req.query
+  layer1.ts   — transform(data) → calls layer2
+  layer2.ts   — process(data) → calls layer3
+  layer3.ts   — format(data) → calls sink
+```
+
+Tests FlowStar transitive closure through 3+ function call levels.
+Query: find TaintAlerts where source is http_input.
+
+### 22b. `testdata/compat/projects/field-sensitive/`
+
+Field-sensitive taint tracking patterns.
+
+```
+src/
+  app.ts — Express routes using:
+    - const id = req.query.id → db.query (field access)
+    - const { name } = req.body → res.send (destructuring)
+    - obj.field = tainted; use(obj.field) (field write/read)
+```
+
+**Blocked by Plan 21.** Create fixture now, skip test until Plan 21 lands.
+
+### 22c. `testdata/compat/projects/koa-app/`
+
+Non-Express framework to test Koa-specific framework rules.
+
+```
+src/
+  app.ts — Koa app with ctx.request.query → ctx.body flow
+```
+
+Tests that the framework detection isn't Express-only.
+
+## Acceptance criteria
+
+- Each fixture has a QL query and committed golden
+- deep-call-chain tests pass end-to-end
+- field-sensitive test is skipped with documented reason
+- koa-app tests pass if Koa framework rules exist, skipped otherwise
+- Add all three to `compatTestCases()`

--- a/docs/impl-plans/23-e2e-phase4-perf.md
+++ b/docs/impl-plans/23-e2e-phase4-perf.md
@@ -1,0 +1,57 @@
+# Plan 23 — E2E Phase 4: Performance Benchmarks
+
+**Status:** not started
+**Phase:** Performance regression detection
+**Dependencies:** none (can be done independently)
+
+## Scope
+
+### 23a. Fixture generator
+
+Create `testdata/perf/gen_fixture.go` that generates synthetic JS/TS projects:
+
+```
+go run testdata/perf/gen_fixture.go -files 50 -functions-per-file 10 -call-depth 5 -taint-chains 20
+```
+
+Each generated file:
+- Imports from other generated files (cross-file flow)
+- Defines N functions with local variable chains (local flow)
+- Calls functions from other files (inter-procedural flow)
+- Includes taint sources and sinks (taint analysis)
+
+### 23b. Medium-tier benchmarks
+
+Add to `benchmark_test.go`:
+
+- `BenchmarkExtractionMedium` — extraction on ~1000 LOC generated project
+- `BenchmarkFlowStarConvergence` — FlowStar fixpoint on deep call chains
+- `BenchmarkTaintAnalysisMedium` — full taint analysis on medium project
+- `BenchmarkMultipleConfigurations` — 4 configs on the same DB
+- `BenchmarkDBSerializationMedium` — encode/decode roundtrip on medium DB
+
+### 23c. CI baseline
+
+- Commit `testdata/perf/baseline.txt` with benchmark output
+- Add `bench-check` Makefile target:
+  ```makefile
+  bench-check:
+      go test -bench=. -benchtime=3s -count=3 > /tmp/bench-new.txt
+      benchstat testdata/perf/baseline.txt /tmp/bench-new.txt
+  ```
+
+### 23d. Timeout thresholds
+
+Add per-query timing assertions to compat tests:
+```go
+if elapsed > 5*time.Second {
+    t.Errorf("query took %v (>5s threshold)", elapsed)
+}
+```
+
+## Acceptance criteria
+
+- Fixture generator produces valid JS that extracts without errors
+- Medium benchmarks run in CI
+- Baseline committed and benchstat comparison works
+- No existing benchmark regresses >20%

--- a/docs/impl-plans/DEPENDENCY-GRAPH.md
+++ b/docs/impl-plans/DEPENDENCY-GRAPH.md
@@ -44,6 +44,19 @@ means B must land before A.
        │
        ├─> 11-typed-ts-fixtures (stronger test story once facts populate)
        └─> 12-typecheck-checker-test
+
+  18-sanitizer-function-symbol (no deps — extraction change)
+       │
+       ├─> 19-command-injection-sinks (needs FunctionSymbol for imports)
+       └─> 20-path-traversal-sinks   (needs FunctionSymbol for imports)
+
+  21-field-sensitive-taint (no deps — taint rule addition)
+       │
+       └─> 22-e2e-phase3-fixtures (field-sensitive fixture blocked by 21)
+
+  22-e2e-phase3-fixtures   (partial dep on 21; deep-call-chain and koa are independent)
+
+  23-e2e-phase4-perf       (no deps — independent benchmarking infrastructure)
 ```
 
 ## Notes
@@ -76,5 +89,8 @@ digraph impl_plans {
   "16-dataflow-dispatch" -> "09-custom-config";
   "17-type-facts" -> "11-typed-fixtures";
   "17-type-facts" -> "12-checker-test";
+  "18-sanitizer-fn-symbol" -> "19-cmdi-sinks";
+  "18-sanitizer-fn-symbol" -> "20-pathtraversal-sinks";
+  "21-field-sensitive" -> "22-e2e-phase3";
 }
 ```

--- a/docs/impl-plans/README.md
+++ b/docs/impl-plans/README.md
@@ -65,6 +65,12 @@ Merge order is top to bottom. See `DEPENDENCY-GRAPH.md` for the DAG.
 | 15 | [builtin-splitat](15-builtin-splitat.md)       | 1e residual   | not started |
 | 16 | [dataflow-config-dispatch](16-dataflow-config-dispatch.md) | 2b, 2c | not started |
 | 17 | [type-fact-population](17-type-fact-population.md) | 3b           | not started |
+| 18 | [sanitizer-function-symbol](18-sanitizer-function-symbol.md) | Sanitizer fix | not started |
+| 19 | [command-injection-sinks](19-command-injection-sinks.md) | Sink coverage | not started |
+| 20 | [path-traversal-sinks](20-path-traversal-sinks.md) | Sink coverage | not started |
+| 21 | [field-sensitive-taint](21-field-sensitive-taint.md) | Taint precision | not started |
+| 22 | [e2e-phase3-fixtures](22-e2e-phase3-fixtures.md) | E2E Phase 3 | not started |
+| 23 | [e2e-phase4-perf](23-e2e-phase4-perf.md) | E2E Phase 4 | not started |
 
 ## How to execute a plan
 


### PR DESCRIPTION
## Summary

- 6 new implementation plans covering all known gaps identified during E2E testing
- Updated dependency graph and README index

## Plans

| # | Plan | What it fixes | Deps |
|---|------|---------------|------|
| 18 | FunctionSymbol for imports | Sanitizers never fire — FunctionSymbol not emitted for import bindings | none |
| 19 | Command injection sinks | exec/spawn sinks don't detect taint | 18 |
| 20 | Path traversal sinks | No extraction rule for fs.readFile etc. | 18 |
| 21 | Field-sensitive taint | `req.query.id` doesn't chain taint (only `req.query` works) | none |
| 22 | E2E Phase 3 fixtures | deep-call-chain, field-sensitive, koa-app | 21 (partial) |
| 23 | E2E Phase 4 perf | Fixture generator, medium benchmarks, CI baseline | none |

## Critical path

Plan 18 (sanitizer fix) is the highest-priority item — it unblocks 19, 20, and fixes the sanitizer-bypass golden. Plan 21 (field-sensitive taint) is independent and improves taint precision for realistic query patterns.

## Test plan

- [x] Docs only — no code changes