### PR TITLE
feat(P8): add fuzz tests for QL parser and DB reader; fix reader OOB panic

### DIFF
--- a/extract/db/fuzz_test.go
+++ b/extract/db/fuzz_test.go
@@ -1,0 +1,110 @@
+package db
+
+// fuzz_test.go — Go 1.18+ fuzz tests for the binary fact DB reader.
+//
+// Run manually with:
+//
+//	go test -fuzz=FuzzReadDB ./extract/db/ -fuzztime=60s
+//
+// The seed corpus is seeded from a valid encoded DB so the fuzzer starts from
+// real binary data and mutates from there. This is more effective than starting
+// from random bytes because it exercises the actual parsing paths.
+//
+// Safety contract: ReadDB must NEVER panic on arbitrary byte input. It must
+// either return a valid *DB or return an error. A crash (nil dereference,
+// index out of bounds, integer overflow, etc.) is a bug.
+//
+// Note: ReadDB already has bounds checks (maxRelations = 1024, maxStrings = 16M)
+// that guard against obviously malicious inputs. The fuzz test probes for cases
+// where intermediate parsing steps panic before those guards fire.
+
+import (
+	"bytes"
+	"testing"
+)
+
+// FuzzReadDB feeds arbitrary bytes into the binary DB reader and asserts it
+// does not panic. ReadDB may return errors; that is expected and correct.
+// Any panic is a bug.
+func FuzzReadDB(f *testing.F) {
+	// Seed corpus: encode a real DB with non-trivial content so the fuzzer
+	// has a valid starting point for structural mutations.
+	validDB := makeSeededDB(f)
+	var buf bytes.Buffer
+	if err := validDB.Encode(&buf); err != nil {
+		f.Fatalf("seeding: encode DB: %v", err)
+	}
+	f.Add(buf.Bytes())
+
+	// Additional seeds: truncated header, wrong magic, zero-length.
+	f.Add([]byte{})                                  // empty input
+	f.Add([]byte("TSQ\x00"))                         // magic only, no version
+	f.Add([]byte("TSQ\x00\x01\x00\x00\x00"))         // magic + version, no counts
+	f.Add([]byte("XXXX\x00\x00\x00\x00"))            // wrong magic
+	f.Add(make([]byte, 16))                          // all-zero header
+	f.Add(bytes.Repeat([]byte{0xff}, 32))            // all-0xff
+	f.Add(append([]byte("TSQ\x00"), buf.Bytes()...)) // double magic
+	f.Add(buf.Bytes()[:len(buf.Bytes())/2])          // truncated mid-stream
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		r := bytes.NewReader(data)
+		// The contract is no panic, not no error.
+		//nolint:errcheck // intentional: we only care about panics, not errors
+		_, _ = ReadDB(r, int64(len(data)))
+	})
+}
+
+// makeSeededDB returns a *DB populated with representative tuples across
+// several schema-registered relations. This gives the fuzzer a realistic
+// binary structure to start mutating from.
+func makeSeededDB(f *testing.F) *DB {
+	f.Helper()
+	database := NewDB()
+
+	// File relation: 2 files.
+	fr := database.Relation("File")
+	if err := fr.AddTuple(database, int32(1001), "/src/main.ts", "sha256:abc"); err != nil {
+		f.Fatalf("AddTuple File 1: %v", err)
+	}
+	if err := fr.AddTuple(database, int32(1002), "/src/utils.ts", "sha256:def"); err != nil {
+		f.Fatalf("AddTuple File 2: %v", err)
+	}
+
+	// Node relation: several AST nodes.
+	nr := database.Relation("Node")
+	for i, row := range [][]interface{}{
+		{int32(2001), int32(1001), "FunctionDeclaration", int32(1), int32(0), int32(5), int32(0)},
+		{int32(2002), int32(1001), "CallExpression", int32(3), int32(4), int32(3), int32(20)},
+		{int32(2003), int32(1002), "ArrowFunction", int32(1), int32(10), int32(1), int32(30)},
+	} {
+		if err := nr.AddTuple(database, row...); err != nil {
+			f.Fatalf("AddTuple Node %d: %v", i, err)
+		}
+	}
+
+	// Function relation.
+	fnr := database.Relation("Function")
+	if err := fnr.AddTuple(database, int32(2001), "processData", int32(0), int32(0), int32(0), int32(0)); err != nil {
+		f.Fatalf("AddTuple Function: %v", err)
+	}
+
+	// Call relation.
+	cr := database.Relation("Call")
+	if err := cr.AddTuple(database, int32(2002), int32(2003), int32(2)); err != nil {
+		f.Fatalf("AddTuple Call: %v", err)
+	}
+
+	// CallArg relation.
+	car := database.Relation("CallArg")
+	if err := car.AddTuple(database, int32(2002), int32(0), int32(3001)); err != nil {
+		f.Fatalf("AddTuple CallArg: %v", err)
+	}
+
+	// SchemaVersion — exactly one.
+	sv := database.Relation("SchemaVersion")
+	if err := sv.AddTuple(database, int32(SchemaVersion)); err != nil {
+		f.Fatalf("AddTuple SchemaVersion: %v", err)
+	}
+
+	return database
+}

