### PR TITLE
fix(cmd): unify cmdCheck/cmdQuery via shared buildProgram

### DIFF
--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -424,20 +424,26 @@ func cmdCheck(args []string, stdout, stderr io.Writer) int {
 	// would surface during evaluation (e.g. system-rule planning failures) are
 	// caught here. The fact DB is not loaded, so size hints are nil — the
 	// planner uses its default heuristics.
-	_, mod, buildErrs := buildProgram(string(src), queryFile, importLoader, nil)
+	_, mod, resolveWarnings, buildErrs := buildProgram(string(src), queryFile, importLoader, nil)
 
 	hasErrors := false
-	if buildErrs != nil {
+	if len(buildErrs) > 0 {
 		for _, e := range buildErrs {
 			fmt.Fprintf(stderr, "  %s\n", e.Error())
 		}
 		hasErrors = true
 	}
 
-	// Surface deprecation warnings (non-fatal). buildProgram returns the
-	// parsed module even on later-stage errors so we can still report these.
+	// Surface resolve-phase deprecation warnings (non-fatal). These were
+	// previously emitted by cmdCheck directly; preserve that behaviour now
+	// that resolution happens inside buildProgram.
+	for _, w := range resolveWarnings {
+		fmt.Fprintf(stderr, "  %s\n", w.String())
+	}
+
+	// Surface bridge capability warnings. buildProgram returns the parsed
+	// module even on later-stage errors so we can still report these.
 	if mod != nil {
-		// Capability warnings.
 		manifest := bridge.V1Manifest()
 		var imports []string
 		for _, imp := range mod.Imports {
@@ -467,25 +473,28 @@ func cmdCheck(args []string, stdout, stderr io.Writer) int {
 // sizeHints may be nil; the planner will use its default heuristics in that
 // case. The parsed *ast.Module is returned even when later phases produce
 // errors, so callers can still surface things like capability warnings.
-func buildProgram(src, file string, importLoader func(string) (*ast.Module, error), sizeHints map[string]int) (*plan.ExecutionPlan, *ast.Module, []error) {
+// Resolve-phase warnings (e.g. deprecated imports) are returned alongside
+// errors so callers can surface them regardless of whether later phases ran.
+func buildProgram(src, file string, importLoader func(string) (*ast.Module, error), sizeHints map[string]int) (*plan.ExecutionPlan, *ast.Module, []resolve.Warning, []error) {
 	// Parse.
 	p := parse.NewParser(src, file)
 	mod, err := p.Parse()
 	if err != nil {
-		return nil, nil, []error{fmt.Errorf("parse: %w", err)}
+		return nil, nil, nil, []error{fmt.Errorf("parse: %w", err)}
 	}
 
 	// Resolve.
 	resolved, err := resolve.Resolve(mod, importLoader)
 	if err != nil {
-		return nil, mod, []error{fmt.Errorf("resolve: %w", err)}
+		return nil, mod, nil, []error{fmt.Errorf("resolve: %w", err)}
 	}
+	warnings := resolved.Warnings
 	if len(resolved.Errors) > 0 {
 		errs := make([]error, 0, len(resolved.Errors))
 		for _, e := range resolved.Errors {
 			errs = append(errs, fmt.Errorf("resolve: %w", e))
 		}
-		return nil, mod, errs
+		return nil, mod, warnings, errs
 	}
 
 	// Desugar.
@@ -495,7 +504,7 @@ func buildProgram(src, file string, importLoader func(string) (*ast.Module, erro
 		for _, e := range dsErrors {
 			errs = append(errs, fmt.Errorf("desugar: %w", e))
 		}
-		return nil, mod, errs
+		return nil, mod, warnings, errs
 	}
 
 	// Inject system rules so derived relations (CallTarget, LocalFlow,
@@ -511,10 +520,10 @@ func buildProgram(src, file string, importLoader func(string) (*ast.Module, erro
 		for _, e := range planErrors {
 			errs = append(errs, fmt.Errorf("plan: %w", e))
 		}
-		return nil, mod, errs
+		return nil, mod, warnings, errs
 	}
 
-	return execPlan, mod, nil
+	return execPlan, mod, warnings, nil
 }
 
 // compileAndEval reads a .ql file, compiles it, loads a fact DB, and evaluates.
@@ -549,7 +558,7 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string) (*eval.Result
 	// rule graph (parse → resolve → desugar → MergeSystemRules → plan).
 	bridgeFiles := bridge.LoadBridge()
 	importLoader := makeBridgeImportLoader(bridgeFiles)
-	execPlan, _, buildErrs := buildProgram(string(src), queryFile, importLoader, sizeHints)
+	execPlan, _, _, buildErrs := buildProgram(string(src), queryFile, importLoader, sizeHints)
 	if len(buildErrs) > 0 {
 		// Reproduce the prior multi-error formatting of compileAndEval: group
 		// by phase and join with newline-indented messages so callers see one

--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -417,64 +417,37 @@ func cmdCheck(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	// Parse.
-	p := parse.NewParser(string(src), queryFile)
-	mod, err := p.Parse()
-	if err != nil {
-		fmt.Fprintf(stderr, "parse error: %v\n", err)
-		return 1
-	}
-
-	// Resolve with bridge loader.
 	bridgeFiles := bridge.LoadBridge()
 	importLoader := makeBridgeImportLoader(bridgeFiles)
-	resolved, err := resolve.Resolve(mod, importLoader)
-	if err != nil {
-		fmt.Fprintf(stderr, "resolve error: %v\n", err)
-		return 1
-	}
 
-	// Surface deprecation warnings (non-fatal).
-	for _, w := range resolved.Warnings {
-		fmt.Fprintf(stderr, "  %s\n", w.String())
-	}
+	// Run the same compilation pipeline used by `query` so that issues which
+	// would surface during evaluation (e.g. system-rule planning failures) are
+	// caught here. The fact DB is not loaded, so size hints are nil — the
+	// planner uses its default heuristics.
+	_, mod, buildErrs := buildProgram(string(src), queryFile, importLoader, nil)
 
 	hasErrors := false
-	if len(resolved.Errors) > 0 {
-		for _, e := range resolved.Errors {
+	if buildErrs != nil {
+		for _, e := range buildErrs {
 			fmt.Fprintf(stderr, "  %s\n", e.Error())
 		}
 		hasErrors = true
 	}
 
-	// Desugar.
-	prog, dsErrors := desugar.Desugar(resolved)
-	if len(dsErrors) > 0 {
-		for _, e := range dsErrors {
-			fmt.Fprintf(stderr, "  desugar: %v\n", e)
+	// Surface deprecation warnings (non-fatal). buildProgram returns the
+	// parsed module even on later-stage errors so we can still report these.
+	if mod != nil {
+		// Capability warnings.
+		manifest := bridge.V1Manifest()
+		var imports []string
+		for _, imp := range mod.Imports {
+			imports = append(imports, imp.Path)
 		}
-		hasErrors = true
-	}
-
-	// Plan.
-	_, planErrors := plan.Plan(prog, nil)
-	if len(planErrors) > 0 {
-		for _, e := range planErrors {
-			fmt.Fprintf(stderr, "  plan: %v\n", e)
+		warnings := manifest.CheckQuery(imports)
+		for _, w := range warnings {
+			fmt.Fprintf(stdout, "warning: import %q uses unavailable feature (%s, expected %s)\n",
+				w.Import, w.Reason, w.VersionTarget)
 		}
-		hasErrors = true
-	}
-
-	// Capability warnings.
-	manifest := bridge.V1Manifest()
-	var imports []string
-	for _, imp := range mod.Imports {
-		imports = append(imports, imp.Path)
-	}
-	warnings := manifest.CheckQuery(imports)
-	for _, w := range warnings {
-		fmt.Fprintf(stdout, "warning: import %q uses unavailable feature (%s, expected %s)\n",
-			w.Import, w.Reason, w.VersionTarget)
 	}
 
 	if hasErrors {
@@ -486,48 +459,70 @@ func cmdCheck(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
+// buildProgram runs the shared QL compilation pipeline used by both `check`
+// and `query`: parse → resolve → desugar → MergeSystemRules → plan. Both
+// callers must use this helper so that a query which passes `check` cannot
+// later hang or OOM in `query` due to a divergent rule graph (issue #82).
+//
+// sizeHints may be nil; the planner will use its default heuristics in that
+// case. The parsed *ast.Module is returned even when later phases produce
+// errors, so callers can still surface things like capability warnings.
+func buildProgram(src, file string, importLoader func(string) (*ast.Module, error), sizeHints map[string]int) (*plan.ExecutionPlan, *ast.Module, []error) {
+	// Parse.
+	p := parse.NewParser(src, file)
+	mod, err := p.Parse()
+	if err != nil {
+		return nil, nil, []error{fmt.Errorf("parse: %w", err)}
+	}
+
+	// Resolve.
+	resolved, err := resolve.Resolve(mod, importLoader)
+	if err != nil {
+		return nil, mod, []error{fmt.Errorf("resolve: %w", err)}
+	}
+	if len(resolved.Errors) > 0 {
+		errs := make([]error, 0, len(resolved.Errors))
+		for _, e := range resolved.Errors {
+			errs = append(errs, fmt.Errorf("resolve: %w", e))
+		}
+		return nil, mod, errs
+	}
+
+	// Desugar.
+	prog, dsErrors := desugar.Desugar(resolved)
+	if len(dsErrors) > 0 {
+		errs := make([]error, 0, len(dsErrors))
+		for _, e := range dsErrors {
+			errs = append(errs, fmt.Errorf("desugar: %w", e))
+		}
+		return nil, mod, errs
+	}
+
+	// Inject system rules so derived relations (CallTarget, LocalFlow,
+	// TaintAlert, etc.) are present in the planned graph. This used to live
+	// only in `query`, which meant `check` could green-light a program whose
+	// system-rule-augmented form failed to plan or hung at eval time.
+	prog = rules.MergeSystemRules(prog, rules.AllSystemRules())
+
+	// Plan.
+	execPlan, planErrors := plan.Plan(prog, sizeHints)
+	if len(planErrors) > 0 {
+		errs := make([]error, 0, len(planErrors))
+		for _, e := range planErrors {
+			errs = append(errs, fmt.Errorf("plan: %w", e))
+		}
+		return nil, mod, errs
+	}
+
+	return execPlan, mod, nil
+}
+
 // compileAndEval reads a .ql file, compiles it, loads a fact DB, and evaluates.
 func compileAndEval(ctx context.Context, queryFile, dbFile string) (*eval.ResultSet, error) {
 	src, err := os.ReadFile(queryFile)
 	if err != nil {
 		return nil, fmt.Errorf("read query file: %w", err)
 	}
-
-	// Parse.
-	p := parse.NewParser(string(src), queryFile)
-	mod, err := p.Parse()
-	if err != nil {
-		return nil, fmt.Errorf("parse: %w", err)
-	}
-
-	// Resolve.
-	bridgeFiles := bridge.LoadBridge()
-	importLoader := makeBridgeImportLoader(bridgeFiles)
-	resolved, err := resolve.Resolve(mod, importLoader)
-	if err != nil {
-		return nil, fmt.Errorf("resolve: %w", err)
-	}
-	if len(resolved.Errors) > 0 {
-		var msgs []string
-		for _, e := range resolved.Errors {
-			msgs = append(msgs, e.Error())
-		}
-		return nil, fmt.Errorf("resolve errors:\n  %s", strings.Join(msgs, "\n  "))
-	}
-
-	// Desugar.
-	prog, dsErrors := desugar.Desugar(resolved)
-	if len(dsErrors) > 0 {
-		var msgs []string
-		for _, e := range dsErrors {
-			msgs = append(msgs, e.Error())
-		}
-		return nil, fmt.Errorf("desugar errors:\n  %s", strings.Join(msgs, "\n  "))
-	}
-
-	// Inject system rules so derived relations (CallTarget, LocalFlow, TaintAlert, etc.)
-	// are available for evaluation.
-	prog = rules.MergeSystemRules(prog, rules.AllSystemRules())
 
 	// Load fact DB before planning so we can pass actual tuple counts as size hints.
 	f, err := os.Open(dbFile)
@@ -550,14 +545,16 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string) (*eval.Result
 	// order joins by true relation size rather than a uniform default of 1000.
 	sizeHints := buildSizeHints(factDB)
 
-	// Plan.
-	execPlan, planErrors := plan.Plan(prog, sizeHints)
-	if len(planErrors) > 0 {
-		var msgs []string
-		for _, e := range planErrors {
-			msgs = append(msgs, e.Error())
-		}
-		return nil, fmt.Errorf("plan errors:\n  %s", strings.Join(msgs, "\n  "))
+	// Compile via the shared pipeline so that `check` and `query` agree on the
+	// rule graph (parse → resolve → desugar → MergeSystemRules → plan).
+	bridgeFiles := bridge.LoadBridge()
+	importLoader := makeBridgeImportLoader(bridgeFiles)
+	execPlan, _, buildErrs := buildProgram(string(src), queryFile, importLoader, sizeHints)
+	if len(buildErrs) > 0 {
+		// Reproduce the prior multi-error formatting of compileAndEval: group
+		// by phase and join with newline-indented messages so callers see one
+		// error per phase boundary rather than a flat error.Join blob.
+		return nil, joinPhaseErrors(buildErrs)
 	}
 
 	// Evaluate.
@@ -567,6 +564,39 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string) (*eval.Result
 		return nil, fmt.Errorf("evaluate: %w", err)
 	}
 	return rs, nil
+}
+
+// joinPhaseErrors reformats a slice of phase-prefixed errors back into the
+// "<phase> errors:\n  <msg1>\n  <msg2>" shape that compileAndEval used to
+// produce. Callers (cmdQuery via stderr) parse this for human display only.
+func joinPhaseErrors(errs []error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	// Group consecutive errors that share the same prefix (e.g. "desugar:").
+	// In practice buildProgram only returns errors from a single phase per
+	// call, so this is just a faithful flatten with the phase header.
+	prefix := ""
+	if i := strings.Index(errs[0].Error(), ":"); i > 0 {
+		prefix = errs[0].Error()[:i]
+	}
+	var msgs []string
+	for _, e := range errs {
+		s := e.Error()
+		// Trim the "<phase>: " prefix added by buildProgram so it's not
+		// repeated on every line of the joined output.
+		if prefix != "" && strings.HasPrefix(s, prefix+": ") {
+			s = s[len(prefix)+2:]
+		}
+		msgs = append(msgs, s)
+	}
+	if prefix == "" {
+		return fmt.Errorf("errors:\n  %s", strings.Join(msgs, "\n  "))
+	}
+	return fmt.Errorf("%s errors:\n  %s", prefix, strings.Join(msgs, "\n  "))
 }
 
 // makeBridgeImportLoader creates an import loader that parses bridge .qll files.

--- a/cmd/tsq/main_test.go
+++ b/cmd/tsq/main_test.go
@@ -181,7 +181,7 @@ select x
 `
 	loader := makeBridgeImportLoader(bridgeLoadForTest())
 
-	checkPlan, _, errs := buildProgram(src, "test.ql", loader, nil)
+	checkPlan, _, _, errs := buildProgram(src, "test.ql", loader, nil)
 	if len(errs) > 0 {
 		t.Fatalf("buildProgram (check config) returned errors: %v", errs)
 	}
@@ -204,7 +204,7 @@ select x
 	}
 
 	// Now build a second plan with size hints, simulating the `query` path.
-	queryPlan, _, errs := buildProgram(src, "test.ql", loader, map[string]int{"Node": 100, "Call": 50})
+	queryPlan, _, _, errs := buildProgram(src, "test.ql", loader, map[string]int{"Node": 100, "Call": 50})
 	if len(errs) > 0 {
 		t.Fatalf("buildProgram (query config) returned errors: %v", errs)
 	}

--- a/cmd/tsq/main_test.go
+++ b/cmd/tsq/main_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/bridge"
 )
 
 func TestVersion(t *testing.T) {
@@ -153,6 +155,86 @@ func TestUsageErrorExitCode(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Regression for issue #82: cmdCheck must run the same compilation pipeline
+// as cmdQuery, including rules.MergeSystemRules. Before the fix, `check`
+// stopped at user-program planning and would green-light a query that later
+// failed (or hung / OOM'd) inside `query` because the system-rule-augmented
+// rule graph differed.
+//
+// We assert two things:
+//  1. buildProgram's resulting plan contains rules whose head names come
+//     from the system-rule set (e.g. "CallTarget"). This proves
+//     MergeSystemRules ran during the shared pipeline, which both `check`
+//     and `query` now go through.
+//  2. The plans built with sizeHints=nil (the `check` configuration) and
+//     sizeHints=non-nil (the `query` configuration with real DB cardinality)
+//     contain the same set of rule head predicates — i.e. the rule graph is
+//     identical, only join ordering may differ. This is the exact
+//     equivalence that issue #82 required.
+func TestBuildProgramMergesSystemRulesForCheck(t *testing.T) {
+	src := `import tsq::base
+from int x
+where x = 1
+select x
+`
+	loader := makeBridgeImportLoader(bridgeLoadForTest())
+
+	checkPlan, _, errs := buildProgram(src, "test.ql", loader, nil)
+	if len(errs) > 0 {
+		t.Fatalf("buildProgram (check config) returned errors: %v", errs)
+	}
+	if checkPlan == nil {
+		t.Fatal("buildProgram (check config) returned nil plan")
+	}
+
+	// Collect head predicate names from every stratum.
+	heads := make(map[string]bool)
+	for _, stratum := range checkPlan.Strata {
+		for _, r := range stratum.Rules {
+			heads[r.Head.Predicate] = true
+		}
+	}
+
+	// CallTarget is defined in extract/rules/callgraph.go (CallGraphRules).
+	// Its presence proves MergeSystemRules ran inside buildProgram.
+	if !heads["CallTarget"] {
+		t.Errorf("expected CallTarget rule head in plan (proof of MergeSystemRules), got heads: %v", heads)
+	}
+
+	// Now build a second plan with size hints, simulating the `query` path.
+	queryPlan, _, errs := buildProgram(src, "test.ql", loader, map[string]int{"Node": 100, "Call": 50})
+	if len(errs) > 0 {
+		t.Fatalf("buildProgram (query config) returned errors: %v", errs)
+	}
+	queryHeads := make(map[string]bool)
+	for _, stratum := range queryPlan.Strata {
+		for _, r := range stratum.Rules {
+			queryHeads[r.Head.Predicate] = true
+		}
+	}
+
+	// Plan rule-set must be identical between the two configurations: the
+	// only difference allowed is join ordering driven by size hints.
+	if len(heads) != len(queryHeads) {
+		t.Errorf("plan rule-head count differs: check=%d query=%d", len(heads), len(queryHeads))
+	}
+	for h := range heads {
+		if !queryHeads[h] {
+			t.Errorf("head %q present in check plan but absent in query plan", h)
+		}
+	}
+	for h := range queryHeads {
+		if !heads[h] {
+			t.Errorf("head %q present in query plan but absent in check plan", h)
+		}
+	}
+}
+
+// bridgeLoadForTest wraps bridge.LoadBridge so the test reads clearly.
+func bridgeLoadForTest() map[string][]byte {
+	return bridge.LoadBridge()
 }
 
 // Regression: global flags followed by a valid subcommand should work.


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

Closes #82.

## Summary

`cmdCheck` and `cmdQuery` (`compileAndEval`) had divergent compilation pipelines: `cmdQuery` called `rules.MergeSystemRules(prog, rules.AllSystemRules())` before planning, but `cmdCheck` did not. This meant a query could pass `tsq check` and then hang or OOM under `tsq query` because the rule graph the planner actually saw differed between the two commands. Finding F26 in the April eng-review.

This PR extracts a shared `buildProgram` helper that runs the full pipeline — `parse → resolve → desugar → MergeSystemRules → plan` — and routes both `cmdCheck` and `compileAndEval` through it. `cmdCheck` passes `nil` sizeHints (no fact DB), `compileAndEval` passes the real per-relation tuple counts. Behaviour for valid programs is unchanged; error formatting for invalid programs is preserved (phase prefixes intact, `compileAndEval`'s multi-line `\"<phase> errors:\\n  ...\"` shape reproduced via `joinPhaseErrors`).

```go
func buildProgram(
    src, file string,
    importLoader func(string) (*ast.Module, error),
    sizeHints map[string]int,
) (*plan.ExecutionPlan, *ast.Module, []error)
```

The parsed `*ast.Module` is returned even on later-phase errors so `cmdCheck` can still surface capability warnings.

## Scope

- `cmd/tsq/main.go` — refactor only, no other files touched
- `cmd/tsq/main_test.go` — new regression test

## Test Plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1 -short` all packages pass
- [x] New test: `TestBuildProgramMergesSystemRulesForCheck` in `cmd/tsq/main_test.go`
  - Asserts the plan returned by the check-config call (`sizeHints=nil`) contains `CallTarget` rule heads — proof that `MergeSystemRules` ran during `check`
  - Asserts the check-config and query-config plans agree on the full rule head set, so any planning failure surfaced by `query` is now also surfaced by `check`
- [x] Existing `cmd/tsq` tests unaffected (TestVersion, TestCheckMissingArgs, TestQueryBadFormat, TestCheckNonexistentFile, TestHelpExitCode, etc.)