### PR TITLE
fix: seven eng-review fixes (system rules, SARIF col, map dedup, scope perf, size hints, benchmark, flags)

### DIFF
--- a/analysis/SUMMARY.md
+++ b/analysis/SUMMARY.md
@@ -1,0 +1,138 @@
+# tsq Connascence Analysis — Summary
+
+**Date:** 13 April 2026
+**Scope:** Full codebase (~15.5k LOC Go, 119 source files, 6 packages)
+
+---
+
+## Connascence Matrix
+
+| FROM | TO | FORM | DEGREE | DIR | VERDICT |
+|------|-----|------|--------|-----|---------|
+| extract/ | extract/schema/ | CoN | 78 | uni | Necessary structure; ~70 string relation names are accidental |
+| extract/ | extract/rules/ | **CoP** | **120** | uni | **Highest risk.** Positional args must match schema column order |
+| extract/ | extract/typecheck/ | CoT | 8 | uni | Clean. No action needed |
+| extract/ | extract/db/ | CoM | 12 | uni | `interface{}` variadic API trades type safety for convenience |
+| ql/parse/ | ql/ast/ | CoT | 30 | uni | Clean producer-consumer |
+| ql/ast/ | ql/resolve/ | CoI | 28 | uni | Pointer-identity annotation maps — fragile |
+| ql/resolve/ | ql/desugar/ | CoI | 36 | uni | Inherited CoI from resolve's annotation maps |
+| ql/desugar/ | ql/datalog/ | CoT | 12 | uni | Clean producer-consumer |
+| ql/datalog/ | ql/plan/ | CoT | 15 | uni | Clean |
+| ql/plan/ | ql/eval/ | CoT+CoM | 28 | uni | Cross-subsystem dep on extract/db is accidental |
+| extract/schema/ | bridge/ | CoN | 110 | bi | Triple redundancy: schema, manifest, .qll predicates |
+| bridge/ | ql/ | CoN+CoV | 60 | bi | Path-to-file map duplicated in embed.go and main.go |
+| cmd/tsq/ | everything | CoEx | 40+ | uni | Orchestrator — mostly necessary |
+| output/ | ql/eval/ | CoT+CoM | 6 | uni | Likely SARIF column off-by-one bug (0-based → 1-based) |
+
+---
+
+## Top 5 Findings (by severity)
+
+### 1. Positional Argument Coupling in Datalog Rules (CoP, 120 points)
+
+**Location:** `extract/rules/*.go` ↔ `extract/schema/relations.go`
+
+Datalog rules construct `datalog.Literal` with arguments at hardcoded positions that must match the column ordering in `schema.RelationDef`. Example: `pos("Assign", w(), v("rhsExpr"), v("lhsSym"))` assumes column 0=lhsNode, 1=rhsExpr, 2=lhsSym. Reordering columns in the schema silently breaks all rules referencing that relation with **no compile-time or runtime error** until query results are wrong.
+
+**Fix:** Named-column rule builder that maps column names to positions. Converts CoP → CoN, caught at construction time.
+
+### 2. Triple Name Redundancy in Schema–Bridge Chain (CoN, 110 points)
+
+**Location:** `extract/schema/relations.go` → `bridge/manifest.go` → `bridge/*.qll`
+
+Adding a new fact relation requires three manual updates in three different languages (Go, Go, QL). Bridge `.qll` files also access columns by pure position (`Node(this, _, _, result, _, _, _)` = column 3), compounding CoP on top of CoN.
+
+**Fix:** Generate manifest and .qll stubs from the schema registry. Single source of truth.
+
+### 3. Pointer-Identity Annotation Maps (CoI, 64 points combined)
+
+**Location:** `ql/resolve/resolve.go` → `ql/desugar/desugar.go`
+
+The resolver stores annotations in `map[*ast.ClassDecl]ResolvedInfo` keyed by pointer identity. The desugarer looks them up by the same pointers. If any AST transformation creates new node objects (copy, clone, rewrite), annotation lookup silently fails. This couples resolve and desugar through object identity rather than through data.
+
+**Fix:** Assign stable IDs to AST nodes; key annotation maps by ID instead of pointer.
+
+### 4. Magic String Proliferation ("this", "result", builtins)
+
+**Location:** 4-way across `ql/parse/`, `ql/resolve/`, `ql/desugar/`, `ql/eval/`
+
+The strings `"this"`, `"result"`, and `"super"` carry semantic meaning across four packages with no shared constant. The builtin naming convention (`"__builtin_string_" + methodName`) is synthesised by string concatenation in desugar and matched by registry keys in eval — an implicit CoA.
+
+**Fix:** Define shared constants in `ql/ast/` or a `ql/convention` package.
+
+### 5. Duplicate Path-to-File Maps (CoV)
+
+**Location:** `bridge/embed.go` ↔ `cmd/tsq/main.go`
+
+Both files maintain identical 30-entry maps from import paths to .qll filenames. Adding a new bridge file requires updating both. Low-effort fix, high confidence.
+
+**Fix:** Single map exported from `bridge/`, consumed by `cmd/tsq/`.
+
+---
+
+## Likely Bug Found
+
+**SARIF off-by-one column:** `output/sarif.go` copies the 0-based `startCol` from the fact schema directly into `sarifRegion.StartColumn`, but SARIF 2.1.0 specifies 1-based columns. All SARIF column numbers are off by one.
+
+---
+
+## Architecture Assessment
+
+**Well-designed boundaries:**
+- The QL pipeline (parse → ast → resolve → desugar → datalog → plan → eval) has clean unidirectional CoT boundaries. This is textbook compiler pipeline design.
+- The `ExtractorBackend` interface cleanly separates tree-sitter and vendored backends. `ErrUnsupported` sentinel enables graceful degradation.
+- Error propagation is well-contained — each layer defines its own error shape with no cross-layer error type coupling.
+
+**Architectural concern:**
+- `ql/eval/` imports `extract/db/` and `extract/schema/` directly for base fact loading. This couples the query engine to the extraction layer, preventing independent testing. A fact-loader adapter interface would decouple the subsystems.
+
+**Structural observations:**
+- `walker_v2.go` is a decorator around `walker.go` (not a fork), but reaches into `FactWalker`'s internal fields directly (CoI) — fragile.
+- `scope.go` hardcodes `FunctionKinds` list instead of using the shared `IsFunctionKind()` from `kinds.go` — silent divergence risk.
+- `aggregate.go`'s `evalLiterals` duplicates the join loop from `evalJoinSteps` — operates on `datalog.Literal` instead of `plan.JoinStep`.
+- `childByField()` is duplicated identically in `scope.go` and `walker.go`.
+
+---
+
+## Refactoring Priority (impact/effort ratio)
+
+| # | Action | Impact | Effort |
+|---|--------|--------|--------|
+| 1 | Deduplicate path-to-file map (bridge ↔ main) | Eliminate CoV desync risk | Low |
+| 2 | Fix SARIF column off-by-one | Correctness bug | Low |
+| 3 | Named-column rule builder | Convert 120 CoP points to CoN | Medium |
+| 4 | Generate manifest + stubs from schema | Eliminate 110 name duplications | Medium |
+| 5 | Extract fact-loader adapter for eval | Decouple subsystems | Low |
+| 6 | Shared constants for "this"/"result"/builtins | Eliminate 4-way magic strings | Low |
+| 7 | Node IDs for annotation maps (resolve/desugar) | Eliminate CoI fragility | Medium |
+| 8 | Typed emit helpers per relation | Convert CoM to CoT | Medium |
+
+---
+
+## Connascence Spectrum
+
+```
+Weakest                                              Strongest
+  CoN -------- CoT -------- CoP -------- CoM -------- CoI
+   |            |            |            |            |
+  schema/     parse/ast    rules/       db/AddTuple  resolve/
+  bridge/     desugar/     (120 pts)    eval/load    desugar/
+  (110 pts)   plan/eval                 output/SARIF annotations
+              typecheck/
+```
+
+The strongest accidental couplings are concentrated in two areas:
+1. **Extract-side infrastructure** — rules positional coupling, schema-bridge name triplication
+2. **QL resolver/desugarer** — pointer-identity annotation maps
+
+The QL pipeline itself is well-layered. The output layer is clean. The CLI has expected orchestration coupling with some domain logic that should be pushed down.
+
+---
+
+## Detailed Analysis Files
+
+- `phase1_boundaries.md` — All 14 inter-package boundaries
+- `phase2_intrapackage.md` — Intra-package coupling (extract/, ql/eval/, ql/parse/, extract/rules/)
+- `phase3_hotspots.md` — Deep dives on 8 files >500 LOC
+- `phase4_crosscutting.md` — Entity IDs, source positions, relation names, QL semantics, error propagation
+- `phase5_matrix.md` — Connascence matrix and refactoring priorities