--- a/extract/db/reader.go
+++ b/extract/db/reader.go
@@ -137,6 +137,9 @@ func ReadDB(r io.ReaderAt, size int64) (*DB, error) {
 }
 
 func readStringTable(r io.ReaderAt, fileSize int64, strCount uint32, strTableStart int64, le binary.ByteOrder) ([]string, error) {
+	if strTableStart < 0 || strTableStart > fileSize {
+		return nil, fmt.Errorf("string table offset %d out of file bounds (size %d)", strTableStart, fileSize)
+	}
 	strData := make([]byte, fileSize-strTableStart)
 	if _, err := r.ReadAt(strData, strTableStart); err != nil {
 		return nil, err

--- a/ql/parse/fuzz_test.go
+++ b/ql/parse/fuzz_test.go
@@ -68,16 +68,16 @@ func FuzzLexer(f *testing.F) {
 	f.Fuzz(func(t *testing.T, src string) {
 		l := parse.NewLexer(src, "fuzz.ql")
 		// Drain all tokens — the lexer must terminate on all inputs.
+		maxTokens := len(src)*2 + 100
+		count := 0
 		for {
 			tok := l.Next()
 			if tok.Type == parse.TokEOF {
 				break
 			}
-			// Safety: avoid infinite loops on lexers that never reach EOF.
-			// Use a generous upper bound relative to input length.
-			if len(src)+1024 < 0 {
-				// This branch is unreachable but documents the bound intent.
-				t.Fatal("unreachable")
+			count++
+			if count > maxTokens {
+				t.Fatalf("lexer produced %d tokens without EOF on input of length %d", count, len(src))
 			}
 		}
 	})

--- a/ql/parse/fuzz_test.go
+++ b/ql/parse/fuzz_test.go
@@ -1,0 +1,143 @@
+package parse_test
+
+// fuzz_test.go — Go 1.18+ fuzz tests for the QL parser and lexer.
+//
+// These tests are NOT run in CI (they'd take too long). Run manually with:
+//
+//	go test -fuzz=FuzzParser ./ql/parse/ -fuzztime=60s
+//	go test -fuzz=FuzzLexer  ./ql/parse/ -fuzztime=60s
+//
+// The seed corpus is seeded from the real .ql/.qll files under testdata/queries/
+// and bridge/ so the fuzzer starts from valid inputs and mutates from there.
+// This maximises coverage of interesting parser paths rather than random bytes.
+//
+// Safety contract: the parser and lexer must NEVER panic on arbitrary input.
+// They may return errors; that is expected and correct. A crash (nil dereference,
+// index out of bounds, stack overflow on deeply nested input, etc.) is a bug.
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/parse"
+)
+
+// FuzzParser feeds arbitrary bytes into the QL parser and asserts it does not panic.
+// The parser may return a *parse.Error for syntactically invalid input — that is
+// expected. Any panic is a bug.
+func FuzzParser(f *testing.F) {
+	// Seed from real .ql and .qll files in the repo so the fuzzer starts from
+	// valid inputs and explores from there, maximising coverage.
+	addQueryCorpus(f)
+
+	f.Fuzz(func(t *testing.T, src string) {
+		// The contract is no panic, not no error. Errors are fine.
+		p := parse.NewParser(src, "fuzz.ql")
+		//nolint:errcheck // intentional: we only care about panics, not errors
+		_, _ = p.Parse()
+	})
+}
+
+// FuzzLexer feeds arbitrary bytes into the QL lexer and asserts it does not panic
+// and always terminates. The lexer must consume all input and return EOF without
+// hanging or panicking.
+func FuzzLexer(f *testing.F) {
+	addQueryCorpus(f)
+
+	// Extra seeds that target lexer edge cases: unterminated strings, lone slashes,
+	// very long identifiers, NUL bytes, high unicode.
+	edgeCases := []string{
+		`"unterminated string`,
+		`/* unterminated block comment`,
+		`//`,
+		`/`,
+		strings.Repeat("a", 4096),
+		"\x00\x01\x02",
+		"αβγδεζηθ",
+		`"\n\t\r\\"`,
+		`:: :: ::`,
+		`@@ @`,
+	}
+	for _, seed := range edgeCases {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, src string) {
+		l := parse.NewLexer(src, "fuzz.ql")
+		// Drain all tokens — the lexer must terminate on all inputs.
+		for {
+			tok := l.Next()
+			if tok.Type == parse.TokEOF {
+				break
+			}
+			// Safety: avoid infinite loops on lexers that never reach EOF.
+			// Use a generous upper bound relative to input length.
+			if len(src)+1024 < 0 {
+				// This branch is unreachable but documents the bound intent.
+				t.Fatal("unreachable")
+			}
+		}
+	})
+}
+
+// addQueryCorpus reads real .ql and .qll files from the repo and adds them
+// as fuzz seed corpus entries. This gives the fuzzer real-world starting points
+// so coverage expands from valid syntax rather than starting from random bytes.
+func addQueryCorpus(f *testing.F) {
+	f.Helper()
+
+	// Locate the repo root relative to this file.
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return
+	}
+	// thisFile is ql/parse/fuzz_test.go; root is two levels up.
+	repoRoot := filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
+
+	var dirs []string
+	dirs = append(dirs, filepath.Join(repoRoot, "bridge"))
+	dirs = append(dirs, filepath.Join(repoRoot, "testdata", "queries"))
+	dirs = append(dirs, filepath.Join(repoRoot, "testdata", "queries", "v2"))
+	dirs = append(dirs, filepath.Join(repoRoot, "testdata", "compat"))
+
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue // directory may not exist in all build contexts
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			if !strings.HasSuffix(name, ".ql") && !strings.HasSuffix(name, ".qll") {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(dir, name))
+			if err != nil {
+				continue
+			}
+			f.Add(string(data))
+		}
+	}
+
+	// Always add a handful of minimal seeds so the corpus is never empty.
+	for _, seed := range []string{
+		`from Function f select f.getName()`,
+		`import tsq::functions
+from Function f
+select f.getName() as "name"`,
+		`import tsq::taint
+from TaintAlert a
+select a.getSrcKind() as "srcKind"`,
+		`class Foo extends Bar { Foo() { Bar() } }`,
+		`predicate p(int x) { x = 1 }`,
+		``,    // empty input
+		`!!!`, // all-invalid input
+	} {
+		f.Add(seed)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `FuzzParser` and `FuzzLexer` in `ql/parse/fuzz_test.go` — feeds arbitrary string input to the QL parser and lexer, seeded from real `.ql`/`.qll` files in `testdata/` and `bridge/`. Verifies no panics on any input.
- Adds `FuzzReadDB` in `extract/db/fuzz_test.go` — feeds arbitrary bytes to the binary fact DB reader, seeded from a real encoded DB plus common adversarial inputs (empty, wrong magic, truncated, all-zeros, all-0xff, double-magic). Verifies no panics.
- Both fuzz tests are for manual use only (`go test -fuzz=FuzzParser ./ql/parse/ -fuzztime=60s`); not run in CI. Seed corpus runs as normal tests on every `go test`.
- Also fixes a panic caught by `FuzzReadDB` seed corpus: `readStringTable` in `extract/db/reader.go` called `make([]byte, fileSize-strTableStart)` without checking `strTableStart <= fileSize`, causing a signed integer overflow and `makeslice: len out of range` panic on the double-magic seed. Added a bounds check before the `make` call.

## Test plan

- [x] `go test ./extract/db/...` — passes (including all fuzz seed cases)
- [x] `go test ./ql/parse/...` — passes (including all fuzz seed cases)
- [x] `go test ./...` — all 17 packages pass
- [x] `go vet ./...` — clean