--- a/analysis/phase1_boundaries.md
+++ b/analysis/phase1_boundaries.md
@@ -1,0 +1,327 @@
+# Phase 1: Inter-Package Boundary Analysis
+
+## Methodology
+
+Each boundary was analysed by reading source files, tracing import paths, identifying shared types, and classifying coupling points by connascence form. "Degree" is the count of distinct coupling points (shared names, types, or conventions) across the boundary.
+
+---
+
+## 1.1 extract/ <-> extract/schema/
+
+**Imports:** `extract/db` imports `extract/schema`; `extract/` does not import `extract/schema/` directly. The coupling is indirect: `extract/` -> `extract/db/` -> `extract/schema/`.
+
+**What crosses the boundary:**
+- `schema.RelationDef`, `schema.ColumnDef`, `schema.ColumnType` (TypeInt32, TypeEntityRef, TypeString) -- used by `db.Relation` and `db.DB` to validate tuples, determine column storage format, and serialize/deserialize data.
+- `schema.Registry` (global slice) -- iterated by `db.Encode()` for relation ordering and by `db.ReadDB()` via `schema.Lookup()` for deserialization.
+- `schema.Lookup(name)` -- called by `db.DB.Relation()` to find definitions by name.
+- Relation names as strings -- `extract/walker.go` calls `fw.emit("Node", ...)` where "Node" must match `schema.RelationDef.Name` exactly.
+
+**Dominant connascence form:** **CoN (Name)** at the surface (70+ relation name strings that must match between `walker.go`'s `emit()` calls and `relations.go`'s `RegisterRelation()` calls), with **CoT (Type)** underneath (column types must match the Go types passed to `AddTuple`).
+
+**Degree:** ~70 relation names + 3 column type constants + 5 structural types = ~78 coupling points.
+
+**Direction:** Unidirectional. `extract/schema/` is a pure definition package; it knows nothing about its consumers.
+
+**Necessary vs accidental:** Mostly necessary -- a relational schema registry is the right abstraction for a fact database. The string-based relation name lookup (`fw.emit("Node", ...)`) is **accidental CoN**: a typo in a relation name string causes a runtime panic (via `db.Relation()`'s call to `schema.Lookup()`), not a compile-time error.
+
+**Refactoring opportunity:** Generate typed emit helpers (e.g., `fw.emitNode(id, file, kind, ...)`) from the schema registry to convert runtime CoN to compile-time CoT. This would eliminate the ~70 string-name coupling points.
+
+---
+
+## 1.2 extract/ <-> extract/rules/
+
+**Imports:** `extract/rules/` imports `ql/datalog` (not `extract/` directly). `extract/` does not import `extract/rules/`. The coupling between these two packages is **indirect through shared relation names**.
+
+**What crosses the boundary:**
+- Relation name strings: `rules/localflow.go` references predicates like `"Assign"`, `"ExprMayRef"`, `"SymInFunction"`, `"VarDecl"`, `"LocalFlow"`, `"LocalFlowStar"`, etc. These must exactly match the names registered in `extract/schema/relations.go` and the tuples emitted by `extract/walker.go` and `extract/walker_v2.go`.
+- Column positional semantics: `rules/` constructs `datalog.Literal` with args at specific positions (e.g., `pos("Assign", w(), v("rhsExpr"), v("lhsSym"))` assumes column 0=lhsNode, 1=rhsExpr, 2=lhsSym). These positions must match the `ColumnDef` order in `schema/relations.go`.
+
+**Dominant connascence form:** **CoP (Position)** -- the Datalog rule arguments are positional, and must match the column ordering in the schema. This is stronger than CoN because reordering columns in a `RelationDef` silently breaks all rules that reference that relation. Secondary: **CoN** on predicate/relation names.
+
+**Degree:** ~30 distinct relation name references across 7 rule files, each with 2-6 positional arguments = ~120 positional coupling points.
+
+**Direction:** Unidirectional. `extract/rules/` depends on the schema defined in `extract/schema/` (via shared string names). `extract/` does not depend on `extract/rules/`.
+
+**Necessary vs accidental:** The positional coupling (CoP) is **accidental** -- Datalog is inherently positional, but the system could use named-column rule construction (e.g., `col("Assign", "rhsExpr", v("rhsExpr"))`) to convert CoP to CoN. The name coupling is necessary.
+
+**Refactoring opportunity:** Introduce a schema-aware rule builder that maps column names to positions, turning CoP into CoN. Would catch column reordering bugs at rule construction time rather than at query evaluation time.
+
+---
+
+## 1.3 extract/ <-> extract/typecheck/
+
+**Imports:** `extract/typecheck/` is self-contained (no imports from `extract/`). `extract/` (via `cmd/tsq/main.go`) imports `extract/typecheck/` for enrichment.
+
+**What crosses the boundary:**
+- `typecheck.Client` -- created by `cmd/tsq/` and passed to `typecheck.NewEnricher()`.
+- `typecheck.Enricher` -- called by `cmd/tsq/` to query tsgo for type info.
+- `typecheck.Position` -- a simple `{Line, Col int}` struct used to specify query positions.
+- `typecheck.TypeFact` -- the enrichment result struct containing `{Line, Col, TypeDisplay, TypeHandle}`.
+- `typecheck.DetectTsgo()` -- auto-detection utility called by `cmd/tsq/`.
+- `typecheck.WriteTypeFacts()` -- callback-based function accepting `emit`, `posNodeID`, `symID`, `typeEntityID` callbacks. These callbacks are implemented in `cmd/tsq/main.go` using `extract.PositionNodeID`, `extract.SymID`, `extract.TypeEntityID`.
+
+**Dominant connascence form:** **CoT (Type)** -- the boundary is typed structs and function signatures. The callback pattern in `WriteTypeFacts` introduces mild **CoP** (callback argument order).
+
+**Degree:** ~8 exported types/functions crossing the boundary.
+
+**Direction:** Unidirectional. `typecheck/` is a leaf package; `cmd/tsq/` and indirectly `extract/` consume it.
+
+**Necessary vs accidental:** Mostly necessary. The callback-based `WriteTypeFacts` is slightly accidental -- it exists to decouple `typecheck/` from `extract/db`, but the callbacks create an indirect coupling that could be simplified.
+
+**Refactoring opportunity:** Minor. The `WriteTypeFacts` callback pattern could be replaced by having `typecheck/` return structured data and letting the caller write it, which is essentially what `EnrichFile` already does. `WriteTypeFacts` is redundant with the direct write path in `cmd/tsq/main.go`.
+
+---
+
+## 1.4 extract/ <-> extract/db/
+
+**Imports:** `extract/db` imports `extract/schema`. `extract/walker.go` imports `extract/db`.
+
+**What crosses the boundary:**
+- `db.DB` -- created by the caller, passed to `NewFactWalker(database)`, used throughout extraction.
+- `db.Relation` -- returned by `db.DB.Relation(name)`, used to add tuples.
+- `db.Relation.AddTuple(db, vals...)` -- the primary write API. Arguments are `interface{}` values that must match the column types from the schema.
+- `db.SchemaVersion` -- referenced by `walker.go` to emit the SchemaVersion tuple.
+- `db.NewDB()` -- called by `cmd/tsq/` to create the database.
+- `db.DB.Encode(w)` / `db.ReadDB(r, size)` -- serialization/deserialization.
+- `db.Relation.Tuples()`, `db.Relation.GetInt()`, `db.Relation.GetString()` -- read API used by `cmd/tsq/` for enrichment position collection.
+
+**Dominant connascence form:** **CoT (Type)** on the `db.DB` and `db.Relation` types. **CoM (Meaning)** on `AddTuple`'s `interface{}` variadic args -- the caller must know which positions expect `int32` vs `uint32` vs `string`, and what constitutes an entity ref vs a plain int. A wrong Go type (e.g., passing `int` where `string` is expected) produces a runtime error, not a compile-time one.
+
+**Degree:** ~12 API surface points (2 types, ~10 methods).
+
+**Direction:** Bidirectional in a limited sense. `extract/walker.go` depends on `db.DB` (writes). `cmd/tsq/main.go` depends on `db.DB` (reads/writes). `db/` depends on `schema/`.
+
+**Necessary vs accidental:** The `interface{}` variadic API for `AddTuple` is **accidental CoM** -- it trades type safety for convenience. The boundary types themselves are necessary.
+
+**Refactoring opportunity:** Generate typed `AddXxx()` methods per relation (e.g., `r.AddNodeTuple(id, file, kind, startLine, startCol, endLine, endCol)`) to convert CoM to CoT.
+
+---
+
+## 1.5 ql/parse/ -> ql/ast/
+
+**Imports:** `ql/parse` imports `ql/ast`.
+
+**What crosses the boundary:**
+- The entire `ast` package -- all AST node types (`Module`, `ClassDecl`, `PredicateDecl`, `Formula` interface, `Expr` interface, and ~25 concrete node types).
+- `ast.Span` -- attached to every node.
+- `ast.TypeRef`, `ast.VarDecl`, `ast.ParamDecl`, `ast.Annotation` -- structural types.
+- The parser's return type: `func (p *Parser) Parse() (*ast.Module, error)`.
+
+**Dominant connascence form:** **CoT (Type)** -- the parser constructs and returns `ast.*` types. This is a classic producer-consumer relationship. Every AST node type is a coupling point.
+
+**Degree:** ~30 AST types constructed by the parser.
+
+**Direction:** Strictly unidirectional. `parse/` produces `ast.*` nodes; `ast/` has no knowledge of `parse/`.
+
+**Necessary vs accidental:** Entirely necessary. A parser must produce an AST; the type coupling is inherent to the architecture.
+
+**Refactoring opportunity:** None needed. This is clean, well-separated coupling.
+
+---
+
+## 1.6 ql/ast/ -> ql/resolve/
+
+**Imports:** `ql/resolve` imports `ql/ast`.
+
+**What crosses the boundary:**
+- `ast.Module` -- input to `resolve.Resolve()`.
+- All AST types -- the resolver traverses the full AST, type-switching on `Formula` and `Expr` interface implementations.
+- `ast.Span` -- used for error/warning location reporting.
+- `ast.ClassDecl`, `ast.PredicateDecl`, `ast.MemberDecl` -- stored by pointer in `resolve.Environment`.
+- `ast.ParamDecl` -- stored in `resolve.VarBinding`.
+- `resolve.ResolvedModule` -- contains `*ast.Module` plus resolution side-tables.
+- `resolve.Environment` -- maps class/predicate names to `*ast.ClassDecl` / `*ast.PredicateDecl`.
+- `resolve.Annotations` -- maps `ast.Expr` and `*ast.Variable` to resolution results.
+- `ast.MemberDefiningClass()` -- shared utility in `ast/heritage.go` called by both `resolve/` and `desugar/`.
+
+**Dominant connascence form:** **CoT (Type)** -- heavy use of AST types. Some **CoI (Identity)** -- `resolve.Annotations` uses pointer identity of AST nodes as map keys (`map[ast.Expr]*Resolution`, `map[*ast.Variable]VarBinding`), meaning the resolver and the desugarer must operate on the **same** AST objects, not copies.
+
+**Degree:** ~20 AST types referenced + 6 resolve output types + identity-keyed maps = ~28 coupling points.
+
+**Direction:** Unidirectional. `resolve/` depends on `ast/`; `ast/` has a small reverse dependency via `heritage.go` which provides `MemberDefiningClass` (a shared utility, but defined in `ast/` to be importable by both `resolve/` and `desugar/`).
+
+**Necessary vs accidental:** Mostly necessary. The **CoI** (pointer identity for annotation maps) is **accidental** and fragile -- any AST transformation that creates new node objects (e.g., cloning for immutability) would silently break resolution annotations.
+
+**Refactoring opportunity:** Use node IDs or spans as map keys instead of pointer identity to eliminate CoI.
+
+---
+
+## 1.7 ql/resolve/ -> ql/desugar/
+
+**Imports:** `ql/desugar` imports `ql/ast`, `ql/datalog`, and `ql/resolve`.
+
+**What crosses the boundary:**
+- `resolve.ResolvedModule` -- the primary input to `desugar.Desugar()`.
+- `resolve.Annotations` -- accessed for `ExprResolutions` and `VarBindings` (using the same pointer-identity keys as resolve).
+- `resolve.Environment` -- accessed for class hierarchy (`Classes`, `Predicates`, `Imports`).
+- All `ast.*` types -- the desugarer walks the AST, constructing Datalog rules from each predicate/class.
+- `ast.MemberDefiningClass()` -- shared algorithm for supertype member lookup.
+
+**Dominant connascence form:** **CoI (Identity)** -- the desugarer accesses `resolve.Annotations` maps keyed by AST node pointers. It **must** receive the exact same AST object graph that the resolver annotated. **CoA (Algorithm)** -- `MemberDefiningClass` is a shared algorithm between resolve and desugar (already deduplicated into `ast/heritage.go`, which is good).
+
+**Degree:** ~15 types from resolve + ~20 AST types + 1 shared algorithm = ~36 coupling points.
+
+**Direction:** Unidirectional. `desugar/` depends on `resolve/` and `ast/`.
+
+**Necessary vs accidental:** The CoI is accidental (see 1.6). The algorithm sharing via `ast/heritage.go` is a good pattern that eliminates what was previously CoA.
+
+**Refactoring opportunity:** Same as 1.6 -- eliminate pointer-identity-based annotation maps.
+
+---
+
+## 1.8 ql/desugar/ -> ql/datalog/
+
+**Imports:** `ql/desugar` imports `ql/datalog`.
+
+**What crosses the boundary:**
+- `datalog.Program` -- the output of `Desugar()`.
+- `datalog.Rule`, `datalog.Atom`, `datalog.Literal`, `datalog.Query` -- constructed by the desugarer.
+- `datalog.Term` interface and its implementations: `datalog.Var`, `datalog.IntConst`, `datalog.StringConst`, `datalog.Wildcard`.
+- `datalog.Comparison`, `datalog.Aggregate` -- constructed for comparison and aggregate subgoals.
+
+**Dominant connascence form:** **CoT (Type)** -- the desugarer is a pure producer of `datalog.*` IR types. Clean producer-consumer pattern.
+
+**Degree:** ~12 datalog types constructed.
+
+**Direction:** Strictly unidirectional. `desugar/` produces `datalog.*` structures; `datalog/` is a pure data definition package.
+
+**Necessary vs accidental:** Entirely necessary.
+
+**Refactoring opportunity:** None needed. Clean separation.
+
+---
+
+## 1.9 ql/datalog/ -> ql/plan/
+
+**Imports:** `ql/plan` imports `ql/datalog`.
+
+**What crosses the boundary:**
+- `datalog.Program` -- input to `plan.Plan()` and `plan.WithMagicSet()`.
+- `datalog.Rule` -- iterated for validation, stratification, and join ordering.
+- `datalog.Atom`, `datalog.Literal`, `datalog.Term` -- inspected during planning (variable binding analysis, join column computation).
+- `datalog.Aggregate` -- extracted from rule bodies for aggregate planning.
+- `plan.ExecutionPlan` -- the output, containing `plan.Stratum` (which wraps `plan.PlannedRule`).
+- `plan.PlannedRule.Head` is `datalog.Atom` and `plan.JoinStep.Literal` is `datalog.Literal` -- the plan embeds datalog types directly.
+
+**Dominant connascence form:** **CoT (Type)** -- plan types embed datalog types. This is tighter than the parse->ast boundary because the plan doesn't just construct new types -- it **embeds** datalog types within its own structures (`PlannedRule.Head` is `datalog.Atom`).
+
+**Degree:** ~10 datalog types referenced + 5 plan output types = ~15 coupling points.
+
+**Direction:** Unidirectional. `plan/` depends on `datalog/`.
+
+**Necessary vs accidental:** Mostly necessary. The embedding of `datalog.Atom` and `datalog.Literal` inside plan types is a reasonable design choice -- creating wrapper types would add boilerplate without benefit.
+
+**Refactoring opportunity:** None needed.
+
+---
+
+## 1.10 ql/plan/ -> ql/eval/
+
+**Imports:** `ql/eval` imports `ql/plan`, `extract/db`, and `extract/schema`.
+
+**What crosses the boundary:**
+- `plan.ExecutionPlan` -- input to `eval.NewEvaluator()` and `eval.Evaluate()`.
+- `plan.Stratum`, `plan.PlannedRule`, `plan.JoinStep`, `plan.PlannedQuery`, `plan.PlannedAggregate` -- traversed during evaluation.
+- `datalog.Literal`, `datalog.Atom`, `datalog.Term` (via plan types) -- matched against during join execution.
+- `db.DB` -- input to `eval.NewEvaluator()` for loading base facts.
+- `schema.Registry` and `schema.ColumnType` -- used by `loadBaseRelations()` to convert `db.Relation` tuples into `eval.Relation` tuples.
+- `eval.ResultSet` -- the output type (containing `eval.Value`, `eval.IntVal`, `eval.StrVal`).
+
+**Dominant connascence form:** **CoT (Type)** on plan types. **CoM (Meaning)** on the value mapping: `schema.TypeInt32`/`schema.TypeEntityRef` -> `eval.IntVal`, `schema.TypeString` -> `eval.StrVal`. The evaluator must agree with the schema on what column types mean. This is a secondary mapping layer between the extract-side type system and the eval-side type system.
+
+**Degree:** ~15 plan types + ~8 eval types + ~5 schema/db types = ~28 coupling points.
+
+**Direction:** Unidirectional from plan to eval. Eval also has a direct dependency on `extract/db` and `extract/schema` (for base fact loading), creating a cross-subsystem dependency.
+
+**Necessary vs accidental:** The cross-subsystem dependency (`ql/eval` -> `extract/db`, `extract/schema`) is **accidental** -- it means the query engine has a hard dependency on the extraction layer, preventing independent testing without the extract package. The plan->eval coupling is necessary.
+
+**Refactoring opportunity:** Extract `loadBaseRelations` into a separate adapter package (or make it a function of `cmd/tsq/`) so `ql/eval/` depends only on `ql/plan/` and its own `Relation` type. The fact-loading logic would move to the orchestrator.
+
+---
+
+## 1.11 extract/schema/ <-> bridge/
+
+**Imports:** `bridge/manifest.go` imports `extract/schema`.
+
+**What crosses the boundary:**
+- `schema.Registry` -- iterated by `CapabilityManifest.AllRelationsCovered()` to verify that every schema relation has a bridge class.
+- Relation name strings -- the `AvailableClass.Relation` field in the manifest must exactly match `RelationDef.Name` values from the schema.
+- Import path strings -- `bridge/embed.go` defines a mapping from QL import paths (e.g., `"tsq::base"`) to `.qll` filenames. These import paths are used by `ql/resolve/` during import loading.
+- `.qll` file contents -- the bridge files define QL classes whose predicates reference relation names that must match the schema.
+
+**Dominant connascence form:** **CoN (Name)** -- three-way name agreement between (1) `schema.RelationDef.Name`, (2) `AvailableClass.Relation` in the manifest, and (3) predicate references inside `.qll` files. This is high-degree CoN because adding a new relation requires updating all three.
+
+**Degree:** ~80 relation name references in the manifest + import path mapping (~30 entries) = ~110 coupling points.
+
+**Direction:** `bridge/` depends on `extract/schema/` (unidirectional in Go imports). But the `.qll` file contents create an implicit bidirectional coupling: schema changes require `.qll` updates.
+
+**Necessary vs accidental:** Partially accidental. The manifest duplicates schema information. The `.qll` files duplicate relation names. This triple redundancy is a maintenance burden.
+
+**Refactoring opportunity:** Generate the manifest and `.qll` stubs from the schema registry. Would eliminate ~80 manually-maintained name couplings.
+
+---
+
+## 1.12 bridge/ <-> ql/ (via import loading)
+
+**Imports:** `bridge/embed.go` defines `ImportLoader()` which returns a function matching the signature expected by `resolve.Resolve()`. In `cmd/tsq/main.go`, `makeBridgeImportLoader()` duplicates the path-to-file mapping and returns `func(path string) (*ast.Module, error)`.
+
+**What crosses the boundary:**
+- Import path strings -- must match between user `.ql` files' `import` declarations, `bridge.ImportLoader`'s path-to-file map, and `resolve.Resolve`'s import processing.
+- `ast.Module` -- bridge `.qll` files are parsed into `*ast.Module` by the parser, then resolved recursively by `resolve.Resolve`.
+- The import loader callback signature: `func(path string) (*ast.Module, error)`.
+- QL class and predicate names defined in `.qll` files -- these must match what user queries reference.
+
+**Dominant connascence form:** **CoN (Name)** on import paths and QL identifiers. The path-to-file mapping in `bridge/embed.go` is **duplicated** in `cmd/tsq/main.go` (`makeBridgeImportLoader()`), introducing **CoV (Value)** -- both maps must contain the same entries.
+
+**Degree:** ~30 import path mappings (duplicated in two locations) + QL identifier names across ~30 `.qll` files.
+
+**Direction:** Bidirectional. `bridge/` provides the `.qll` content and path mapping; `ql/resolve/` consumes it via the callback. The duplication in `cmd/tsq/` adds a third coupling point.
+
+**Necessary vs accidental:** The duplication of the path-to-file map between `bridge/embed.go` and `cmd/tsq/main.go` is **clearly accidental CoV**. Both must stay in sync manually.
+
+**Refactoring opportunity:** Eliminate the duplication: have `cmd/tsq/main.go` use `bridge.ImportLoader()` directly (adapting its signature), or extract the path map into a shared constant. This would halve the coupling surface.
+
+---
+
+## 1.13 cmd/tsq/ -> everything
+
+**Imports:** `cmd/tsq/main.go` imports: `bridge`, `extract`, `extract/db`, `extract/typecheck`, `output`, `ql/ast`, `ql/desugar`, `ql/eval`, `ql/parse`, `ql/plan`, `ql/resolve`.
+
+**What crosses the boundary:**
+- All major types from every package: `extract.ProjectConfig`, `extract.ExtractorBackend`, `extract.TreeSitterBackend`, `extract.VendoredBackend`, `extract.TypeAwareWalker`, `db.DB`, `db.ReadDB`, `typecheck.Client`, `typecheck.Enricher`, `typecheck.Position`, `parse.Parser`, `ast.Module`, `resolve.Resolve`, `desugar.Desugar`, `plan.Plan`, `eval.NewEvaluator`, `eval.ResultSet`, `output.WriteSARIF`, `output.WriteJSONLines`, `output.WriteCSV`, `bridge.LoadBridge`, `bridge.V1Manifest`.
+- Pipeline orchestration: `cmd/tsq/` drives the entire pipeline: parse -> resolve -> desugar -> plan -> eval -> output.
+- The `nonTaintablePrimitives` map in `cmd/tsq/main.go` -- domain knowledge about TypeScript type semantics that arguably belongs in `extract/` or `bridge/`.
+- `extract.FileID`, `extract.SymID`, `extract.PositionNodeID`, `extract.TypeEntityID` -- ID generation functions called during enrichment.
+
+**Dominant connascence form:** **CoEx (Execution)** -- the CLI must execute pipeline stages in the correct order (parse before resolve, resolve before desugar, etc.). Also heavy **CoT** on the types from every imported package.
+
+**Degree:** ~40+ imported types and functions across 11 packages.
+
+**Direction:** Strictly unidirectional. `cmd/tsq/` depends on everything; nothing depends on `cmd/tsq/`.
+
+**Necessary vs accidental:** The CoEx is mostly necessary -- a pipeline orchestrator inherently has execution order dependencies. Some coupling is accidental: `nonTaintablePrimitives` is domain knowledge living in the wrong place, and the duplicated import path map (see 1.12) adds unnecessary coupling.
+
+**Refactoring opportunity:** Move `nonTaintablePrimitives` to `extract/schema/` or `bridge/`. Extract the compilation pipeline (`parse -> resolve -> desugar -> plan`) into a `ql.Compile()` helper to reduce the surface area of `cmd/tsq/`.
+
+---
+
+## 1.14 output/ <- ql/eval/
+
+**Imports:** `output/` imports `ql/eval`.
+
+**What crosses the boundary:**
+- `eval.ResultSet` -- the primary input to all three formatters (`WriteSARIF`, `WriteJSONLines`, `WriteCSV`).
+- `eval.Value` interface and its implementations `eval.IntVal`, `eval.StrVal` -- type-switched in the formatters for value extraction.
+- `eval.ValueToString()` -- utility function called by CSV and SARIF formatters.
+- `eval.ResultSet.Columns` (column names as `[]string`) -- used for CSV headers, JSON keys, and SARIF location heuristics.
+- `eval.ResultSet.Rows` (`[][]Value`) -- iterated by all formatters.
+
+**Dominant connascence form:** **CoT (Type)** -- the formatters depend on the `ResultSet` and `Value` types. Some **CoM (Meaning)** -- SARIF formatting uses column name heuristics (e.g., column named "file" is treated as a URI, "line" as a line number). This is **semantic coupling**: the formatter assigns meaning to column names that is not declared anywhere in the schema.
+
+**Degree:** ~6 types/functions crossing the boundary.
+
+**Direction:** Strictly unidirectional. `output/` depends on `ql/eval/`; `eval/` has no knowledge of `output/`.
+
+**Necessary vs accidental:** The CoT is necessary. The CoM (column name heuristics) is **accidental** -- it creates an implicit contract between query authors and the SARIF formatter about what column names mean.
+
+**Refactoring opportunity:** Define a formal `Location` annotation type in the evaluation result (or allow queries to explicitly mark location columns) instead of relying on name heuristics.

--- a/analysis/phase2_intrapackage.md
+++ b/analysis/phase2_intrapackage.md
@@ -1,0 +1,328 @@
+# Phase 2: Intra-Package Coupling Analysis
+
+## 2.1 extract/ Internals
+
+### walker.go (964 LOC) vs walker_v2.go (1043 LOC) — Relationship
+
+Both walkers are active. `TypeAwareWalker` (walker_v2.go) **wraps** `FactWalker` (walker.go) via composition — it holds a `*FactWalker` field (`tw.fw`) and delegates all v1 operations to it.
+
+**Coupling pattern:** TypeAwareWalker calls `tw.fw.Enter()`, `tw.fw.Leave()`, `tw.fw.EnterFile()`, `tw.fw.LeaveFile()` for v1 facts, then overlays v2 facts by calling `tw.fw.emit()` directly. This creates:
+
+- **CoN (Name):** walker_v2 references `fw.emit`, `fw.nid`, `fw.fileID`, `fw.filePath`, `fw.scope` — deeply coupled to FactWalker's internal field names and method signatures.
+- **CoI (Identity):** Both share the *same* `*db.DB` instance via `tw.fw.db`. walker_v2 has no independent database reference — all writes flow through `fw.emit()`.
+- **CoEx (Execution):** Strict ordering dependency — `tw.fw.Enter(node)` must execute before `tw.emitV2Facts(node)` because v1 populates the parent stack, scope, and Node/Contains tuples that v2 facts reference. Similarly, `tw.fw.Leave()` must run after v2 stack pops.
+- **CoM (Meaning):** Both walkers must agree on what `uint32` IDs mean. walker_v2 computes IDs via `tw.fw.nid()` (delegating to walker.go's `NodeID()` call), ensuring identical semantics.
+
+**Bidirectional coupling:** No. walker_v2 depends on walker.go but not vice versa. walker.go is unaware of walker_v2.
+
+**Duplicated helpers:** walker_v2 reuses `childByField()` and `childByKind()` from walker.go (package-level free functions). No duplication here — good factoring.
+
+**Risk:** walker_v2 reaches into `fw` internals (`fw.filePath`, `fw.fileID`, `fw.scope`, `fw.emit`). These are unexported fields accessed by same-package code, but any refactoring of FactWalker's internal state will break walker_v2.
+
+### backend.go ↔ backend_treesitter.go ↔ backend_vendored.go
+
+**backend.go** defines the `ExtractorBackend` interface (6 methods: Open, WalkAST, ResolveSymbol, ResolveType, CrossFileRefs, Close) plus `ASTNode` interface (8 methods) and supporting types (`ProjectConfig`, `ASTVisitor`, `SymbolRef`, `SymbolDecl`, `NodeRef`).
+
+**backend_treesitter.go** implements `ExtractorBackend` with tree-sitter. Contains:
+- `TreeSitterBackend` struct
+- `tsASTNode` struct implementing `ASTNode`
+- `kindMap` — the canonical kind mapping (120+ entries)
+- `normalise()` — the snake_case-to-PascalCase converter
+
+**backend_vendored.go** implements `ExtractorBackend` by embedding `*TreeSitterBackend` for AST walking and adding tsgo subprocess for semantic operations.
+
+**Coupling forms:**
+
+- **CoN (Name):** Both backends implement `ExtractorBackend` — must agree on all 6 method signatures. This is healthy interface-based CoN.
+- **CoI (Identity):** `VendoredBackend` embeds `*TreeSitterBackend` — they share the same tree-sitter parser instances. `VendoredBackend.WalkAST` delegates directly to `b.treeSitter.WalkAST()`.
+- **CoA (Algorithm):** `kindMap` in backend_treesitter.go and `tsgoKindMap` in tsgonode.go must produce the **same canonical PascalCase names** for equivalent AST concepts. Both map their respective parser's kind strings to the same canonical names (e.g., "CallExpression", "MemberExpression"). This is a duplicated algorithm — if the canonical name for a concept changes, both maps must be updated.
+- **CoM (Meaning):** `ErrUnsupported` sentinel (defined in backend.go) carries semantic meaning — both backends return it from unimplemented methods, and callers check for it to degrade gracefully.
+
+**vendored_scope.go** adds another layer: `VendoredScopeAdapter` wraps `*VendoredBackend` + `*ScopeAnalyzer`, implementing the same `Resolve(name, atNode)` interface. This creates CoN with scope.go's `Declaration` type.
+
+### scope.go (498 LOC) — Consumers
+
+**Primary consumer:** `FactWalker` (walker.go). The walker creates a `ScopeAnalyzer` per file (`fw.scope = NewScopeAnalyzer(path)`), calls `fw.scope.Build(node)` on the Program root, then calls `fw.scope.Resolve(name, node)` during fact emission for:
+- `emitExprMayRef` — identifier resolution
+- `emitCall` — callee symbol resolution (CallCalleeSym)
+- `emitAssign` — LHS symbol resolution
+- `emitFieldRead` / `emitFieldWrite` — base object resolution
+- `emitJsxElement` — JSX tag resolution
+
+**Secondary consumer:** `VendoredScopeAdapter` wraps scope.go's `ScopeAnalyzer` as a fallback.
+
+**Coupling forms:**
+- **CoI (Identity):** scope.go's `ScopeAnalyzer` holds a `nodeScope map[int]*Scope` that is populated during `Build()` and queried during `Resolve()`. The walker depends on scope being built on the same tree-sitter nodes that are being walked — if build and query happen on different parse trees, byte offsets won't match.
+- **CoEx (Execution):** `Build()` must be called exactly once per file, on the Program root node, before any `Resolve()` calls. walker.go enforces this with the `rootSeen` flag.
+- **CoM (Meaning):** scope.go uses `nodeStartByte()` which type-asserts `ASTNode` to `*tsASTNode` to access `n.StartByte()`. This creates an implicit coupling to the tree-sitter backend's concrete type. The fallback (line*10000 + col) is only approximate.
+- **CoA (Algorithm):** scope.go has its own `childByField()` and `firstChildByKind()` methods on `ScopeAnalyzer` that are functionally identical to the free functions in walker.go. This is a minor code duplication (CoA) — both implement the same child-lookup algorithm.
+
+### kinds.go — Cross-file Usage
+
+`kinds.go` defines two constant sets: `FunctionKinds` (6 entries) and `ExpressionKinds` (31 entries), plus lookup functions `IsFunctionKind()` and `isExpressionKind()`.
+
+**Consumers (5 files):**
+1. **walker.go:** `IsFunctionKind(kind)` to decide when to call `emitFunction()`
+2. **walker_v2.go:** `IsFunctionKind(kind)` for function stack management and `FunctionContains` emission; `isExpressionKind(kind)` for `ExprInFunction` emission
+3. **scope.go:** Hardcoded list in `buildScope()` case statement: `"FunctionDeclaration", "FunctionExpression", "ArrowFunction", "MethodDefinition", "GeneratorFunction", "GeneratorFunctionDeclaration"` — this is a **duplicated constant set** (CoA) that must stay in sync with `FunctionKinds`
+4. **kinds_test.go:** Tests the lookup functions
+
+**Coupling forms:**
+- **CoN (Name):** All consumers must agree on the exact string values ("FunctionDeclaration", "ArrowFunction", etc.)
+- **CoA (Algorithm, critical):** scope.go's case statement duplicates the `FunctionKinds` list instead of using `IsFunctionKind()`. If a new function kind is added to `FunctionKinds`, scope.go must be updated manually. The comment in kinds.go says "scope.go all reference this slice" but scope.go actually hardcodes the values.
+- **CoM (Meaning):** The kind strings are the canonical PascalCase names that `normalise()` / `normaliseTsgoKind()` produce from raw parser output. If canonical names change, kinds.go, backend_treesitter.go's `kindMap`, and tsgonode.go's `tsgoKindMap` must all agree.
+
+### ids.go — ID Format Dependencies
+
+`ids.go` defines 6 ID functions: `NodeID`, `SymID`, `ReturnSymID`, `FileID`, `TypeEntityID`, `PositionNodeID`. All use FNV-1a hashing truncated to uint32.
+
+**Consumers (6 files):**
+1. **walker.go:** `NodeID()`, `SymID()`, `FileID()` — used extensively for all fact emission
+2. **walker_v2.go:** `SymID()`, `ReturnSymID()` — for Symbol, FunctionSymbol, ReturnSym emission
+3. **scope.go:** No direct use — but scope.go's `Declaration` stores `StartLine`/`StartCol` which are later fed to `SymID()` by walker.go
+4. **typecheck/enricher.go:** `TypeEntityID()`, `PositionNodeID()` — for tsgo enrichment
+5. **walker_test.go:** Tests ID computation
+
+**Coupling forms:**
+- **CoA (Algorithm):** All callers must feed the same inputs in the same order. `NodeID` takes `(filePath, startLine, startCol, endLine, endCol, kind)` — if any caller permutes or omits fields, IDs won't match across the extraction pipeline.
+- **CoV (Value):** `SymID` and the scope resolution must produce matching IDs. walker.go computes `SymID(fw.filePath, decl.Name, decl.StartLine, decl.StartCol)` using values from scope.go's `Declaration`. If scope resolution returns different position information than what walker.go would compute directly, the IDs diverge. This is a cross-file value constraint.
+- **CoM (Meaning):** The uint32 IDs are used as entity references throughout the entire system — in the fact database (db.DB), in eval.go (as IntVal), and in QL queries. Everyone must agree that these are FNV-1a hashes of specific string representations.
+
+---
+
+## 2.2 ql/eval/ Internals
+
+### eval.go ↔ seminaive.go ↔ join.go ↔ relation.go ↔ parallel.go
+
+This is the Datalog evaluation engine. The relationships are:
+
+**eval.go** (80 LOC): Entry point. `Evaluator` struct wraps `*plan.ExecutionPlan` + `*db.DB`. `loadBaseRelations()` converts db.DB tuples into eval.Relation objects. Calls `Evaluate()`.
+
+**seminaive.go** (210 LOC): Core evaluation loop. `Evaluate()` implements stratified semi-naive bottom-up evaluation. Orchestrates:
+- Calls `Rule()` and `RuleDelta()` from join.go
+- Calls `Aggregate()` from aggregate.go
+- Calls `parallelBootstrap()` / `parallelDelta()` from parallel.go
+- Uses `relKey()` from relkey.go for all map lookups
+- Uses `NewRelation()` and `Relation.Add()` from relation.go
+
+**join.go** (379 LOC): Join implementation. Contains `Rule()`, `RuleDelta()`, `evalJoinSteps()`, `applyStep()`, `applyPositive()`, `applyNegative()`, `projectHead()`.
+
+**relation.go** (220 LOC): Data structures. `Value` interface (`IntVal`, `StrVal`), `Tuple`, `Relation` (with hash indexes), `HashIndex`.
+
+**parallel.go** (118 LOC): Parallel variants of bootstrap and delta evaluation.
+
+**Coupling analysis:**
+
+- **CoT (Type):** All files share the same type vocabulary: `Value`, `IntVal`, `StrVal`, `Tuple`, `Relation`, `binding`, `HashIndex`. This is healthy type-level coupling.
+- **CoN (Name):** `relKey()` is called from seminaive.go (8 calls), join.go (4 calls), parallel.go (3 calls), aggregate.go (1 call). Every relation lookup must use this function — forgetting it was the source of the arity-shadow bug documented in relkey.go.
+- **CoI (Identity):** `allRels map[string]*Relation` is the central shared mutable state. seminaive.go, parallel.go, and aggregate.go all read and write this map. In parallel mode, `parallelBootstrap()` and `parallelDelta()` read `allRels` concurrently (safe because they don't mutate it during the parallel phase) then merge results sequentially via `headRel.Add(t)`.
+- **CoEx (Execution):** Strict stratum ordering — strata must be evaluated sequentially. Within a stratum: bootstrap before fixpoint. Aggregates after fixpoint. The `parallelBootstrap` goroutines must all complete before the sequential merge phase.
+- **CoA (Algorithm):** `applyPositive()` in join.go and `applyNegative()` in join.go implement mirror-image logic (positive extends bindings, negative filters them). Both use the same index lookup pattern (`rel.Index(boundCols).Lookup(boundVals)`) and the same column matching verification loop — near-duplicate code.
+
+### Join Strategy ↔ Relation Representation Coupling
+
+**Tight coupling.** The join implementation in join.go directly depends on:
+1. `Relation.Index(cols)` returns a `*HashIndex` — join.go uses this for bound-column probing
+2. `HashIndex.Lookup(key)` returns `[]int` indices into `Relation.Tuples()`
+3. `Relation.Tuples()` returns `[]Tuple` for index-based access
+4. `partialKey()` / `tupleKey()` in relation.go must produce consistent keys for both index building and deduplication
+
+**CoA (Algorithm):** The `HashIndex.Lookup` method rebuilds the key via `partialKey(Tuple(key), seqCols)` where `seqCols = [0, 1, ..., len(key)-1]`. This means the caller's key values must be in the same canonical column order as the index was built with. `sortedColKey()` ensures indexes are canonical, but `Lookup()` assumes key[i] maps to sorted cols[i] — the ordering contract is implicit.
+
+**CoV (Value):** `Relation.Add()` panics if tuple arity doesn't match `r.Arity`. This is a hard runtime constraint linking the relation schema to every tuple producer (join.go's `projectHead`, aggregate.go's tuple construction, seminaive.go's bootstrap).
+
+### builtins.go (691 LOC) + builtin.go (138 LOC) — Split
+
+**builtin.go** (138 LOC): Infrastructure. Contains `Compare()`, `Arithmetic()`, `ValueToString()` — generic value operations used by the join engine.
+
+**builtins.go** (691 LOC): Builtin predicate implementations. Contains:
+- `builtinRegistry` map (string → builtinFunc)
+- `IsBuiltin()` / `ApplyBuiltin()` dispatch functions
+- 30+ individual builtin implementations (`builtinStringLength`, `builtinIntAbs`, etc.)
+- Helper functions (`resolveStringArg`, `resolveIntArg`, `bindResult`)
+
+**Coupling forms:**
+- **CoT (Type):** Both files operate on `Value`/`IntVal`/`StrVal` from relation.go.
+- **CoN (Name):** builtins.go calls `Compare()` from builtin.go (in `bindResult`), and `lookupTerm()` from join.go. join.go calls `IsBuiltin()` and `ApplyBuiltin()` from builtins.go.
+- **CoM (Meaning):** All builtin predicate names must start with `__builtin_` — this prefix is the implicit convention. The registry keys and the QL desugarer must agree on exact names.
+- **CoP (Position):** Every builtin's argument positions are hardcoded: e.g., `builtinStringLength` expects `atom.Args[0]` = this, `atom.Args[1]` = result. The QL desugarer must emit args in this exact order. This is positional connascence between the eval engine and the QL compiler.
+
+### relkey.go — Key Representation Coupling
+
+`relKey(name, arity)` returns `"name/arity"` as a string key. This is used by every file in eval/ that does relation lookups.
+
+- **CoA (Algorithm):** The encoding `name + "/" + strconv.Itoa(arity)` is duplicated implicitly — any code that constructs or parses these keys must agree on the format. Currently only `relKey()` constructs them, which is good.
+- **CoN (Name):** `relKey` is called 16+ times across 4 files. Renaming it or changing its signature would require touching every call site.
+- **CoM (Meaning):** The `/` separator carries meaning — relation names cannot contain `/` or the encoding would be ambiguous. This is an undocumented constraint.
+
+### aggregate.go — Own Machinery or Shared?
+
+Aggregate evaluation uses **its own join machinery** (`evalLiterals`) that is simpler than the planner-ordered `evalJoinSteps`:
+
+```go
+func evalLiterals(lits []datalog.Literal, rels map[string]*Relation) []binding {
+    // Mirrors evalJoinSteps but works on []datalog.Literal directly,
+    // without planner-ordered JoinSteps.
+}
+```
+
+**CoA (Algorithm, duplicated):** `evalLiterals` reimplements the join loop from `evalJoinSteps` but operates on `datalog.Literal` instead of `plan.JoinStep`. It calls the same `applyComparison`, `applyPositive`, `applyNegative` from join.go. The duplication is because aggregates bypass the planner — their body literals are evaluated naively.
+
+- **CoN (Name):** aggregate.go calls `tupleKey()`, `NewRelation()`, `lookupTerm()` from other files.
+- **CoT (Type):** Shares `Value`, `Tuple`, `Relation`, `binding` types.
+- **CoEx (Execution):** Aggregates run after fixpoint (enforced by seminaive.go). The `Aggregate()` function is called in stratum order, after the fixpoint loop completes.
+
+---
+
+## 2.3 ql/parse/ Internals
+
+### parser.go (1522 LOC) ↔ lexer.go (369 LOC) — Token Coupling
+
+**Token interface:** The parser accesses the lexer through a clean, narrow interface:
+
+1. `NewLexer(src, file)` — construction
+2. `l.Next()` — returns a `Token` struct
+
+The `Token` struct is the coupling point:
+```go
+type Token struct {
+    Type TokenType  // enum (int)
+    Lit  string     // literal text
+    Line int
+    Col  int
+}
+```
+
+**Coupling forms:**
+
+- **CoT (Type):** Parser depends on `Token` struct and `TokenType` enum. Both are defined in lexer.go. The parser uses `TokIdent`, `TokInt`, `TokString`, `TokKwFrom`, `TokKwSelect`, etc. — 59 distinct references to `p.current.Type` or `p.at(Tok...)` patterns.
+- **CoN (Name):** All ~40 `TokenType` constants are shared names between lexer and parser. Adding a new keyword requires adding it to both lexer.go's `keywords` map and using it in parser.go.
+- **CoM (Meaning):** The `Lit` field carries semantic content for `TokIdent` (the identifier text), `TokInt` (the numeric text), and `TokString` (the string content with escapes resolved). The parser relies on these conventions.
+
+**Does the parser reach into lexer internals?**
+
+**Yes, partially.** The `Parser.saveState()` / `restoreState()` methods directly access lexer internals for backtracking:
+```go
+func (p *Parser) saveState() parserState {
+    return parserState{
+        current: p.current,
+        lexPos:  p.lexer.pos,    // internal field
+        lexLine: p.lexer.line,   // internal field
+        lexCol:  p.lexer.col,    // internal field
+        lexErr:  p.lexer.err,    // internal field
+    }
+}
+```
+
+This is **CoI (Identity)** — the parser directly references and mutates the lexer's internal position state. The `Lexer` struct's fields (`pos`, `line`, `col`, `err`) are unexported but accessible because parser and lexer are in the same package. This is the tightest coupling in the parse package — the parser cannot use a different lexer implementation without matching these exact internal fields.
+
+**No bidirectional coupling:** The lexer has no knowledge of the parser. Data flows strictly lexer → parser.
+
+---
+
+## 2.4 extract/rules/ Internals
+
+### Rule Files — Independent Fact Emitters or Composing?
+
+All rule files (`callgraph.go`, `localflow.go`, `taint.go`, `frameworks.go`, `summaries.go`, `higherorder.go`, `composition.go`) share the same pattern: each exports a function returning `[]datalog.Rule`. They are **independent fact emitters** with **implicit data coupling through shared relation names**.
+
+**Coupling forms:**
+
+- **CoN (Name, dominant):** All rules reference the same relation names as string literals: `"CallTarget"`, `"LocalFlow"`, `"LocalFlowStar"`, `"FlowStar"`, `"TaintedSym"`, `"ExprMayRef"`, `"Parameter"`, `"SymInFunction"`, etc. These must match exactly:
+  - The schema definitions in `extract/schema/`
+  - The fact emission in walker.go / walker_v2.go
+  - Other rules that produce or consume the same relation
+  - There is no compile-time enforcement — a typo in a relation name is a silent logic error.
+
+- **CoP (Position):** Relation arguments are positional. `"Parameter"` is used as `Parameter(fn, idx, _, _, paramSym, _)` — the 6-argument positional convention must match across callgraph.go, localflow.go, summaries.go, frameworks.go, and higherorder.go. All files use `Parameter` with the same 6-arg layout. A schema change to `Parameter`'s column order would require updating every rule file.
+
+- **CoM (Meaning):** String constants carry semantic meaning: `s("http_input")`, `s("xss")`, `s("sql")`, `s("command_injection")` must be used consistently between taint.go (which consumes `TaintSource` kinds), frameworks.go (which produces them), and any user-written QL queries. There is no enum — just string matching.
+
+### Data Flow Between Rules (Implicit Composition)
+
+The rules compose through **shared derived relations** rather than direct function calls:
+
+```
+callgraph.go    → produces: CallTarget, MethodDeclInherited, MethodDeclDirect, Instantiated, CallTargetRTA
+localflow.go    → produces: LocalFlow, LocalFlowStar
+                  consumes: Assign, ExprMayRef, VarDecl, FieldRead, FieldWrite, SymInFunction, DestructureField, ReturnStmt, ReturnSym
+summaries.go    → produces: ParamToReturn, ParamToCallArg, ParamToFieldWrite, ParamToSink, SourceToReturn, CallReturnToReturn
+                  consumes: Parameter, ReturnSym, LocalFlowStar, FunctionContains, CallArg, ExprMayRef, CallCalleeSym, TaintSink, TaintSource
+composition.go  → produces: InterFlow, FlowStar
+                  consumes: CallTarget, CallArg, ExprMayRef, ParamToReturn, CallResultSym, ParamToCallArg, FunctionSymbol, LocalFlowStar, InterFlow, AdditionalTaintStep, AdditionalFlowStep
+taint.go        → produces: TaintedSym, SanitizedEdge, TaintedField, TaintAlert
+                  consumes: TaintSource, ExprMayRef, FlowStar, SanitizedEdge(negation), CallResultSym, CallTarget, Sanitizer, FieldWrite, FieldRead, TaintSink, VarDecl, SymInFunction, ExprInFunction
+frameworks.go   → produces: TaintSource, TaintSink, Sanitizer, ExpressHandler, HttpHandler, KoaHandler, FastifyHandler, LambdaHandler, NextjsHandler
+                  consumes: FieldRead, Parameter, MethodCall, CallArg, ExprMayRef, FunctionSymbol, CallCalleeSym, ImportBinding, ExportBinding, JsxAttribute
+higherorder.go  → produces: InterFlow
+                  consumes: MethodCall, ExprMayRef, CallArg, FunctionSymbol, Parameter
+```
+
+**Key observation:** The dependency graph is acyclic at the file level (frameworks produces sources/sinks, taint consumes them, composition bridges local and inter-procedural flow). But within the Datalog evaluation, recursive rules (e.g., `FlowStar` in composition.go, `LocalFlowStar` in localflow.go, `MethodDeclInherited` in callgraph.go) create circular dependencies handled by the semi-naive fixpoint.
+
+### merge.go — Rule Output Combination
+
+`merge.go` provides two functions:
+
+1. **`AllSystemRules()`** — concatenates all rule sets in a fixed order: CallGraph + LocalFlow + Summaries + Composition + Taint + Frameworks + HigherOrder
+2. **`MergeSystemRules(prog, systemRules)`** — prepends system rules before user rules into a new `datalog.Program`
+
+**Coupling forms:**
+- **CoN (Name):** merge.go must know every rule-producing function name.
+- **CoEx (Execution):** The concatenation order in `AllSystemRules()` doesn't affect correctness (the stratifier handles ordering), but it does affect the order rules are presented to the planner.
+
+### higherorder.go ↔ callgraph.go Coupling
+
+These files are **loosely coupled**. They share no direct function calls or types. Their coupling is entirely through shared relation names:
+
+- Both produce `InterFlow` (higherorder.go directly, composition.go from callgraph's `CallTarget`)
+- Both consume `MethodCall`, `ExprMayRef`, `FunctionSymbol`, `Parameter`
+- higherorder.go is about callback flow (Array.map, Promise.then); callgraph.go is about direct/virtual call resolution
+
+**No bidirectional coupling.** higherorder.go doesn't reference any callgraph-specific relations (CallTarget, MethodDeclInherited, etc.), and callgraph.go doesn't reference higherorder-specific patterns.
+
+### Helper Function Duplication
+
+All rule files share package-level helpers defined in callgraph.go:
+- `v(name)` — creates `datalog.Var`
+- `w()` — creates `datalog.Wildcard`
+- `pos(pred, args...)` — creates positive literal
+- `neg(pred, args...)` — creates negative literal
+- `rule(headPred, headArgs, body...)` — creates a Rule
+
+frameworks.go adds:
+- `s(val)` — creates `datalog.StringConst`
+- `intc(n)` — creates `datalog.IntConst`
+
+These helpers are defined once and used across all files — good factoring, no duplication.
+
+---
+
+## Summary: Dominant Coupling Forms by Area
+
+| Area | Dominant Forms | Highest Risk |
+|------|---------------|--------------|
+| extract/ walkers | CoI (shared db), CoEx (ordering), CoN (internal fields) | walker_v2 reaching into fw internals |
+| extract/ backends | CoA (duplicate kind maps), CoN (interface) | kindMap ↔ tsgoKindMap divergence |
+| extract/ scope | CoEx (build-before-resolve), CoI (same parse tree) | type assertion to *tsASTNode |
+| extract/ kinds | CoA (scope.go hardcodes list), CoN (string constants) | scope.go's FunctionKinds duplication |
+| extract/ ids | CoA (hash input format), CoV (scope→walker ID match) | SymID position mismatch between scope and walker |
+| ql/eval/ core | CoI (shared allRels), CoEx (stratum ordering) | parallel mutation of allRels |
+| ql/eval/ joins | CoA (positive/negative mirror), CoV (arity panics) | evalLiterals duplicating evalJoinSteps |
+| ql/eval/ builtins | CoP (arg positions), CoM (name conventions) | __builtin_ name agreement with desugarer |
+| ql/parse/ | CoI (parser saves lexer state), CoT (Token/TokenType) | backtracking via lexer internals |
+| extract/rules/ | CoN (relation name strings), CoP (arg positions) | No compile-time check on relation name typos |
+
+### Most Critical Cross-File Couplings
+
+1. **scope.go's duplicated FunctionKinds** (CoA) — the case statement hardcodes the same list that kinds.go defines as `FunctionKinds`. Adding a new function kind to one without the other creates a silent bug where scope analysis mishandles that kind.
+
+2. **walker_v2 reaching into FactWalker internals** (CoI/CoN) — `tw.fw.emit()`, `tw.fw.nid()`, `tw.fw.filePath`, `tw.fw.fileID`, `tw.fw.scope` are all accessed. Any FactWalker refactoring is high-risk.
+
+3. **Dual kind maps** (CoA) — `kindMap` (backend_treesitter.go, 120 entries) and `tsgoKindMap` (tsgonode.go, 86 entries) must produce identical canonical names for the same AST concepts. No shared data structure enforces this.
+
+4. **Relation name strings** (CoN across rules/) — ~30 distinct relation names used as bare strings across 7 rule files with no compile-time validation. A typo produces a silent empty-relation join.
+
+5. **Parser ↔ Lexer backtracking** (CoI) — the parser directly saves and restores the lexer's internal position fields (`pos`, `line`, `col`, `err`). This is the strongest coupling in parse/ and prevents any lexer abstraction.
+
+6. **aggregate.go's evalLiterals** (CoA) — reimplements the join loop from evalJoinSteps, creating a maintenance burden where changes to join semantics must be reflected in two places.

--- a/analysis/phase3_hotspots.md
+++ b/analysis/phase3_hotspots.md
@@ -1,0 +1,335 @@
+# Phase 3: Hot-Spot Deep Dives
+
+Connascence analysis of the 8 largest/most critical files in the tsq codebase.
+
+---
+
+## 3.1 ql/parse/parser.go (1522 LOC)
+
+### Connascence Forms
+
+**CoP (Position) in production rule ordering:**
+The parser is recursive-descent, so operator precedence is encoded in call depth:
+`parseFormula -> parseOr -> parseAnd -> parseNot -> parseComparisonOrAtom` and
+`parseExpr -> parseAddSub -> parseMulDiv -> parseUnary -> parsePostfix -> parsePrimary`.
+Any reordering of this call chain silently changes language semantics. This is standard for RD parsers but the positional contract is entirely implicit -- there are no comments or constants documenting the intended precedence levels.
+
+**CoN (Name) with lexer token types:**
+The parser references ~40 `Tok*` constants (`TokKwImport`, `TokKwClass`, `TokIdent`, etc.) that must exactly match the lexer's definitions. Standard CoN but the surface area is large.
+
+**CoV (Value) between lexer position and error span:**
+Error reporting uses `p.current.Line` and `p.current.Col` directly from the lexer's token to construct `ast.Span` values. The parser trusts these are 1-based line / 0-based column -- any drift in the lexer's convention silently corrupts all error messages and span annotations downstream.
+
+**CoM (Meaning) -- embedded QL semantic knowledge:**
+- The parser hardcodes the distinction between characteristic predicates and methods by comparing `qualParts[0] == className` (line 451). This is QL class semantics leaking into parse rules.
+- `parseClassMember` contains logic for `override` modifier, return types, characteristic predicates -- all semantic distinctions that could live in a separate pass.
+- `this`, `result`, `super` are parsed as `ast.Variable` nodes with hardcoded string names (lines 1232-1254). The meaning of these names is a contract shared with resolve.go and desugar.go.
+
+**CoT (Type) -- token-to-AST mappings:**
+`exprToFormula` (line 876) converts `*ast.MethodCall` to `*ast.PredicateCall` and `*ast.Variable` to a zero-arg predicate call. This type-level decision about what constitutes a formula vs expression is a semantic rule embedded in the parser.
+
+### Duplicated Logic
+
+- `parseAnnotations()` handles `private`, `deprecated`, `pragma`, `bindingset`, `language` -- these are hardcoded keyword checks. If a new annotation type is added, both the lexer (for the keyword token) and this function must be updated.
+- Backtracking state save/restore (`saveState`/`restoreState`, lines 51-67) exposes lexer internals (pos, line, col, err pointer) -- tight structural coupling.
+
+### Summary
+
+The parser is clean for a recursive-descent design but embeds QL semantic knowledge (characteristic predicate detection, `this`/`result`/`super` semantics) that could be deferred to a later pass. The precedence chain is a standard CoP hot spot.
+
+---
+
+## 3.2 ql/desugar/desugar.go (1363 LOC)
+
+### Connascence Forms
+
+**CoM (Meaning) -- "this" and "result" variable injection:**
+The desugarer injects `datalog.Var{Name: "this"}` as the first head argument for class predicates (line 239) and `datalog.Var{Name: "result"}` as the last argument for methods with return types (line 421). These magic strings must match:
+- resolve.go's `s.vars["this"]` and `s.vars["result"]` bindings (lines 339, 353)
+- The parser's `TokKwThis`/`TokKwResult` -> `ast.Variable{Name: "this"/"result"}` mapping
+- The eval engine's variable binding semantics
+
+This is CoM: the string "this" means "the receiver instance" and "result" means "the return value." If any component uses a different convention, the pipeline silently produces wrong results.
+
+**CoA (Algorithm) -- override dispatch semantics:**
+`desugarMethod` (line 365) implements override dispatch by:
+1. Collecting all transitive overriding subclasses
+2. Emitting one rule per overrider under the base class predicate name
+3. Each rule excludes its own direct sub-overriders via `not SubClass(this)` literals
+
+This algorithm must match the evaluator's predicate union semantics (multiple rules for the same predicate = union of results). If the eval engine changed to, say, first-match semantics, override dispatch would break silently.
+
+**CoA (Algorithm) -- super resolution:**
+`resolveSuperMethod` (line 1089) walks supertypes left-to-right. This ordering contract is shared with resolve.go's `lookupMemberRec` (which also walks supertypes in order). Both must agree on the resolution strategy for multiple inheritance.
+
+**CoN (Name) -- predicate name mangling:**
+`mangle(className, methodName)` returns `className + "_" + methodName` (line 506). This naming convention is a contract between desugar and eval -- the evaluator must look up predicates by these exact mangled names. If a class or method name contains `_`, there's potential for name collisions (no escaping).
+
+**CoM (Meaning) -- entityTypeRelation map:**
+The `entityTypeRelation` map (lines 284-297) hardcodes the mapping from `@`-prefixed entity types to schema relation names and arities. This is a critical CoM hot spot: if the schema adds a column to `Node` (currently arity 7) or renames a relation, this map silently produces wrong arities.
+
+**CoM (Meaning) -- stringBuiltins map:**
+The `stringBuiltins` map (line 1252) must agree with builtins.go's `builtinRegistry` on which string methods exist. The naming convention (`"__builtin_string_" + methodName`) is computed by string concatenation, not a shared constant.
+
+**CoM (Meaning) -- isPrimitive:**
+`isPrimitive()` (line 1344) duplicates the same set as resolve.go's `primitiveTypes` map but with a different format (switch vs map). They must stay in sync.
+
+### Heritage/Inheritance Handling
+
+The subclass map construction (`buildSubclassMap`, `buildSubclassMapForModule`) walks both imported and local classes, building a `map[string][]string` of parent->children. The `allConcreteSubclasses` function then traverses this to implement abstract class union semantics. The cycle guard in `superTypeConstraintsInner` (line 307) prevents infinite recursion but relies on the resolver having already detected cycles.
+
+### Duplicated Logic
+
+- Type constraint emission (`if !isPrimitive(typeName) { emit Literal }`) appears identically in `desugarExists`, `desugarSelect`, `desugarAggregateExpr`, and `desugarForall` -- 4 copies of the same pattern.
+- `resolveMethodCallPred` and `resolvePredicateCallRecvPred` are parallel implementations for expression-position vs formula-position method calls, with overlapping but non-identical logic.
+
+---
+
+## 3.3 extract/walker_v2.go (1043 LOC) + extract/walker.go (964 LOC)
+
+### Why Two Walkers?
+
+`walker.go` defines `FactWalker` -- the v1 structural fact emitter handling basic AST nodes (functions, calls, variables, imports, exports, JSX, destructuring, template literals).
+
+`walker_v2.go` defines `TypeAwareWalker` -- a **decorator/wrapper** around `FactWalker`. It delegates all v1 fact emission to the inner `FactWalker` and adds v2 type-aware facts: class/interface declarations, heritage clauses, method declarations, new expressions, return statements, function containment, type information, decorators, namespaces, type guards.
+
+This is NOT a feature flag or backend-specific split. It is a layered architecture: `TypeAwareWalker` composes `FactWalker` via delegation (`tw.fw.Enter(node)`, `tw.fw.emit(...)`, `tw.fw.nid(...)`, `tw.fw.scope.Resolve(...)`).
+
+### Connascence Forms
+
+**CoI (Identity) -- shared FactWalker state:**
+`TypeAwareWalker` accesses `tw.fw.filePath`, `tw.fw.fileID`, `tw.fw.scope`, `tw.fw.nid()`, and `tw.fw.emit()` directly. This is CoI: both walkers reference the same `FactWalker` instance and depend on its internal state being correctly maintained. If `FactWalker.Enter` changes the order of its state updates (e.g., `scope.Build` happens later), `TypeAwareWalker.emitV2Facts` would see stale scope data.
+
+**CoEx (Execution) -- Enter/Leave ordering:**
+`TypeAwareWalker.Enter` calls `tw.fw.Enter(node)` first, then `tw.emitV2Facts(node)`. This ordering matters because `fw.Enter` builds scope data that `emitV2Facts` relies on (e.g., `emitSymInFunction` calls `tw.fw.scope.Resolve`). The `Leave` method similarly delegates to `tw.fw.Leave(node)` after popping v2 stacks. The execution order is a fragile implicit contract.
+
+**CoN (Name) -- hardcoded relation names:**
+Both walkers emit facts via `fw.emit("RelationName", ...)` with string literals. There are 50+ unique relation name strings scattered across these two files. They must match:
+- `extract/schema/relations.go` (schema definitions)
+- `bridge/manifest.go` (AvailableClass.Relation mappings)
+- Bridge `.qll` files (QL predicate definitions)
+
+No constants, no registry lookup at emit time. Pure string matching.
+
+**CoN (Name) -- hardcoded AST node kind strings:**
+Both files use string literals for tree-sitter node kinds: `"ClassDeclaration"`, `"FunctionDeclaration"`, `"VariableDeclarator"`, `"MemberExpression"`, etc. These must match tree-sitter's TypeScript grammar. Changes to the grammar (e.g., renaming `"JsxElement"` to `"JSXElement"`) would silently break extraction.
+
+### Shared vs Duplicated Logic
+
+The walkers share utility functions defined in `walker.go`: `childByField()`, `childByKind()`, `boolInt()`. `walker_v2.go` reuses these freely.
+
+However, fact emission patterns are duplicated: both walkers iterate over children, skip punctuation (`","`, `"("`, `")"`, `"{"`, `"}"`), and extract names via `childByField(node, "name")`. Each new relation type reimplements this boilerplate.
+
+### Schema Relation Name Usage
+
+All hardcoded. No registry or constant pool. The `emit()` method calls `fw.db.Relation(rel)` which does a string lookup in the DB's relation map. If a relation name is misspelled, `AddTuple` silently fails (the error is dropped: `_ = r.AddTuple(fw.db, vals...)`).
+
+---
+
+## 3.4 ql/resolve/resolve.go (731 LOC)
+
+### Connascence Forms
+
+**CoM (Meaning) -- "this", "result", "super" semantics:**
+The resolver hardcodes implicit variable bindings:
+- `s.vars["this"] = varInfo{typeName: cd.Name}` in class bodies (line 339)
+- `s.vars["result"] = varInfo{typeName: md.ReturnType.String()}` in methods with return types (line 353)
+- `resolveVariable` special-cases "this", "result", "super" with hardcoded string comparisons (lines 586-611)
+
+These must agree with the parser's token-to-variable mapping and the desugarer's variable injection.
+
+**CoM (Meaning) -- primitiveTypes:**
+`primitiveTypes` map (lines 76-82) defines `int`, `float`, `string`, `boolean`, `date` as built-in scalars. This must match desugar.go's `isPrimitive()` function. Currently they agree, but they are maintained independently.
+
+**CoM (Meaning) -- @-prefixed entity types:**
+`resolveTypeRef` (line 398) treats any type starting with `@` as valid without checking against a registry. This is an implicit contract with the bridge layer -- `@node`, `@symbol`, etc. must correspond to actual entity types in the schema, but the resolver doesn't validate this.
+
+**CoA (Algorithm) -- scope copying:**
+`scope.child()` (line 310) copies all parent variables into the child scope via a map copy. This implements flat scoping (every child sees all parent bindings). The algorithm must match desugar.go's expectation that all variables are visible within their scope.
+
+**CoA (Algorithm) -- member lookup chain:**
+`lookupMemberRec` (line 706) walks the supertype chain depth-first, left-to-right, with a visited set for cycle prevention. This resolution order is a contract shared with desugar.go's `memberDefiningClass` (which delegates to `ast.MemberDefiningClass`).
+
+### Import Resolution Coupling to Bridge
+
+`processImports` (line 160) calls the provided `importLoader` function for each import path. In `cmd/tsq/main.go`, this loader is `makeBridgeImportLoader` which maps import paths like `"tsq::base"` to bridge `.qll` filenames. The resolver recursively resolves imported modules with `nil` as the import loader (line 179), meaning imports are flat (no transitive import loading). This is an explicit design choice but creates a coupling: bridge `.qll` files cannot import other bridges.
+
+---
+
+## 3.5 ql/eval/builtins.go (691 LOC)
+
+### Connascence Forms
+
+**CoN (Name) -- builtin registry:**
+`builtinRegistry` (lines 19-47) maps `__builtin_string_*` and `__builtin_int_*` names to Go functions. These names must match exactly what desugar.go generates via `"__builtin_string_" + mc.Method` (desugar.go line 718). There is no shared constant or type-safe registry.
+
+**CoP (Position) -- argument positions:**
+Every builtin function hardcodes its argument positions. For example, `builtinStringSubstring` expects `atom.Args[0]` = this, `[1]` = start, `[2]` = end, `[3]` = result. These positions must match what the desugarer emits. The arity check (`if len(atom.Args) != N`) is the only guard against mismatches.
+
+**CoA (Algorithm) -- type coercion rules:**
+The builtins use `resolveStringArg` and `resolveIntArg` which do strict type checking via Go type assertions (`v.(StrVal)`, `v.(IntVal)`). There is no implicit coercion -- a string "42" won't match as an int. This strictness is an implicit contract with the QL type system.
+
+**CoM (Meaning) -- string matching semantics:**
+`builtinStringMatches` (line 295) implements CodeQL-style glob matching by converting `%` to `*` and `_` to `?`, then using `filepath.Match`. This is a specific semantic interpretation that QL query authors must know about. The comment says "CodeQL matches uses glob-like patterns" but this conversion is one-way and lossy (a literal `*` in the pattern would be ambiguous).
+
+### Duplicated Logic
+
+Every builtin function follows the identical pattern:
+1. Check arity
+2. Loop over bindings
+3. Resolve args with `resolveStringArg`/`resolveIntArg`
+4. Compute result
+5. Call `bindResult`
+6. Append to output
+
+This boilerplate is repeated 19 times with only the core computation differing. A higher-order helper could reduce this to ~50 LOC.
+
+### Magic Values
+
+- `math.MinInt64` check in `builtinIntAbs` (line 560) -- silently drops the result for MinInt64 overflow.
+- String length is byte-based (`len(s)`), not rune-based. This is an implicit choice that would produce wrong results for multi-byte Unicode strings.
+
+---
+
+## 3.6 cmd/tsq/main.go (622 LOC)
+
+### CoEx (Execution) -- Pipeline Orchestration
+
+The query pipeline follows a strict sequence:
+1. Parse (`parse.NewParser` -> `Parse()`)
+2. Resolve (`resolve.Resolve` with bridge import loader)
+3. Desugar (`desugar.Desugar`)
+4. Plan (`plan.Plan`)
+5. Load fact DB (`db.ReadDB`)
+6. Evaluate (`eval.NewEvaluator` -> `Evaluate`)
+
+This sequence is duplicated between `compileAndEval` (lines 496-567, full pipeline) and `cmdCheck` (lines 402-493, pipeline without eval). The duplication means a change to the pipeline (e.g., adding a new pass) must be applied in both places.
+
+**CoEx within extract:**
+The extract pipeline is: Open backend -> emit SchemaVersion -> WalkAST -> (optional) tsgo enrichment -> encode DB. The tsgo enrichment phase depends on the extract phase having populated `Node`, `VarDecl`, and other relations first.
+
+### Configuration Threading
+
+**CoN (Name) -- import path to bridge file mapping:**
+`makeBridgeImportLoader` (lines 571-617) contains a hardcoded map of 30+ import paths to `.qll` filenames. This is a critical CoN hot spot -- adding a new bridge module requires updating this map, the bridge `LoadBridge()` function, and `bridge/manifest.go`.
+
+**CoM (Meaning) -- nonTaintablePrimitives:**
+The `nonTaintablePrimitives` map (lines 36-44) defines TypeScript primitives that break taint chains. This is QL evaluation semantics embedded in the CLI entry point -- it arguably belongs in the taint analysis layer.
+
+**CoN (Name) -- backend selection:**
+The `--backend` flag accepts `"treesitter"` or `"vendored"` as string literals, matched to concrete types `extract.TreeSitterBackend` and `extract.VendoredBackend`. These strings are not exported constants.
+
+### Duplicated Logic
+
+- `compileAndEval` and `cmdCheck` duplicate the parse-resolve-desugar-plan pipeline with slightly different error handling.
+- Bridge loading (`bridge.LoadBridge()`) is called separately in both `compileAndEval` and `cmdCheck`.
+
+---
+
+## 3.7 extract/scope.go (498 LOC)
+
+### CoA (Algorithm) -- TypeScript Scoping Rules
+
+The `ScopeAnalyzer` implements JavaScript/TypeScript scoping:
+- `var` declarations are hoisted to the enclosing function scope
+- `let`/`const` declarations are block-scoped with temporal dead zone (TDZ)
+- Function declarations are hoisted to the enclosing function scope
+- Import bindings go to the module (file) scope
+- `catch` clause creates a new block scope for the error parameter
+
+This algorithm must faithfully replicate the ECMAScript specification's scoping rules. Any deviation produces incorrect scope resolution, which cascades to wrong `ExprMayRef`, `CallCalleeSym`, `FieldRead`, and `FieldWrite` facts.
+
+**CoM (Meaning) -- TDZ semantics:**
+TDZ is implemented via `atByte < d.StartByte` comparison in `Scope.Resolve` (line 50). This means TDZ is approximated by byte position rather than control flow. A reference in a function body defined before a `let` declaration but called after it would incorrectly fail TDZ (JavaScript allows this). This is a deliberate simplification but an implicit semantic contract.
+
+### Consumer Coupling
+
+**CoI (Identity) -- shared between walker.go and walker_v2.go:**
+`ScopeAnalyzer` is created in `FactWalker.EnterFile` (line 63) and stored as `fw.scope`. It is used by:
+- `FactWalker.emitExprMayRef` (via `fw.scope.Resolve`)
+- `FactWalker.emitCall` (via `fw.scope.Resolve` for `CallCalleeSym`)
+- `FactWalker.emitAssign` (via `fw.scope.Resolve` for LHS symbol)
+- `FactWalker.emitFieldRead/Write` (via `fw.scope.Resolve` for base symbol)
+- `TypeAwareWalker.emitSymInFunction` (via `tw.fw.scope.Resolve`)
+- `TypeAwareWalker.emitClassDecl` (for JSX tag symbol resolution, inherited via FactWalker)
+
+The scope must be built (via `scope.Build`) before any `Resolve` call. This is ensured by the `rootSeen` flag in `FactWalker.enterNode` (line 117-119), which calls `scope.Build` on the first `Program` node.
+
+### Duplicated Logic with walker.go
+
+Both `scope.go` and `walker.go` define `childByField()` methods -- `scope.go` has `sa.childByField` (line 469) and `walker.go` has the package-level `childByField` (line 218). They have identical implementations. Similarly, `sa.firstChildByKind` duplicates `childByKind`.
+
+### Performance Concern -- findScope
+
+`findScope` (line 429) does a linear scan of all recorded scope entries to find the closest one <= startByte. For files with many scopes this is O(n) per resolution. A sorted slice with binary search would be O(log n).
+
+---
+
+## 3.8 bridge/manifest.go (236 LOC)
+
+### Schema <-> Bridge Predicate Name Mapping
+
+**CoN (Name) -- the central mapping:**
+The `v2Manifest()` function (lines 41-196) is a massive static list of `AvailableClass` structs, each mapping:
+- `Name`: the QL class name visible to queries (e.g., `"ASTNode"`, `"Function"`)
+- `Relation`: the underlying schema relation name (e.g., `"Node"`, `"Function"`)
+- `File`: which `.qll` file defines the bridge class
+
+This is the **single most important CoN hot spot** in the codebase. There are 100+ entries. Every entry creates a 3-way name contract:
+1. The schema relation name must match `extract/schema/relations.go`
+2. The QL class name must match what bridge `.qll` files define
+3. The file name must match what `bridge/embed.go` or `LoadBridge()` provides
+
+### Where Mismatches Hide
+
+**Name != Relation divergences:**
+Most entries have `Name == Relation` (e.g., `Function`/`Function`), but several diverge:
+- `"ASTNode"` -> `"Node"` -- QL users write `ASTNode`, schema stores `Node`
+- `"Type"` -> `"ResolvedType"` -- alias for the same backing relation
+- `"SymbolTypeBinding"` -> `"SymbolType"` -- different QL name
+- `"DataFlow::Node"` -> `"Symbol"` -- CodeQL compatibility shim maps to a different relation
+- `"DataFlow::PathNode"` -> `"Symbol"` -- same backing relation as DataFlow::Node
+- `"DOM::Element"` -> `"JsxElement"` -- compatibility mapping
+- `"DOM::InnerHtmlWrite"` -> `"FieldWrite"` -- reuses existing relation
+- `"HTTP::ResponseBody"` -> `"TaintSink"` -- compatibility alias
+- `"DatabaseAccess"` -> `"TaintSink"` -- another alias
+
+These are the places where a schema rename would silently break the bridge without any compile-time error.
+
+**Relation reuse risk:**
+Multiple QL classes map to the same backing relation: `"DataFlow::Node"`, `"DataFlow::PathNode"`, and `"TaintTracking::Configuration"` all map to `"Symbol"`. This means a schema change to `Symbol` would break 3+ bridge classes simultaneously.
+
+**CoV (Value) -- AllRelationsCovered check:**
+The `AllRelationsCovered` method (line 221) validates that every schema relation has a corresponding bridge entry. This is a runtime coverage check, not a compile-time guarantee. It iterates `schema.Registry` and checks against the manifest. If a new relation is added to the schema without a manifest entry, this check catches it -- but only if the check is actually called (it appears to be used only in tests).
+
+### Magic Values
+
+- The `Unavailable` slice is currently empty (line 194: `Unavailable: []UnavailableClass{}`), meaning the `CheckQuery` method (line 200) will never produce warnings. This is dead code until features are marked unavailable.
+
+---
+
+## Cross-Cutting Findings
+
+### Highest-Risk Connascence
+
+1. **Relation name strings** (CoN, high fan-out): ~50+ relation names used as bare strings in walker.go, walker_v2.go, manifest.go, desugar.go, and main.go. A single typo silently drops facts.
+
+2. **"this"/"result" variable convention** (CoM, 4-way): parser, resolver, desugarer, and evaluator must all agree that `"this"` means receiver and `"result"` means return value. No shared constant.
+
+3. **entityTypeRelation arities** (CoV): hardcoded arities in desugar.go must match schema definitions. Adding a column to Node (arity 7) without updating this map produces wrong grounding constraints.
+
+4. **Builtin naming convention** (CoA, 2-way): desugar.go concatenates `"__builtin_string_" + methodName`, builtins.go uses the same strings as map keys. No shared definition.
+
+5. **Import path -> filename mapping** (CoN, 2-way): main.go's `pathToFile` map and bridge's file loading must agree on filenames.
+
+### Recommended Mitigations (Priority Order)
+
+1. **Extract relation names into a `schema/names` constants package** used by walkers, manifest, and desugar. Compile-time enforcement of CoN.
+
+2. **Create a shared `ql/conventions` package** defining `ThisVarName = "this"`, `ResultVarName = "result"`, `BuiltinPrefix = "__builtin_"`. Eliminates the 4-way CoM.
+
+3. **Generate entityTypeRelation from schema.Registry** instead of hardcoding arities. Eliminates the CoV risk.
+
+4. **Extract the parse-resolve-desugar-plan pipeline** in main.go into a shared `compile()` function to eliminate the duplication between `compileAndEval` and `cmdCheck`.
+
+5. **Add compile-time tests** that assert `stringBuiltins` keys match `builtinRegistry` keys (minus the prefix), and that `isPrimitive()` matches `primitiveTypes`.

--- a/analysis/phase4_crosscutting.md
+++ b/analysis/phase4_crosscutting.md
@@ -1,0 +1,250 @@
+# Phase 4: Cross-Cutting Connascence Analysis
+
+## 4.1 Entity ID Generation and Referencing
+
+### The Full Chain
+
+Entity IDs flow through five layers:
+
+1. **Generation** (`extract/ids.go`): Five `uint32` ID generators using FNV-1a hashing truncated from 64 to 32 bits:
+   - `NodeID(filePath, startLine, startCol, endLine, endCol, kind)` — AST nodes
+   - `SymID(filePath, name, startLine, startCol)` — symbols
+   - `FileID(filePath)` — files (prefixed with `"file:"`)
+   - `TypeEntityID(typeHandle)` — type entities (prefixed with `"type:"`)
+   - `PositionNodeID(filePath, line, col)` — position-only nodes (prefixed with `"posnode:"`)
+   - `ReturnSymID(filePath, fnStartLine, fnStartCol)` — delegates to `SymID` with name `"$return"`
+
+2. **Schema** (`extract/schema/registry.go`): `TypeEntityRef` is declared as a column type distinct from `TypeInt32`, but both map to `int32` in storage. The distinction is purely semantic — it exists in the schema metadata but is never enforced differently at the storage layer.
+
+3. **Serialization** (`extract/db/writer.go`): `AddTuple` accepts `interface{}` values. For `TypeEntityRef` and `TypeInt32` columns, `toInt32()` converts via type-switch supporting `int32`, `int`, `uint32`, `int64`. The `uint32` from ID generators is cast to `int32` (line 151: `return int32(x), true`). **This is a lossy conversion** — IDs with bit 31 set will become negative `int32` values. Both write and read treat the column as 4 bytes of little-endian data, so the round-trip preserves bits, but the Go-level sign interpretation flips.
+
+4. **Deserialization** (`extract/db/reader.go`): Reads 4 bytes as `uint32`, then casts to `int32` (line 122: `int32(le.Uint32(...))`). Bit-preserving round-trip confirmed.
+
+5. **Evaluation** (`ql/eval/eval.go`): `loadBaseRelations` widens `int32` to `int64` for the eval `IntVal` type (line 58: `IntVal{V: int64(v)}`). Entity refs and plain integers become indistinguishable `IntVal` values at the eval layer.
+
+### Connascence Analysis
+
+| Form | Instances | Severity |
+|------|-----------|----------|
+| **CoA (Algorithm)** | All five ID generators must use FNV-1a with the same field ordering, separator bytes, and truncation. Anyone producing an ID that refers to the same entity must replicate the exact algorithm. `walker.go` calls `NodeID(fw.filePath, node.StartLine(), node.StartCol(), node.EndLine(), node.EndCol(), node.Kind())` — the argument order must exactly match `ids.go`. | **High** |
+| **CoA (Algorithm)** | `PositionNodeID` and `NodeID` generate different IDs for the same node (different prefixes, different input fields). The `enrichWithTsgo` function in `main.go` uses `PositionNodeID` to link ExprType tuples, while the walker uses `NodeID`. These only match if a QL query never needs to join them — which is exactly the design, but it's an implicit contract. | **Medium** |
+| **CoT (Type)** | The `uint32 → int32 → int64` widening chain creates a type connascence. IDs generated as `uint32` are stored as `int32` (reinterpreted bits, not value-preserving for large IDs), then widened to `int64` in eval. The round-trip works because all conversions preserve the bit pattern, but this is fragile — any intermediate code that does arithmetic on the `int32` value (e.g., comparison, sorting) will get wrong results for "negative" IDs. | **Medium** |
+| **CoM (Meaning)** | The semantic distinction between `TypeEntityRef` and `TypeInt32` exists only in schema metadata. At eval time, both are `IntVal`. A query cannot distinguish an entity reference from a plain integer. This is deliberate (Datalog doesn't have types), but means ID semantics are entirely implicit. | **Low** |
+| **CoV (Value)** | Hash collisions. FNV-1a-64 truncated to 32 bits has ~50% collision probability at ~77k entities (birthday bound). For large TypeScript projects this is a real concern. No collision detection exists. | **Medium** |
+
+### ID Semantics: Implicit, Not Documented
+
+- **Not monotonic**: Hash-based, order depends on input strings.
+- **Not globally unique**: Only unique per-entity-class by construction (different prefixes). But `NodeID` and `SymID` share the `TypeEntityRef` column type with no namespace separation at the storage level.
+- **Per-file?** No — `FileID` includes the path, `NodeID` includes the path, so they're project-scoped. But `TypeEntityID` is path-independent (keyed by type handle string).
+- **No documentation** of these properties exists. The contracts are entirely implicit in the hash function implementations.
+
+---
+
+## 4.2 Source Position Threading
+
+### Position Representation at Each Layer
+
+| Layer | Line Basis | Column Basis | Representation |
+|-------|-----------|-------------|----------------|
+| tree-sitter (backend) | 0-based (rows) | 0-based bytes | `TSPoint{Row, Column}` |
+| `ASTNode` interface | **1-based** | **0-based byte** | `StartLine() int`, `StartCol() int` (documented in `backend.go:70-73`) |
+| `tsgoNode` adapter | **1-based** | **0-based byte** | Same contract (documented in `tsgonode.go:17-20`) |
+| `extract/scope.go` Declaration | **1-based** | **0-based byte** | `StartLine int`, `StartCol int` (documented in `scope.go:19-20`) |
+| Schema (Node relation) | **1-based** | **0-based byte** | `startLine TypeInt32`, `startCol TypeInt32` (stored as-is from ASTNode) |
+| Schema (ExtractError) | **1-based** | N/A | `nodeStartLine TypeInt32` |
+| `ql/ast.Span` | 1-based | 1-based character | `StartLine`, `StartCol`, `EndLine`, `EndCol` (no documentation of basis) |
+| QL lexer `Token` | **1-based** | **1-based character** | `Line int`, `Col int` (lexer.go initializes `line: 1, col: 1`) |
+| SARIF output | **1-based** (SARIF spec) | **1-based** (SARIF spec) | `StartLine`, `StartColumn` |
+| `typecheck.Position` | 1-based | 0-based | Used for tsgo enrichment queries |
+
+### Connascence Analysis
+
+| Form | Issue | Severity |
+|------|-------|----------|
+| **CoM (Meaning)** | **Column basis mismatch between extraction and QL AST.** The extraction layer uses 0-based byte columns (from tree-sitter), stored directly into the Node relation. The QL parser/lexer uses 1-based character columns. These are different coordinate systems. A QL query that reads `startCol` from the Node relation gets a 0-based byte offset, while `Span.StartCol` in the QL AST is 1-based character. They never interact directly (one is TypeScript source positions, the other is QL source positions), but the naming overlap (`startCol` vs `StartCol`) creates confusion risk. | **Low** (currently non-interacting) |
+| **CoM (Meaning)** | **SARIF output does not adjust column basis.** `sarif.go:178` copies `IntVal.V` directly into `sarifRegion.StartColumn`. SARIF spec requires 1-based columns. The stored `startCol` is 0-based. **This is a bug**: SARIF consumers will see columns off by one. | **High** |
+| **CoA (Algorithm)** | The `NodeID` hash includes `startLine` and `startCol` as decimal strings. The `PositionNodeID` also includes line and col. Both depend on the ASTNode interface returning consistent values. If tree-sitter and tsgo report different positions for the same node (which they can — tsgo uses byte offsets internally, adapter converts), the IDs won't match. The `enrichWithTsgo` path in `main.go` (line 285) uses `PositionNodeID` with tsgo-reported positions, creating a join dependency on position agreement between backends. | **Medium** |
+| **CoV (Value)** | `StartLine` and `EndLine` must satisfy `EndLine >= StartLine`, and when equal, `EndCol >= StartCol`. This constraint is implicit — no validation exists. | **Low** |
+
+### Position Survival Path
+
+```
+tree-sitter (0-based row, 0-based byte col)
+  → TreeSitterBackend.nodeFromSitter() adds 1 to row → (1-based line, 0-based byte col)
+    → walker.go Enter() → NodeID() → stored in Node relation as int32
+      → db.Encode() → binary format
+        → db.ReadDB() → int32
+          → eval.loadBaseRelations() → IntVal{V: int64(v)}
+            → query select → ResultSet row
+              → output/sarif.go → sarifRegion.StartLine, .StartColumn
+```
+
+The key observation: positions are opaque integers after extraction. No layer between extraction and SARIF output interprets or transforms them. The SARIF column off-by-one bug survives because no layer knows the semantic convention.
+
+---
+
+## 4.3 Relation Name Contracts
+
+### The Chain of Agreement
+
+Four artifacts must agree on every relation name:
+
+1. **`extract/schema/relations.go`** — Canonical source of truth. `init()` calls `RegisterRelation(RelationDef{Name: "Node", ...})` for every relation. This is the single authoritative registry.
+
+2. **`extract/walker*.go`** — Emits tuples by calling `fw.emit("Node", ...)` with string literal relation names. The `emit` method calls `db.Relation(name)` which calls `schema.Lookup(name)` and **panics** if the name isn't registered. This provides a runtime check but no compile-time safety.
+
+3. **`bridge/*.qll`** — References relation names as bare predicates: `Node(this, _, _, _, _, _, _)`. The QL parser treats these as predicate calls. At eval time, the evaluator looks up relations by name in the `baseRels` map loaded from the DB.
+
+4. **`bridge/manifest.go`** — Maps QL class names to relation names: `{Name: "ASTNode", Relation: "Node", File: "tsq_base.qll"}`. This is used by `AllRelationsCovered()` to verify completeness.
+
+### Tests That Guard the Chain
+
+| Test | What It Checks | Gap |
+|------|---------------|-----|
+| `TestAllRelationsCovered` (manifest_test.go) | Every relation in `schema.Registry` has a corresponding entry in the manifest's `Available` or `Unavailable` list | Does NOT check that the manifest's `Relation` field matches actual .qll predicate usage |
+| `TestAvailableClassesHaveFiles` | Every available class has a non-empty `Relation` and `File` field | Does NOT check that the .qll file actually contains the named predicate |
+| `TestManifestAvailableNamesUnique` | No duplicate class names in the manifest | Does NOT check relation name uniqueness |
+| `db.Relation()` panic guard | Runtime: panics if you emit to an unregistered relation | Catches walker typos at test time, not at compile time |
+| Walker tests (`walker_test.go`) | End-to-end: extract TypeScript, check tuple counts by relation name | Only covers relations exercised by test fixtures |
+
+### Blast Radius of a Relation Rename
+
+**Severity: High. A relation rename requires coordinated changes across 5+ files with no compiler enforcement.**
+
+If `"Node"` were renamed to `"AstNode"`:
+
+1. `extract/schema/relations.go` — Change `RegisterRelation(RelationDef{Name: "Node", ...})` → `"AstNode"`
+2. `extract/walker.go` — Change every `fw.emit("Node", ...)` call (and `TypeAwareWalker`)
+3. `bridge/tsq_base.qll` — Change `Node(this, _, ...)` to `AstNode(this, _, ...)`
+4. `bridge/manifest.go` — Change `Relation: "Node"` to `Relation: "AstNode"` in the manifest entry
+5. `extract/db/writer.go` — No change needed (names are data, not code)
+6. `cmd/tsq/main.go` — Change `collectEnrichmentPositions` which hardcodes column indices by calling `database.Relation("Node")`
+7. Every `.ql` query file that references the `Node` predicate via the bridge
+
+The chain is held together by string equality with no type-safe wiring. The manifest's `AllRelationsCovered` test would catch a mismatch between schema and manifest, but nothing catches a mismatch between manifest and `.qll` file content.
+
+### Connascence
+
+| Form | Description | Severity |
+|------|-------------|----------|
+| **CoN (Name)** | All four artifacts (schema, walker, bridge .qll, manifest) must use identical string names for each relation | **High** — 80+ relation names, all string-based |
+| **CoP (Position)** | Bridge .qll predicates reference columns by position: `Node(this, _, _, result, _, _, _)` means column 3 = startLine. This must match the column order in `relations.go`. No names, pure position. | **High** |
+| **CoV (Value)** | Arity must match: `Node(this, _, _, _, _, _, _)` has 7 args, which must equal the 7 columns in the Node relation definition | **High** |
+
+---
+
+## 4.4 QL Language Semantics Shared Knowledge
+
+### Magic Strings Across Boundaries
+
+| String | Where Used | Semantics |
+|--------|-----------|-----------|
+| `"this"` | **parse** (lexer keyword `TokKwThis` → parser emits `Variable{Name: "this"}`), **resolve** (pre-bound in class scope, special-cased in `resolveVariable`), **desugar** (injected as `datalog.Var{Name: "this"}` in class rule heads), **eval** (builtins use `atom.Args[0]` as "this" by convention — `__builtin_string_length(this, result)`) | Implicit receiver identity |
+| `"result"` | **parse** (keyword `TokKwResult` → `Variable{Name: "result"}`), **resolve** (bound when method/predicate has ReturnType), **desugar** (added to head args for return-type predicates), **eval** (builtins bind result via `atom.Args[1]` or similar) | Implicit return value identity |
+| `"super"` | **parse** (keyword `TokKwSuper` → `Variable{Name: "super"}`), **resolve** (special-cased: resolves to first supertype), **desugar** (line 984/1058: special handling for super method calls, delegates to parent class predicate) | Parent class reference |
+| `"none"` | **parse** (keyword `TokKwNone` → `None{}` AST node), **resolve** (no special handling), **desugar** (emitted as empty body = always false), **eval** (no special handling needed — empty relation) | Always-false formula |
+| `"_"` | **datalog** (Wildcard type), **eval** (builtins check `v.Name != "_"` before binding in `bindResult`), **desugar** (emitted for don't-care positions) | Wildcard/don't-care |
+| `"__builtin_string_*"` | **desugar** (synthesizes `"__builtin_string_" + methodName` for string method calls, line 716/960), **eval** (`builtinRegistry` maps these to Go functions) | Method dispatch by name convention |
+| `"@"` prefix | **resolve** (line 398: `@`-prefixed types are always valid, no class declaration needed), **bridge .qll** (classes use `extends @node`, `extends @file` etc.) | Database entity types |
+
+### Semantic Knowledge Distribution
+
+```
+parse/  → Knows: syntax, keywords, operator precedence, AST structure
+resolve/ → Knows: scoping rules, type references, "this"/"result"/"super" binding, @-type convention
+desugar/ → Knows: class-to-Datalog lowering, "this"/"result" as head args, builtin name synthesis, super dispatch
+eval/   → Knows: semi-naive fixpoint, join evaluation, builtin dispatch, value types (IntVal/StrVal)
+```
+
+### Duplicated/Shared Semantic Knowledge
+
+| Knowledge | Shared Between | Form |
+|-----------|---------------|------|
+| "this" is always first arg of class predicates | resolve (binds it), desugar (puts it in head position 0) | **CoP** — position 0 is hardcoded in both |
+| "result" is last arg of return-type predicates | resolve (binds it), desugar (appends to head args) | **CoP** |
+| String methods become `__builtin_string_<name>` | desugar (name construction), eval (registry keys) | **CoA** — both must agree on the naming algorithm |
+| `@`-prefixed types are entity types | resolve (skips validation), bridge .qll (uses in `extends`) | **CoM** — the `@` prefix carries semantic meaning |
+| Aggregate function names ("count", "min", etc.) | parse (keywords), datalog IR (Aggregate.Func string), eval (aggregate evaluation) | **CoN** — string names must match across three packages |
+| Comparison operators ("=", "!=", "<", etc.) | parse (tokens), ast (Comparison.Op string), datalog (Comparison.Op string), eval (Compare function switch) | **CoN** across four packages |
+
+### No Contradictions Found
+
+The semantic knowledge is well-partitioned: each layer adds its own interpretation without contradicting others. The main risk is that the `__builtin_string_*` naming convention is an implicit CoA between desugar and eval with no shared constant or type.
+
+---
+
+## 4.5 Error Propagation Patterns
+
+### Error Types by Layer
+
+| Layer | Error Type | How Created |
+|-------|-----------|-------------|
+| `extract/` | `ErrUnsupported` (sentinel `errors.New`) | Returned by semantic methods when backend doesn't support operation |
+| `extract/` | `fmt.Errorf` wrapping | Returned by `walker.Run`, backend operations |
+| `extract/schema/` | `fmt.Errorf` | `RelationDef.Validate()` |
+| `extract/db/` | `fmt.Errorf` with `%w` | Reader/writer errors wrap underlying IO errors |
+| `ql/parse/` | Single `error` return from `Parse()` | `fmt.Errorf` with position info |
+| `ql/resolve/` | `[]resolve.Error` (custom type with Span) | Accumulated non-fatally, returned in `ResolvedModule.Errors` |
+| `ql/resolve/` | `[]resolve.Warning` (custom type with Span) | Accumulated alongside errors |
+| `ql/desugar/` | `[]error` | Accumulated via `errorf`, returned alongside program |
+| `ql/plan/` | `[]error` | From `ValidateRule` and stratification |
+| `ql/eval/` | Single `error` return | `fmt.Errorf` with `%w` wrapping |
+| `output/` | Single `error` return | From JSON/CSV encoding |
+
+### Error Propagation to CLI
+
+In `cmd/tsq/main.go`, the `compileAndEval` function is the primary pipeline:
+
+```
+Parse error → fmt.Errorf("parse: %w", err) → single error return
+Resolve errors → collected into string list → fmt.Errorf("resolve errors:\n  ...") 
+Desugar errors → collected into string list → fmt.Errorf("desugar errors:\n  ...")
+Plan errors → collected into string list → fmt.Errorf("plan errors:\n  ...")
+Eval error → fmt.Errorf("evaluate: %w", err) → single error return
+```
+
+The `cmdCheck` function handles each phase separately, printing errors to stderr and continuing to the next phase. This means check reports errors from ALL phases, while query stops at the first failing phase.
+
+### `ErrUnsupported` Sentinel
+
+**Definition:** `extract/backend.go:11` — `var ErrUnsupported = errors.New("operation not supported by backend")`
+
+**Producers:**
+- `TreeSitterBackend.ResolveSymbol/ResolveType/CrossFileRefs` — always returns `ErrUnsupported`
+- `VendoredBackend.ResolveSymbol/ResolveType/CrossFileRefs` — returns `ErrUnsupported` when `!b.tsgoAvailable`
+- `VendoredBackend.rpc()` — returns `ErrUnsupported` when tsgo unavailable
+
+**Consumers:**
+- `extract/vendored_scope.go:70` — `// Any error (including ErrUnsupported) means we fall back.` Treats it as "not available, degrade gracefully."
+- Test files: Check with `errors.Is(err, ErrUnsupported)` to verify graceful degradation.
+
+**Notably absent:** No consumer in the CLI (`main.go`) checks for `ErrUnsupported` — it's fully handled within the extract layer. The walker never surfaces it to the CLI.
+
+### Connascence Analysis
+
+| Form | Description | Severity |
+|------|-------------|----------|
+| **CoM (Meaning)** | `ErrUnsupported` carries implicit meaning: "this is expected, degrade gracefully, don't treat as failure." Callers must know this convention. Well-documented but not enforced by type system. | **Low** — small, well-contained |
+| **CoT (Type)** | Each layer defines its own error type: `resolve.Error` (with Span), `desugar` uses plain `error`, `plan` uses plain `error`. The CLI must handle both `[]error` (from resolve/desugar/plan) and single `error` (from parse/eval). No shared error interface for positioned errors. | **Medium** |
+| **CoM (Meaning)** | The resolve layer's distinction between `Errors` (fatal) and `Warnings` (non-fatal) is a semantic convention. Warnings include deprecation notices. The CLI (`cmdCheck`) prints both to stderr but only counts errors for exit code. The `cmdQuery` path (`compileAndEval`) checks `len(resolved.Errors) > 0` but silently drops warnings. | **Low** |
+| **CoEx (Execution)** | Error checking order matters: in `compileAndEval`, resolve errors are checked before desugar runs, but `Desugar(resolved)` is called even when `resolved.Errors` is non-empty (desugar gets a valid program because resolve continues past errors). This is safe because desugar operates on the AST, not on resolution results. But in `cmdCheck`, all phases run regardless of earlier errors, meaning plan validation runs on a potentially malformed program. | **Low** — intentional for check mode |
+
+### Missing: Structured Error Codes
+
+There are no error codes or typed error categories beyond `ErrUnsupported`. All errors are string-formatted. This means:
+- Programmatic error handling is limited to `errors.Is(err, ErrUnsupported)` and `len(errors) > 0`
+- Error messages are the only "API" for distinguishing error causes
+- No CoN on error names/codes exists because there are no error names/codes
+
+---
+
+## Summary: Cross-Cutting Risk Matrix
+
+| Concern | Highest Connascence | Risk Level | Key Finding |
+|---------|-------------------|------------|-------------|
+| **4.1 Entity IDs** | CoA (algorithm replication across callers) | **Medium** | Hash collision probability for large projects; uint32→int32 sign-flip is correct but brittle |
+| **4.2 Positions** | CoM (column basis meaning) | **High** | SARIF output likely has off-by-one column bug (0-based stored, 1-based required by SARIF spec) |
+| **4.3 Relation names** | CoN + CoP (names and column positions across 4 artifacts) | **High** | 80+ relation names held together by string equality; .qll files use positional column access with no compile-time check |
+| **4.4 QL semantics** | CoA (builtin name synthesis) | **Medium** | `__builtin_string_*` convention is implicit CoA between desugar and eval; "this"/"result" position conventions span 3 packages |
+| **4.5 Error propagation** | CoT (heterogeneous error types) | **Low** | Each layer defines its own error shape; ErrUnsupported is well-contained; no structured error codes |

--- a/analysis/phase5_matrix.md
+++ b/analysis/phase5_matrix.md
@@ -1,0 +1,76 @@
+# Phase 5: Connascence Matrix
+
+## Matrix
+
+| FROM | TO | FORM | DEGREE | DIRECTION | VERDICT |
+|------|-----|------|--------|-----------|---------|
+| extract/ | extract/schema/ | CoN | 78 | uni | Necessary structure, accidental string-based name coupling on ~70 relation names. Generate typed emit helpers. |
+| extract/ | extract/rules/ | CoP | 120 | uni | **Accidental.** Positional args in Datalog rules must match schema column order. Strongest accidental coupling in the codebase. Named-column rule builder needed. |
+| extract/ | extract/typecheck/ | CoT | 8 | uni | Clean. Typed structs, minimal surface. No action needed. |
+| extract/ | extract/db/ | CoM | 12 | uni | **Accidental.** `AddTuple(interface{}...)` trades type safety for convenience. Generate typed per-relation insert methods. |
+| ql/parse/ | ql/ast/ | CoT | 30 | uni | **Necessary.** Parser-produces-AST is inherent. Clean boundary. |
+| ql/ast/ | ql/resolve/ | CoI | 28 | uni | **Accidental** CoI via pointer-identity annotation maps. Fragile under AST transformations. Use node IDs as keys. |
+| ql/resolve/ | ql/desugar/ | CoI | 36 | uni | **Accidental** CoI inherited from resolve's annotation maps. Same fix as 1.6. CoA on member lookup already resolved (heritage.go). |
+| ql/desugar/ | ql/datalog/ | CoT | 12 | uni | **Necessary.** Clean producer-consumer of IR types. |
+| ql/datalog/ | ql/plan/ | CoT | 15 | uni | **Necessary.** Plan embeds datalog types; clean design. |
+| ql/plan/ | ql/eval/ | CoT+CoM | 28 | uni | Mostly necessary. Cross-subsystem dep (eval->extract/db) is **accidental**. Extract fact-loading adapter. |
+| extract/schema/ | bridge/ | CoN | 110 | bi (implicit) | **Accidental** triple redundancy: schema names, manifest entries, .qll predicates. Generate manifest and stubs from schema. |
+| bridge/ | ql/ (imports) | CoN+CoV | 60 | bi | **Accidental** CoV: path-to-file map duplicated between bridge/embed.go and cmd/tsq/main.go. Deduplicate. |
+| cmd/tsq/ | everything | CoEx | 40+ | uni | Mostly **necessary** (orchestrator). Some accidental: domain knowledge (nonTaintablePrimitives) in wrong package. |
+| output/ | ql/eval/ | CoT+CoM | 6 | uni | Mostly **necessary**. CoM on SARIF column-name heuristics is **accidental**. Define explicit location annotations. |
+
+## Strength Ranking (strongest to weakest accidental coupling)
+
+1. **extract/ <-> extract/rules/ (CoP, degree 120)** -- Positional argument coupling between Datalog rules and schema column definitions. A column reorder silently breaks all rules referencing that relation. This is the highest-risk boundary.
+
+2. **extract/schema/ <-> bridge/ (CoN, degree 110)** -- Triple name redundancy (schema registry, capability manifest, .qll file predicates). Adding a relation requires three manual updates. High maintenance cost.
+
+3. **ql/ast/ <-> ql/resolve/ <-> ql/desugar/ (CoI, degree 64 combined)** -- Pointer-identity-based annotation maps create fragile coupling. Any AST transformation that creates new node objects breaks the annotation lookup silently.
+
+4. **bridge/ <-> ql/ via cmd/tsq/ (CoV, degree 60)** -- Duplicated path-to-file mapping between `bridge/embed.go` and `cmd/tsq/main.go`. A new bridge file requires updating both maps.
+
+5. **extract/ <-> extract/db/ (CoM, degree 12)** -- The `interface{}` variadic tuple API means callers must know column type semantics without compiler help.
+
+6. **output/ <-> ql/eval/ (CoM, degree 6)** -- Column-name heuristics in SARIF output assume semantic meaning of column names. Low degree, low risk.
+
+## Cross-Subsystem Dependencies
+
+The codebase has two major subsystems:
+- **Extract** (extract/, extract/schema/, extract/db/, extract/typecheck/, extract/rules/)
+- **Query** (ql/parse/, ql/ast/, ql/resolve/, ql/desugar/, ql/datalog/, ql/plan/, ql/eval/)
+
+Cross-subsystem dependencies:
+- `ql/eval/` -> `extract/db/`, `extract/schema/` (for `loadBaseRelations`)
+- `extract/rules/` -> `ql/datalog/` (rules package produces datalog IR)
+- `bridge/` -> `extract/schema/` (manifest coverage check)
+
+The `ql/eval/ -> extract/db/` dependency is the most architecturally significant cross-subsystem coupling. It prevents the query engine from being tested independently of the extraction layer.
+
+The `extract/rules/ -> ql/datalog/` dependency is a deliberate design choice: system rules are expressed as Datalog programs that get merged with user queries. This is architecturally sound.
+
+## Refactoring Priority (by impact/effort ratio)
+
+| Priority | Boundary | Action | Impact | Effort |
+|----------|----------|--------|--------|--------|
+| 1 | bridge/ <-> cmd/tsq/ | Deduplicate path-to-file map | Eliminate CoV, prevent desync | Low |
+| 2 | extract/ <-> rules/ | Named-column rule builder | Convert CoP to CoN (120 points) | Medium |
+| 3 | extract/schema/ <-> bridge/ | Generate manifest from schema | Eliminate 80+ name duplications | Medium |
+| 4 | ql/eval/ <-> extract/db/ | Extract fact-loader adapter | Decouple subsystems | Low |
+| 5 | extract/ <-> extract/db/ | Typed emit helpers per relation | Convert CoM to CoT | Medium |
+| 6 | ql/ast/ annotations | Use node IDs not pointer identity | Eliminate CoI | Medium |
+| 7 | cmd/tsq/ | Move nonTaintablePrimitives to extract/schema/ | Reduce orchestrator knowledge | Low |
+| 8 | output/ SARIF | Define explicit location annotation | Eliminate column-name CoM | Low |
+
+## Connascence Spectrum Summary
+
+```
+Weakest                                              Strongest
+  CoN -------- CoT -------- CoP -------- CoM -------- CoI
+   |            |            |            |            |
+  schema/     parse/ast    rules/       db/AddTuple  resolve/
+  bridge/     desugar/     (120 pts)    eval/load    desugar/
+  (110 pts)   plan/eval                 output/SARIF annotations
+              typecheck/
+```
+
+The codebase is generally well-structured with clean unidirectional boundaries in the QL pipeline (parse -> ast -> resolve -> desugar -> datalog -> plan -> eval). The strongest accidental couplings are concentrated in the extract-side infrastructure (rules positional coupling, schema-bridge name triplication) and the annotation identity coupling in the QL resolver/desugarer.

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -176,8 +176,8 @@ select f.getName() as "name"
 
 	b.Run("with_magic_set", func(b *testing.B) {
 		// Magic set benefits are more visible on larger programs with targeted queries.
-		// For this benchmark, we just verify both paths work.
-		benchmarkQuery(b, factDB, query, false)
+		// Pass true to actually exercise the magic-set code path.
+		benchmarkQuery(b, factDB, query, true)
 	})
 }
 

--- a/bridge/embed.go
+++ b/bridge/embed.go
@@ -51,6 +51,43 @@ func LoadBridge() map[string][]byte {
 	return result
 }
 
+// ImportPathToFile maps QL import paths (e.g. "tsq::base") to their embedded
+// .qll filenames. This is the single source of truth; cmd/tsq/main.go consumes it
+// rather than maintaining a duplicate map.
+var ImportPathToFile = map[string]string{
+	"tsq::base":           "tsq_base.qll",
+	"tsq::functions":      "tsq_functions.qll",
+	"tsq::calls":          "tsq_calls.qll",
+	"tsq::variables":      "tsq_variables.qll",
+	"tsq::expressions":    "tsq_expressions.qll",
+	"tsq::jsx":            "tsq_jsx.qll",
+	"tsq::imports":        "tsq_imports.qll",
+	"tsq::errors":         "tsq_errors.qll",
+	"tsq::types":          "tsq_types.qll",
+	"tsq::symbols":        "tsq_symbols.qll",
+	"tsq::callgraph":      "tsq_callgraph.qll",
+	"tsq::dataflow":       "tsq_dataflow.qll",
+	"tsq::summaries":      "tsq_summaries.qll",
+	"tsq::composition":    "tsq_composition.qll",
+	"tsq::taint":          "tsq_taint.qll",
+	"tsq::express":        "tsq_express.qll",
+	"tsq::react":          "tsq_react.qll",
+	"tsq::node":           "tsq_node.qll",
+	"javascript":          "compat_javascript.qll",
+	"DataFlow::PathGraph": "compat_dataflow.qll",
+	"TaintTracking":       "compat_tainttracking.qll",
+	"semmle.javascript.security.dataflow.XssQuery":              "compat_security_xss.qll",
+	"semmle.javascript.security.dataflow.CommandInjectionQuery": "compat_security_cmdi.qll",
+	"semmle.javascript.security.dataflow.SqlInjectionQuery":     "compat_security_sqli.qll",
+	"semmle.javascript.security.dataflow.PathTraversalQuery":    "compat_security_pathtraversal.qll",
+	"semmle.javascript.security.dataflow.DomBasedXssQuery":      "compat_dom.qll",
+	"semmle.javascript.security.CryptoLibraries":                "compat_crypto.qll",
+	"semmle.javascript.frameworks.HTTP":                         "compat_http.qll",
+	"semmle.javascript.security.dataflow.DatabaseAccess":        "compat_io.qll",
+	"semmle.javascript.security.dataflow.FileSystemAccess":      "compat_io.qll",
+	"semmle.javascript.security.dataflow.RegExpInjectionQuery":  "compat_regexp.qll",
+}
+
 // ImportLoader returns a function suitable for use as the importLoader
 // parameter to resolve.Resolve. It checks the bridge embed first, returning
 // the .qll source for known bridge paths. For unknown paths it returns nil.
@@ -61,42 +98,8 @@ func LoadBridge() map[string][]byte {
 //	loader := bridge.ImportLoader(bridgeFiles, parseFunc)
 //	resolved, err := resolve.Resolve(mod, loader)
 func ImportLoader(bridgeFiles map[string][]byte, parseFn func(src, file string) interface{}) func(path string) (interface{}, bool) {
-	// Map import paths (e.g. "tsq::base") to filenames.
-	pathToFile := map[string]string{
-		"tsq::base":           "tsq_base.qll",
-		"tsq::functions":      "tsq_functions.qll",
-		"tsq::calls":          "tsq_calls.qll",
-		"tsq::variables":      "tsq_variables.qll",
-		"tsq::expressions":    "tsq_expressions.qll",
-		"tsq::jsx":            "tsq_jsx.qll",
-		"tsq::imports":        "tsq_imports.qll",
-		"tsq::errors":         "tsq_errors.qll",
-		"tsq::types":          "tsq_types.qll",
-		"tsq::symbols":        "tsq_symbols.qll",
-		"tsq::callgraph":      "tsq_callgraph.qll",
-		"tsq::dataflow":       "tsq_dataflow.qll",
-		"tsq::summaries":      "tsq_summaries.qll",
-		"tsq::composition":    "tsq_composition.qll",
-		"tsq::taint":          "tsq_taint.qll",
-		"tsq::express":        "tsq_express.qll",
-		"tsq::react":          "tsq_react.qll",
-		"tsq::node":           "tsq_node.qll",
-		"javascript":          "compat_javascript.qll",
-		"DataFlow::PathGraph": "compat_dataflow.qll",
-		"TaintTracking":       "compat_tainttracking.qll",
-		"semmle.javascript.security.dataflow.XssQuery":              "compat_security_xss.qll",
-		"semmle.javascript.security.dataflow.CommandInjectionQuery": "compat_security_cmdi.qll",
-		"semmle.javascript.security.dataflow.SqlInjectionQuery":     "compat_security_sqli.qll",
-		"semmle.javascript.security.dataflow.PathTraversalQuery":    "compat_security_pathtraversal.qll",
-		"semmle.javascript.security.dataflow.DomBasedXssQuery":      "compat_dom.qll",
-		"semmle.javascript.security.CryptoLibraries":                "compat_crypto.qll",
-		"semmle.javascript.frameworks.HTTP":                         "compat_http.qll",
-		"semmle.javascript.security.dataflow.DatabaseAccess":        "compat_io.qll",
-		"semmle.javascript.security.dataflow.FileSystemAccess":      "compat_io.qll",
-		"semmle.javascript.security.dataflow.RegExpInjectionQuery":  "compat_regexp.qll",
-	}
 	return func(path string) (interface{}, bool) {
-		filename, ok := pathToFile[path]
+		filename, ok := ImportPathToFile[path]
 		if !ok {
 			return nil, false
 		}

--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -17,6 +17,8 @@ import (
 	"github.com/Gjdoalfnrxu/tsq/bridge"
 	"github.com/Gjdoalfnrxu/tsq/extract"
 	"github.com/Gjdoalfnrxu/tsq/extract/db"
+	"github.com/Gjdoalfnrxu/tsq/extract/rules"
+	"github.com/Gjdoalfnrxu/tsq/extract/schema"
 	"github.com/Gjdoalfnrxu/tsq/extract/typecheck"
 	"github.com/Gjdoalfnrxu/tsq/output"
 	"github.com/Gjdoalfnrxu/tsq/ql/ast"
@@ -53,18 +55,13 @@ func run(args []string, stdout, stderr io.Writer) int {
 	}
 
 	// Parse global flags that appear before the subcommand.
-	var verbose, quiet bool
+	// verbose and quiet are accepted for forward compatibility but not yet wired up.
 	var timeout time.Duration
 
 	// Find the subcommand: skip global flags.
 	subcmdIdx := -1
 	for i, arg := range args {
-		if arg == "--verbose" || arg == "-verbose" {
-			verbose = true
-			continue
-		}
-		if arg == "--quiet" || arg == "-quiet" {
-			quiet = true
+		if arg == "--verbose" || arg == "-verbose" || arg == "--quiet" || arg == "-quiet" {
 			continue
 		}
 		if strings.HasPrefix(arg, "--timeout=") || strings.HasPrefix(arg, "-timeout=") {
@@ -109,9 +106,6 @@ func run(args []string, stdout, stderr io.Writer) int {
 		ctx, tcancel = context.WithTimeout(ctx, timeout)
 		defer tcancel()
 	}
-
-	_ = verbose // available for future use
-	_ = quiet
 
 	switch subcmd {
 	case "version":
@@ -531,17 +525,11 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string) (*eval.Result
 		return nil, fmt.Errorf("desugar errors:\n  %s", strings.Join(msgs, "\n  "))
 	}
 
-	// Plan.
-	execPlan, planErrors := plan.Plan(prog, nil)
-	if len(planErrors) > 0 {
-		var msgs []string
-		for _, e := range planErrors {
-			msgs = append(msgs, e.Error())
-		}
-		return nil, fmt.Errorf("plan errors:\n  %s", strings.Join(msgs, "\n  "))
-	}
+	// Inject system rules so derived relations (CallTarget, LocalFlow, TaintAlert, etc.)
+	// are available for evaluation.
+	prog = rules.MergeSystemRules(prog, rules.AllSystemRules())
 
-	// Load fact DB.
+	// Load fact DB before planning so we can pass actual tuple counts as size hints.
 	f, err := os.Open(dbFile)
 	if err != nil {
 		return nil, fmt.Errorf("open fact DB: %w", err)
@@ -558,6 +546,20 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string) (*eval.Result
 		return nil, fmt.Errorf("read fact DB: %w", err)
 	}
 
+	// Build size hints from actual tuple counts in the DB so the planner can
+	// order joins by true relation size rather than a uniform default of 1000.
+	sizeHints := buildSizeHints(factDB)
+
+	// Plan.
+	execPlan, planErrors := plan.Plan(prog, sizeHints)
+	if len(planErrors) > 0 {
+		var msgs []string
+		for _, e := range planErrors {
+			msgs = append(msgs, e.Error())
+		}
+		return nil, fmt.Errorf("plan errors:\n  %s", strings.Join(msgs, "\n  "))
+	}
+
 	// Evaluate.
 	evaluator := eval.NewEvaluator(execPlan, factDB)
 	rs, err := evaluator.Evaluate(ctx)
@@ -568,42 +570,10 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string) (*eval.Result
 }
 
 // makeBridgeImportLoader creates an import loader that parses bridge .qll files.
+// It uses bridge.ImportPathToFile as the single source of truth for the path→filename map.
 func makeBridgeImportLoader(bridgeFiles map[string][]byte) func(path string) (*ast.Module, error) {
-	pathToFile := map[string]string{
-		"tsq::base":           "tsq_base.qll",
-		"tsq::functions":      "tsq_functions.qll",
-		"tsq::calls":          "tsq_calls.qll",
-		"tsq::variables":      "tsq_variables.qll",
-		"tsq::expressions":    "tsq_expressions.qll",
-		"tsq::jsx":            "tsq_jsx.qll",
-		"tsq::imports":        "tsq_imports.qll",
-		"tsq::errors":         "tsq_errors.qll",
-		"tsq::types":          "tsq_types.qll",
-		"tsq::symbols":        "tsq_symbols.qll",
-		"tsq::callgraph":      "tsq_callgraph.qll",
-		"tsq::dataflow":       "tsq_dataflow.qll",
-		"tsq::summaries":      "tsq_summaries.qll",
-		"tsq::composition":    "tsq_composition.qll",
-		"tsq::taint":          "tsq_taint.qll",
-		"tsq::express":        "tsq_express.qll",
-		"tsq::react":          "tsq_react.qll",
-		"tsq::node":           "tsq_node.qll",
-		"javascript":          "compat_javascript.qll",
-		"DataFlow::PathGraph": "compat_dataflow.qll",
-		"TaintTracking":       "compat_tainttracking.qll",
-		"semmle.javascript.security.dataflow.XssQuery":              "compat_security_xss.qll",
-		"semmle.javascript.security.dataflow.CommandInjectionQuery": "compat_security_cmdi.qll",
-		"semmle.javascript.security.dataflow.SqlInjectionQuery":     "compat_security_sqli.qll",
-		"semmle.javascript.security.dataflow.PathTraversalQuery":    "compat_security_pathtraversal.qll",
-		"semmle.javascript.security.dataflow.DomBasedXssQuery":      "compat_dom.qll",
-		"semmle.javascript.security.CryptoLibraries":                "compat_crypto.qll",
-		"semmle.javascript.frameworks.HTTP":                         "compat_http.qll",
-		"semmle.javascript.security.dataflow.DatabaseAccess":        "compat_io.qll",
-		"semmle.javascript.security.dataflow.FileSystemAccess":      "compat_io.qll",
-		"semmle.javascript.security.dataflow.RegExpInjectionQuery":  "compat_regexp.qll",
-	}
 	return func(path string) (*ast.Module, error) {
-		filename, ok := pathToFile[path]
+		filename, ok := bridge.ImportPathToFile[path]
 		if !ok {
 			return nil, fmt.Errorf("unknown import: %s", path)
 		}
@@ -614,6 +584,17 @@ func makeBridgeImportLoader(bridgeFiles map[string][]byte) func(path string) (*a
 		p := parse.NewParser(string(data), filename)
 		return p.Parse()
 	}
+}
+
+// buildSizeHints constructs a relation-name→tuple-count map from the loaded factDB.
+// This gives the planner real cardinality data for join ordering instead of the
+// uniform default of 1000.
+func buildSizeHints(factDB *db.DB) map[string]int {
+	hints := make(map[string]int, len(schema.Registry))
+	for _, def := range schema.Registry {
+		hints[def.Name] = factDB.Relation(def.Name).Tuples()
+	}
+	return hints
 }
 
 func main() {

--- a/extract/scope.go
+++ b/extract/scope.go
@@ -1,6 +1,9 @@
 package extract
 
+import "sort"
+
 // scope.go implements in-file scope analysis on top of the ASTNode interface.
+// It uses a sorted slice of (startByte, *Scope) pairs for O(log n) findScope lookups.
 // It handles:
 //   - var declarations (function-scoped)
 //   - let/const declarations (block-scoped)
@@ -56,21 +59,27 @@ func (s *Scope) Resolve(name string, atByte int) (*Declaration, bool) {
 	return nil, false
 }
 
+// scopeEntry associates a byte offset with the innermost scope at that position.
+type scopeEntry struct {
+	startByte int
+	scope     *Scope
+}
+
 // ScopeAnalyzer builds a scope tree from an ASTNode CST and answers
 // in-file resolution queries.
 type ScopeAnalyzer struct {
 	filePath string
-	// nodeScope maps a node's start byte to the scope that contains it.
-	// We store the innermost scope at each function/block entry.
-	nodeScope map[int]*Scope
-	root      *Scope
+	// scopeEntries is a sorted (by startByte) list of scope assignments recorded
+	// during buildScope. Keeping it sorted lets findScope use binary search
+	// instead of a linear scan over the map.
+	scopeEntries []scopeEntry
+	root         *Scope
 }
 
 // NewScopeAnalyzer creates a ScopeAnalyzer for filePath.
 func NewScopeAnalyzer(filePath string) *ScopeAnalyzer {
 	return &ScopeAnalyzer{
-		filePath:  filePath,
-		nodeScope: make(map[int]*Scope),
+		filePath: filePath,
 	}
 }
 
@@ -95,7 +104,8 @@ func (sa *ScopeAnalyzer) buildScope(n ASTNode, blockScope, fnScope *Scope) {
 	startByte := sa.nodeStartByte(n)
 
 	// Record the scope for this node so Resolve can find it later.
-	sa.nodeScope[startByte] = blockScope
+	// Insert in sorted order for O(log n) findScope lookups.
+	sa.insertScopeEntry(startByte, blockScope)
 
 	switch kind {
 	case "FunctionDeclaration", "FunctionExpression", "ArrowFunction", "MethodDefinition",
@@ -424,20 +434,40 @@ func (sa *ScopeAnalyzer) Resolve(name string, atNode ASTNode) (*Declaration, boo
 	return scope.Resolve(name, startByte)
 }
 
-// findScope finds the innermost scope recorded for a byte offset.
-// It uses the closest recorded entry <= startByte.
-func (sa *ScopeAnalyzer) findScope(startByte int) *Scope {
-	// We stored scope entries at the start byte of each node that opens/is in a scope.
-	// Use the closest one <= startByte.
-	best := -1
-	var bestScope *Scope
-	for k, s := range sa.nodeScope {
-		if k <= startByte && k > best {
-			best = k
-			bestScope = s
-		}
+// insertScopeEntry inserts (startByte, scope) into the sorted scopeEntries slice.
+// Entries with duplicate startByte keys are overwritten (last write wins, matching
+// the previous map semantics where later buildScope calls for the same offset
+// would overwrite the earlier entry).
+func (sa *ScopeAnalyzer) insertScopeEntry(startByte int, scope *Scope) {
+	i := sort.Search(len(sa.scopeEntries), func(i int) bool {
+		return sa.scopeEntries[i].startByte >= startByte
+	})
+	if i < len(sa.scopeEntries) && sa.scopeEntries[i].startByte == startByte {
+		sa.scopeEntries[i].scope = scope
+		return
 	}
-	return bestScope
+	// Insert at position i.
+	sa.scopeEntries = append(sa.scopeEntries, scopeEntry{})
+	copy(sa.scopeEntries[i+1:], sa.scopeEntries[i:])
+	sa.scopeEntries[i] = scopeEntry{startByte: startByte, scope: scope}
+}
+
+// findScope finds the innermost scope recorded for a byte offset.
+// Uses binary search for O(log n) lookup — the closest entry <= startByte.
+func (sa *ScopeAnalyzer) findScope(startByte int) *Scope {
+	entries := sa.scopeEntries
+	if len(entries) == 0 {
+		return nil
+	}
+	// Find the rightmost entry with startByte <= target.
+	i := sort.Search(len(entries), func(i int) bool {
+		return entries[i].startByte > startByte
+	})
+	// i is the first index where startByte > target; the entry before it is <= target.
+	if i == 0 {
+		return nil
+	}
+	return entries[i-1].scope
 }
 
 // nodeStartByte returns the start byte of a node by summing line/col info.

--- a/output/sarif.go
+++ b/output/sarif.go
@@ -179,7 +179,8 @@ func tryBuildLocation(colIdx map[string]int, row []eval.Value) *sarifLocation {
 		}
 		if colCol >= 0 && colCol < len(row) {
 			if iv, ok := row[colCol].(eval.IntVal); ok {
-				region.StartColumn = int(iv.V)
+				// SARIF 2.1.0 requires 1-based column numbers; schema stores 0-based.
+				region.StartColumn = int(iv.V) + 1
 			}
 		}
 		if region.StartLine > 0 || region.StartColumn > 0 {

--- a/output/sarif_test.go
+++ b/output/sarif_test.go
@@ -82,8 +82,10 @@ func TestWriteSARIF_SingleResultWithLocation(t *testing.T) {
 	if pl.Region.StartLine != 42 {
 		t.Errorf("startLine = %d, want 42", pl.Region.StartLine)
 	}
-	if pl.Region.StartColumn != 10 {
-		t.Errorf("startColumn = %d, want 10", pl.Region.StartColumn)
+	// SARIF 2.1.0 requires 1-based columns; the schema stores 0-based (value 10),
+	// so we expect 11 after the +1 correction.
+	if pl.Region.StartColumn != 11 {
+		t.Errorf("startColumn = %d, want 11", pl.Region.StartColumn)
 	}
 }
 


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

Seven fixes identified in the April 2026 engineering review. All tests pass, `go vet` clean.

## Fixes

1. **P0 — CLI system rules not injected** (`cmd/tsq/main.go`): Added `rules.MergeSystemRules(prog, rules.AllSystemRules())` in `compileAndEval` after desugaring and before planning. Without this, all v2 derived relations (CallTarget, LocalFlow, TaintAlert, InterFlow, FlowStar, ParamToReturn) evaluated to empty through the CLI binary. Integration tests injected system rules themselves so they passed; the binary was silently broken.

2. **P1 — SARIF StartColumn off-by-one** (`output/sarif.go`, `output/sarif_test.go`): SARIF 2.1.0 requires 1-based column numbers. Changed `region.StartColumn = int(iv.V)` to `int(iv.V) + 1`. Updated the test to assert the correct 1-based value.

3. **Deduplicate import-path-to-file map** (`bridge/embed.go`, `cmd/tsq/main.go`): Extracted the 30-entry path→filename map to `bridge.ImportPathToFile` (exported var). `makeBridgeImportLoader` in main.go now references this single source of truth. Adding a new bridge file (e.g. for compat_react) now requires updating only `bridge/embed.go`.

4. **findScope O(n) → O(log n)** (`extract/scope.go`): Replaced `map[int]*Scope` + linear scan with a `[]scopeEntry` sorted slice. Insertions use `sort.Search` to find the insertion point (O(log n) amortised); lookups use binary search to find the rightmost entry ≤ startByte. All existing scope tests pass.

5. **Wire planner size hints from factDB** (`cmd/tsq/main.go`): Moved the factDB load before `plan.Plan()` and added `buildSizeHints()` which iterates `schema.Registry` and calls `factDB.Relation(name).Tuples()` for each relation. Real cardinality data is now passed to the join orderer instead of a uniform default of 1000.

6. **Fix BenchmarkMagicSet** (`benchmark_test.go`): The `with_magic_set` sub-benchmark was calling `benchmarkQuery(..., false)` — identical to `without_magic_set`. Changed to `true` so the magic-set code path is actually exercised.

7. **Remove unused verbose/quiet flag stubs** (`cmd/tsq/main.go`): Removed the `var verbose, quiet bool` declarations and the `_ = verbose; _ = quiet` dead assignments. The flags are still silently recognised and consumed in the arg-parsing loop to preserve CLI compatibility; they just no longer have named variables assigned.

## Not in this PR

- Named-column rule builder (Fix 3 in review item #3 — separate PR)
- tsgo PositionNodeID mismatch (review edge case — separate investigation)