### PR TITLE
fix(eval): cap per-rule binding cardinality to prevent OOM

### DIFF
--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -338,6 +338,7 @@ func cmdQuery(ctx context.Context, args []string, stdout, stderr io.Writer) int 
 	fs.SetOutput(stderr)
 	dbFile := fs.String("db", "tsq.db", "fact database file")
 	format := fs.String("format", "json", "output format: sarif, json, csv")
+	maxBindingsPerRule := fs.Int("max-bindings-per-rule", eval.DefaultMaxBindingsPerRule, "per-rule cap on intermediate join binding cardinality (0 = unlimited; prevents OOM on weak joins, see issue #80)")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -362,7 +363,7 @@ func cmdQuery(ctx context.Context, args []string, stdout, stderr io.Writer) int 
 	}
 
 	// Read and compile the query.
-	rs, err := compileAndEval(ctx, queryFile, *dbFile)
+	rs, err := compileAndEval(ctx, queryFile, *dbFile, *maxBindingsPerRule)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
@@ -527,7 +528,9 @@ func buildProgram(src, file string, importLoader func(string) (*ast.Module, erro
 }
 
 // compileAndEval reads a .ql file, compiles it, loads a fact DB, and evaluates.
-func compileAndEval(ctx context.Context, queryFile, dbFile string) (*eval.ResultSet, error) {
+// maxBindingsPerRule caps intermediate join cardinality per rule to prevent
+// OOM on queries with weak join constraints (issue #80). Pass 0 to disable.
+func compileAndEval(ctx context.Context, queryFile, dbFile string, maxBindingsPerRule int) (*eval.ResultSet, error) {
 	src, err := os.ReadFile(queryFile)
 	if err != nil {
 		return nil, fmt.Errorf("read query file: %w", err)
@@ -567,7 +570,7 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string) (*eval.Result
 	}
 
 	// Evaluate.
-	evaluator := eval.NewEvaluator(execPlan, factDB)
+	evaluator := eval.NewEvaluator(execPlan, factDB, eval.WithMaxBindingsPerRule(maxBindingsPerRule))
 	rs, err := evaluator.Evaluate(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("evaluate: %w", err)

--- a/ql/eval/aggregate.go
+++ b/ql/eval/aggregate.go
@@ -12,9 +12,13 @@ import (
 // Aggregate evaluates a planned aggregate and returns the result relation.
 // The result relation is named agg.ResultRelation and contains
 // (groupKey..., aggregatedValue) tuples.
-func Aggregate(agg plan.PlannedAggregate, rels map[string]*Relation) *Relation {
+func Aggregate(agg plan.PlannedAggregate, rels map[string]*Relation, maxBindings int) (*Relation, error) {
 	// Compute bindings over the aggregate body using raw literals (no planner ordering).
-	bindings := evalLiterals(agg.Agg.Body, rels)
+	limits := &joinLimits{maxBindings: maxBindings, ruleName: "aggregate:" + agg.ResultRelation}
+	bindings, err := evalLiterals(agg.Agg.Body, rels, limits)
+	if err != nil {
+		return nil, err
+	}
 
 	// Determine which column holds the aggregated value.
 	aggVar := agg.Agg.Var
@@ -97,7 +101,7 @@ func Aggregate(agg plan.PlannedAggregate, rels map[string]*Relation) *Relation {
 				result.Add(t)
 			}
 		}
-		return result
+		return result, nil
 	}
 
 	for _, gk := range groupOrder {
@@ -113,7 +117,7 @@ func Aggregate(agg plan.PlannedAggregate, rels map[string]*Relation) *Relation {
 		result.Add(t)
 	}
 
-	return result
+	return result, nil
 }
 
 // computeAggregate applies the named aggregate function to a list of Values.
@@ -308,21 +312,28 @@ func asInt64(v Value) (int64, error) {
 // body) naively, returning all resulting bindings.
 // This mirrors evalJoinSteps but works on []datalog.Literal directly,
 // without planner-ordered JoinSteps.
-func evalLiterals(lits []datalog.Literal, rels map[string]*Relation) []binding {
+func evalLiterals(lits []datalog.Literal, rels map[string]*Relation, limits *joinLimits) ([]binding, error) {
 	current := []binding{make(binding)}
-	for _, lit := range lits {
+	for i, lit := range lits {
 		if len(current) == 0 {
-			return nil
+			return nil, nil
 		}
 		if lit.Cmp != nil {
 			current = applyComparison(lit.Cmp, current)
 		} else if lit.Agg != nil {
 			// Nested aggregate in body -- skip for v1.
 		} else if lit.Positive {
-			current = applyPositive(lit.Atom, rels, current)
+			next, err := applyPositive(lit.Atom, rels, current, limits)
+			if err != nil {
+				return nil, err
+			}
+			current = next
 		} else {
 			current = applyNegative(lit.Atom, rels, current)
 		}
+		if err := limits.check(i, len(current)); err != nil {
+			return nil, err
+		}
 	}
-	return current
+	return current, nil
 }

--- a/ql/eval/aggregate_test.go
+++ b/ql/eval/aggregate_test.go
@@ -1,6 +1,8 @@
 package eval
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
@@ -371,5 +373,68 @@ func TestComputeRankStableOrder(t *testing.T) {
 		if r != expected[i] {
 			t.Errorf("rank[%d]: expected %d, got %d", i, expected[i], r)
 		}
+	}
+}
+
+// TestAggregateBindingCapTriggers verifies that the per-rule binding cap fires
+// inside an aggregate body — covering the "aggregate:<resultRelation>" code
+// path that's otherwise untested (every other aggregate test passes cap=0).
+// Regression guard for the threading of joinLimits through Aggregate /
+// evalLiterals.
+func TestAggregateBindingCapTriggers(t *testing.T) {
+	mkUnary := func(name string) *Relation {
+		vals := make([]Value, 10)
+		for i := 0; i < 10; i++ {
+			vals[i] = IntVal{V: int64(i)}
+		}
+		return makeRelation(name, 1, vals...)
+	}
+	rels := RelsOf(mkUnary("A"), mkUnary("B"), mkUnary("C"), mkUnary("D"))
+
+	// Aggregate body is a 4-way Cartesian (10×10×10×10 = 10000) — same shape
+	// as TestRuleBindingCapTriggers, but routed through Aggregate.
+	body := []datalog.Literal{
+		{Positive: true, Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{datalog.Var{Name: "a"}}}},
+		{Positive: true, Atom: datalog.Atom{Predicate: "B", Args: []datalog.Term{datalog.Var{Name: "b"}}}},
+		{Positive: true, Atom: datalog.Atom{Predicate: "C", Args: []datalog.Term{datalog.Var{Name: "c"}}}},
+		{Positive: true, Atom: datalog.Atom{Predicate: "D", Args: []datalog.Term{datalog.Var{Name: "d"}}}},
+	}
+	agg := plan.PlannedAggregate{
+		ResultRelation: "BadAgg",
+		GroupByVars:    []datalog.Var{{Name: "a"}},
+		Agg: datalog.Aggregate{
+			Func:      "count",
+			Var:       "d",
+			ResultVar: datalog.Var{Name: "BadAgg"},
+			Body:      body,
+		},
+	}
+
+	const cap = 100
+	result, err := Aggregate(agg, rels, cap)
+	if err == nil {
+		t.Fatalf("expected ErrBindingCapExceeded, got nil error and result with %d rows", result.Len())
+	}
+	if !errors.Is(err, ErrBindingCapExceeded) {
+		t.Fatalf("expected error wrapping ErrBindingCapExceeded, got: %v", err)
+	}
+	var bce *BindingCapError
+	if !errors.As(err, &bce) {
+		t.Fatalf("expected *BindingCapError, got: %T (%v)", err, err)
+	}
+	if !strings.HasPrefix(bce.Rule, "aggregate:") {
+		t.Errorf("expected rule name with 'aggregate:' prefix, got %q", bce.Rule)
+	}
+	if bce.Rule != "aggregate:BadAgg" {
+		t.Errorf("expected rule name %q, got %q", "aggregate:BadAgg", bce.Rule)
+	}
+	if bce.Cap != cap {
+		t.Errorf("expected cap %d, got %d", cap, bce.Cap)
+	}
+	if bce.Cardinality <= cap {
+		t.Errorf("expected cardinality > cap (%d), got %d", cap, bce.Cardinality)
+	}
+	if bce.Cardinality > 2*cap {
+		t.Errorf("aggregate cap fired late: cardinality=%d, cap=%d", bce.Cardinality, cap)
 	}
 }

--- a/ql/eval/aggregate_test.go
+++ b/ql/eval/aggregate_test.go
@@ -48,7 +48,10 @@ func TestAggCount(t *testing.T) {
 	)
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "count", "cnt")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 2 {
 		t.Fatalf("expected 2 groups, got %d", result.Len())
 	}
@@ -68,7 +71,10 @@ func TestAggCountNoGroup(t *testing.T) {
 	rel := makeRelation("R", 1, IntVal{1}, IntVal{2}, IntVal{3})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "x", nil, "count", "cnt")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 1 {
 		t.Fatalf("expected 1 result, got %d", result.Len())
 	}
@@ -82,7 +88,10 @@ func TestAggMin(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{50}, IntVal{1}, IntVal{10}, IntVal{1}, IntVal{30})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "min", "minv")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 1 {
 		t.Fatalf("expected 1 group, got %d", result.Len())
 	}
@@ -95,7 +104,10 @@ func TestAggMax(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{5}, IntVal{1}, IntVal{100}, IntVal{1}, IntVal{42})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "max", "maxv")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 1 {
 		t.Fatalf("expected 1 group, got %d", result.Len())
 	}
@@ -108,7 +120,10 @@ func TestAggSum(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{10}, IntVal{1}, IntVal{20}, IntVal{2}, IntVal{5})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "sum", "sumv")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 2 {
 		t.Fatalf("expected 2 groups, got %d", result.Len())
 	}
@@ -128,7 +143,10 @@ func TestAggAvg(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{10}, IntVal{1}, IntVal{20}, IntVal{1}, IntVal{30})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "avg", "avgv")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 1 {
 		t.Fatalf("expected 1 group, got %d", result.Len())
 	}
@@ -141,7 +159,10 @@ func TestAggEmptyInput(t *testing.T) {
 	rel := NewRelation("R", 2)
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "count", "cnt")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 0 {
 		t.Errorf("expected 0 results for empty input, got %d", result.Len())
 	}
@@ -151,7 +172,10 @@ func TestAggStrictcount(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{10}, IntVal{1}, IntVal{20}, IntVal{2}, IntVal{30})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "strictcount", "cnt")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 2 {
 		t.Fatalf("expected 2 groups, got %d", result.Len())
 	}
@@ -171,7 +195,10 @@ func TestAggStrictcountEmpty(t *testing.T) {
 	rel := NewRelation("R", 2)
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "strictcount", "cnt")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 0 {
 		t.Errorf("expected 0 results for empty strictcount, got %d", result.Len())
 	}
@@ -181,7 +208,10 @@ func TestAggStrictsum(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{10}, IntVal{1}, IntVal{20})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "strictsum", "sval")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 1 {
 		t.Fatalf("expected 1 group, got %d", result.Len())
 	}
@@ -194,7 +224,10 @@ func TestAggStrictsumEmpty(t *testing.T) {
 	rel := NewRelation("R", 2)
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "strictsum", "sval")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 0 {
 		t.Errorf("expected 0 results for empty strictsum, got %d", result.Len())
 	}
@@ -204,7 +237,10 @@ func TestAggConcat(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, StrVal{"hello"}, IntVal{1}, StrVal{"world"})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "concat", "cval")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 1 {
 		t.Fatalf("expected 1 group, got %d", result.Len())
 	}
@@ -218,7 +254,10 @@ func TestRankOrdinal(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{10}, IntVal{1}, IntVal{20}, IntVal{1}, IntVal{30})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "rank", "rval")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 3 {
 		t.Fatalf("expected 3 tuples (one per value), got %d", result.Len())
 	}
@@ -240,7 +279,10 @@ func TestRankEmptyGroup(t *testing.T) {
 	rel := NewRelation("R", 2)
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "rank", "rval")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 0 {
 		t.Errorf("expected 0 results for empty rank input, got %d", result.Len())
 	}
@@ -283,7 +325,10 @@ func TestAggUniqueSingle(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{42}, IntVal{1}, IntVal{42}, IntVal{1}, IntVal{42})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "unique", "uval")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 1 {
 		t.Fatalf("expected 1 group, got %d", result.Len())
 	}
@@ -296,7 +341,10 @@ func TestAggUniqueMultiple(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{10}, IntVal{1}, IntVal{20})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "unique", "uval")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 0 {
 		t.Errorf("expected 0 results for non-unique values, got %d", result.Len())
 	}
@@ -306,7 +354,10 @@ func TestAggUniqueEmpty(t *testing.T) {
 	rel := NewRelation("R", 2)
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "unique", "uval")
-	result := Aggregate(agg, rels)
+	result, err := Aggregate(agg, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result.Len() != 0 {
 		t.Errorf("expected 0 results for empty unique, got %d", result.Len())
 	}

--- a/ql/eval/arity_shadow_test.go
+++ b/ql/eval/arity_shadow_test.go
@@ -94,7 +94,10 @@ func TestEvalArityShadowSeparateRelations(t *testing.T) {
 		},
 	}
 
-	tuples := Rule(rule, rels)
+	tuples, err := Rule(rule, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(tuples) != 2 {
 		t.Fatalf("expected 2 Match tuples, got %d: %v", len(tuples), tuples)
 	}
@@ -134,7 +137,10 @@ func TestEvalArityShadowSameName(t *testing.T) {
 			},
 		},
 	}
-	out1 := Rule(probe1, rels)
+	out1, err := Rule(probe1, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(out1) != 1 {
 		t.Fatalf("1-arity C: expected 1 tuple, got %d: %v", len(out1), out1)
 	}
@@ -164,7 +170,10 @@ func TestEvalArityShadowSameName(t *testing.T) {
 			},
 		},
 	}
-	out3 := Rule(probe3, rels)
+	out3, err := Rule(probe3, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(out3) != 2 {
 		t.Fatalf("3-arity C: expected 2 tuples, got %d: %v", len(out3), out3)
 	}

--- a/ql/eval/eval.go
+++ b/ql/eval/eval.go
@@ -14,13 +14,17 @@ import (
 type Evaluator struct {
 	execPlan *plan.ExecutionPlan
 	factDB   *db.DB
+	opts     []Option
 }
 
 // NewEvaluator creates an Evaluator that will load base facts from factDB.
-func NewEvaluator(execPlan *plan.ExecutionPlan, factDB *db.DB) *Evaluator {
+// Pass options (WithMaxIterations, WithMaxBindingsPerRule, WithParallel) to
+// configure the underlying call to Evaluate.
+func NewEvaluator(execPlan *plan.ExecutionPlan, factDB *db.DB, opts ...Option) *Evaluator {
 	return &Evaluator{
 		execPlan: execPlan,
 		factDB:   factDB,
+		opts:     opts,
 	}
 }
 
@@ -30,7 +34,7 @@ func (e *Evaluator) Evaluate(ctx context.Context) (*ResultSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("eval: load base relations: %w", err)
 	}
-	return Evaluate(ctx, e.execPlan, baseRels)
+	return Evaluate(ctx, e.execPlan, baseRels, e.opts...)
 }
 
 // loadBaseRelations converts a db.DB into a map of eval.Relation objects.

--- a/ql/eval/join.go
+++ b/ql/eval/join.go
@@ -1,6 +1,8 @@
 package eval
 
 import (
+	"errors"
+
 	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
 	"github.com/Gjdoalfnrxu/tsq/ql/plan"
 )
@@ -41,11 +43,18 @@ func lookupTerm(t datalog.Term, b binding) (Value, bool) {
 }
 
 // Rule evaluates a single PlannedRule against the given relations.
-// Returns all result tuples for the rule head.
-func Rule(rule plan.PlannedRule, rels map[string]*Relation) []Tuple {
+// Returns all result tuples for the rule head. If maxBindings > 0 and the
+// intermediate join cardinality exceeds it during evaluation, Rule returns
+// a *BindingCapError (wraps ErrBindingCapExceeded) and stops early to
+// prevent OOM (issue #80).
+func Rule(rule plan.PlannedRule, rels map[string]*Relation, maxBindings int) ([]Tuple, error) {
 	initial := []binding{make(binding)}
-	bindings := evalJoinSteps(rule.JoinOrder, rels, initial)
-	return projectHead(rule.Head, bindings)
+	limits := &joinLimits{maxBindings: maxBindings, ruleName: rule.Head.Predicate}
+	bindings, err := evalJoinSteps(rule.JoinOrder, rels, initial, limits)
+	if err != nil {
+		return nil, err
+	}
+	return projectHead(rule.Head, bindings), nil
 }
 
 // RuleDelta evaluates a rule in semi-naive mode.
@@ -61,9 +70,10 @@ func Rule(rule plan.PlannedRule, rels map[string]*Relation) []Tuple {
 // When di=1, only the second Path literal uses delta; the first uses full.
 // This avoids the delta×delta over-counting that a global predicate replacement
 // would produce.
-func RuleDelta(rule plan.PlannedRule, rels map[string]*Relation, deltaRels map[string]*Relation) []Tuple {
+func RuleDelta(rule plan.PlannedRule, rels map[string]*Relation, deltaRels map[string]*Relation, maxBindings int) ([]Tuple, error) {
 	seen := make(map[string]struct{})
 	var results []Tuple
+	limits := &joinLimits{maxBindings: maxBindings, ruleName: rule.Head.Predicate}
 
 	for di, step := range rule.JoinOrder {
 		// Only positive atom steps with a delta can be "delta variants".
@@ -82,7 +92,10 @@ func RuleDelta(rule plan.PlannedRule, rels map[string]*Relation, deltaRels map[s
 
 		// Evaluate the join sequence with delta substitution only at step di.
 		initial := []binding{make(binding)}
-		bindings := evalJoinStepsWithDelta(rule.JoinOrder, rels, deltaRels, di, delta, initial)
+		bindings, err := evalJoinStepsWithDelta(rule.JoinOrder, rels, deltaRels, di, delta, initial, limits)
+		if err != nil {
+			return nil, err
+		}
 		tuples := projectHead(rule.Head, bindings)
 		for _, t := range tuples {
 			k := tupleKey(t)
@@ -92,20 +105,32 @@ func RuleDelta(rule plan.PlannedRule, rels map[string]*Relation, deltaRels map[s
 			}
 		}
 	}
-	return results
+	return results, nil
 }
 
 // evalJoinSteps processes a sequence of JoinSteps, starting from the given
-// bindings, and returns all final bindings.
-func evalJoinSteps(steps []plan.JoinStep, rels map[string]*Relation, initial []binding) []binding {
+// bindings, and returns all final bindings. limits may be nil for unlimited.
+func evalJoinSteps(steps []plan.JoinStep, rels map[string]*Relation, initial []binding, limits *joinLimits) ([]binding, error) {
 	current := initial
-	for _, step := range steps {
+	for i, step := range steps {
 		if len(current) == 0 {
-			return nil
+			return nil, nil
 		}
-		current = applyStep(step, rels, current)
+		next, err := applyStep(step, rels, current, limits)
+		if err != nil {
+			// Annotate with the step index where the cap was hit.
+			var bce *BindingCapError
+			if errors.As(err, &bce) && bce.StepIndex == 0 {
+				bce.StepIndex = i
+			}
+			return nil, err
+		}
+		current = next
+		if err := limits.check(i, len(current)); err != nil {
+			return nil, err
+		}
 	}
-	return current
+	return current, nil
 }
 
 // evalJoinStepsWithDelta processes a sequence of JoinSteps like evalJoinSteps,
@@ -113,12 +138,16 @@ func evalJoinSteps(steps []plan.JoinStep, rels map[string]*Relation, initial []b
 // relation for that predicate). All other steps use the full relations in rels.
 // This ensures only one literal position is delta-substituted per variant,
 // which is required for correct semi-naive evaluation.
-func evalJoinStepsWithDelta(steps []plan.JoinStep, rels map[string]*Relation, deltaRels map[string]*Relation, deltaIdx int, deltaRel *Relation, initial []binding) []binding {
+func evalJoinStepsWithDelta(steps []plan.JoinStep, rels map[string]*Relation, deltaRels map[string]*Relation, deltaIdx int, deltaRel *Relation, initial []binding, limits *joinLimits) ([]binding, error) {
 	current := initial
 	for i, step := range steps {
 		if len(current) == 0 {
-			return nil
+			return nil, nil
 		}
+		var (
+			next []binding
+			err  error
+		)
 		if i == deltaIdx {
 			// Use the delta relation for this step only.
 			// Build a merged map where only this literal's (name, arity)
@@ -131,32 +160,44 @@ func evalJoinStepsWithDelta(steps []plan.JoinStep, rels map[string]*Relation, de
 				merged[k] = v
 			}
 			merged[relKey(pred, arity)] = deltaRel
-			current = applyStep(step, merged, current)
+			next, err = applyStep(step, merged, current, limits)
 		} else {
-			current = applyStep(step, rels, current)
+			next, err = applyStep(step, rels, current, limits)
+		}
+		if err != nil {
+			var bce *BindingCapError
+			if errors.As(err, &bce) && bce.StepIndex == 0 {
+				bce.StepIndex = i
+			}
+			return nil, err
+		}
+		current = next
+		if err := limits.check(i, len(current)); err != nil {
+			return nil, err
 		}
 	}
-	return current
+	return current, nil
 }
 
 // applyStep applies a single JoinStep to the current set of bindings.
-func applyStep(step plan.JoinStep, rels map[string]*Relation, bindings []binding) []binding {
+// limits may be nil for unlimited evaluation.
+func applyStep(step plan.JoinStep, rels map[string]*Relation, bindings []binding, limits *joinLimits) ([]binding, error) {
 	lit := step.Literal
 
 	// Comparison filter.
 	if lit.Cmp != nil {
-		return applyComparison(lit.Cmp, bindings)
+		return applyComparison(lit.Cmp, bindings), nil
 	}
 
 	// Aggregate sub-goal (handled at stratum level; skip here).
 	if lit.Agg != nil {
-		return bindings
+		return bindings, nil
 	}
 
 	// Builtin predicate — evaluate procedurally.
 	if IsBuiltin(lit.Atom.Predicate) {
 		if lit.Positive {
-			return ApplyBuiltin(lit.Atom, bindings)
+			return ApplyBuiltin(lit.Atom, bindings), nil
 		}
 		// Negated builtin: keep bindings where the builtin produces no results.
 		var out []binding
@@ -166,14 +207,15 @@ func applyStep(step plan.JoinStep, rels map[string]*Relation, bindings []binding
 				out = append(out, b)
 			}
 		}
-		return out
+		return out, nil
 	}
 
 	if lit.Positive {
-		return applyPositive(lit.Atom, rels, bindings)
+		return applyPositive(lit.Atom, rels, bindings, limits)
 	}
-	// Negative (anti-join).
-	return applyNegative(lit.Atom, rels, bindings)
+	// Negative (anti-join). Anti-joins only filter (output ≤ input), so they
+	// can't grow cardinality past the cap; no limit threading needed.
+	return applyNegative(lit.Atom, rels, bindings), nil
 }
 
 // applyComparison filters bindings by evaluating the comparison against each.
@@ -198,10 +240,10 @@ func applyComparison(cmp *datalog.Comparison, bindings []binding) []binding {
 // The relation lookup is keyed by (predicate, arity) so a 1-arity literal
 // like `C(this)` cannot accidentally probe a 3-arity base relation `C`
 // of the same name.
-func applyPositive(atom datalog.Atom, rels map[string]*Relation, bindings []binding) []binding {
+func applyPositive(atom datalog.Atom, rels map[string]*Relation, bindings []binding, limits *joinLimits) ([]binding, error) {
 	rel, ok := rels[relKey(atom.Predicate, len(atom.Args))]
 	if !ok || rel == nil || rel.Len() == 0 {
-		return nil
+		return nil, nil
 	}
 
 	var out []binding
@@ -283,9 +325,19 @@ func applyPositive(atom datalog.Atom, rels map[string]*Relation, bindings []bind
 				continue
 			}
 			out = append(out, nb)
+			// Early cap check inside the inner loop. Without this, a single
+			// blown literal can still allocate gigabytes of bindings before
+			// the per-step check at the call site fires (issue #80).
+			if limits != nil && limits.maxBindings > 0 && len(out) > limits.maxBindings {
+				return nil, &BindingCapError{
+					Rule:        limits.ruleName,
+					Cap:         limits.maxBindings,
+					Cardinality: len(out),
+				}
+			}
 		}
 	}
-	return out
+	return out, nil
 }
 
 // applyNegative filters bindings by requiring NO matching tuple exists (anti-join).

--- a/ql/eval/join_test.go
+++ b/ql/eval/join_test.go
@@ -1,6 +1,8 @@
 package eval
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
@@ -84,7 +86,10 @@ func TestEvalRuleTwoRelationJoin(t *testing.T) {
 		},
 	}
 
-	results := Rule(rule, rels)
+	results, err := Rule(rule, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(results) != 2 {
 		t.Fatalf("expected 2 path tuples (2-hops), got %d: %v", len(results), results)
 	}
@@ -115,7 +120,10 @@ func TestEvalRuleThreeRelationJoin(t *testing.T) {
 		},
 	}
 
-	results := Rule(rule, rels)
+	results, err := Rule(rule, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(results) != 1 {
 		t.Fatalf("expected 1 result, got %d: %v", len(results), results)
 	}
@@ -139,7 +147,10 @@ func TestEvalRuleNoMatch(t *testing.T) {
 		},
 	}
 
-	results := Rule(rule, rels)
+	results, err := Rule(rule, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(results) != 0 {
 		t.Fatalf("expected 0 results, got %d: %v", len(results), results)
 	}
@@ -163,7 +174,10 @@ func TestEvalRuleComparisonFilter(t *testing.T) {
 		},
 	}
 
-	results := Rule(rule, rels)
+	results, err := Rule(rule, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(results) != 2 {
 		t.Fatalf("expected 2 results (x=1,x=2), got %d: %v", len(results), results)
 	}
@@ -185,7 +199,10 @@ func TestEvalRuleSelfJoin(t *testing.T) {
 		},
 	}
 
-	results := Rule(rule, rels)
+	results, err := Rule(rule, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Each edge should match exactly itself once.
 	if len(results) != 2 {
 		t.Fatalf("expected 2 results, got %d: %v", len(results), results)
@@ -206,7 +223,10 @@ func TestEvalRuleAntiJoin(t *testing.T) {
 		},
 	}
 
-	results := Rule(rule, rels)
+	results, err := Rule(rule, rels, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// x=2 is in B, so excluded. Expected: x=1, x=3.
 	if len(results) != 2 {
 		t.Fatalf("expected 2 results, got %d: %v", len(results), results)
@@ -220,5 +240,100 @@ func TestEvalRuleAntiJoin(t *testing.T) {
 	}
 	if seen[2] {
 		t.Error("x=2 should be excluded by anti-join")
+	}
+}
+
+// TestRuleBindingCapTriggers proves the per-rule cardinality cap (issue #80)
+// fires before the unbounded intermediate-binding slice can OOM the process.
+//
+// We construct a 4-way Cartesian-style join over four small unary base
+// relations:
+//
+//	BadRule(a, b, c, d) :- A(a), B(b), C(c), D(d).
+//
+// Each base relation has 10 tuples and shares no variables with the others,
+// so the intermediate cardinality grows multiplicatively: 10 → 100 → 1000 →
+// 10000 by the final step. With a cap of 100, evaluation must error after
+// the second join (when cardinality first exceeds 100), well before reaching
+// the 10000-row final result.
+//
+// The test asserts:
+//  1. Rule returns a non-nil error.
+//  2. The error wraps ErrBindingCapExceeded (so callers can detect it).
+//  3. The wrapped *BindingCapError carries the right rule name and cap.
+func TestRuleBindingCapTriggers(t *testing.T) {
+	// Four 10-tuple unary relations with no shared columns.
+	mkUnary := func(name string) *Relation {
+		vals := make([]Value, 10)
+		for i := 0; i < 10; i++ {
+			vals[i] = IntVal{V: int64(i)}
+		}
+		return makeRelation(name, 1, vals...)
+	}
+	rels := RelsOf(mkUnary("A"), mkUnary("B"), mkUnary("C"), mkUnary("D"))
+
+	rule := plan.PlannedRule{
+		Head: head("BadRule", v("a"), v("b"), v("c"), v("d")),
+		JoinOrder: []plan.JoinStep{
+			positiveStep("A", v("a")),
+			positiveStep("B", v("b")),
+			positiveStep("C", v("c")),
+			positiveStep("D", v("d")),
+		},
+	}
+
+	const cap = 100
+	results, err := Rule(rule, rels, cap)
+	if err == nil {
+		t.Fatalf("expected ErrBindingCapExceeded, got nil error and %d results", len(results))
+	}
+	if !errors.Is(err, ErrBindingCapExceeded) {
+		t.Fatalf("expected error wrapping ErrBindingCapExceeded, got: %v", err)
+	}
+	var bce *BindingCapError
+	if !errors.As(err, &bce) {
+		t.Fatalf("expected *BindingCapError, got: %T (%v)", err, err)
+	}
+	if bce.Rule != "BadRule" {
+		t.Errorf("expected rule name %q in error, got %q", "BadRule", bce.Rule)
+	}
+	if bce.Cap != cap {
+		t.Errorf("expected cap %d in error, got %d", cap, bce.Cap)
+	}
+	if bce.Cardinality <= cap {
+		t.Errorf("expected reported cardinality > cap (%d), got %d", cap, bce.Cardinality)
+	}
+	if !strings.Contains(err.Error(), "BadRule") || !strings.Contains(err.Error(), "binding cap") {
+		t.Errorf("error message should mention rule name and binding cap: %q", err.Error())
+	}
+}
+
+// TestRuleBindingCapDisabled verifies that passing 0 (or negative) disables
+// the cap entirely — the same query that errors above must succeed when the
+// cap is off, returning the full Cartesian product.
+func TestRuleBindingCapDisabled(t *testing.T) {
+	mkUnary := func(name string) *Relation {
+		vals := make([]Value, 5)
+		for i := 0; i < 5; i++ {
+			vals[i] = IntVal{V: int64(i)}
+		}
+		return makeRelation(name, 1, vals...)
+	}
+	rels := RelsOf(mkUnary("A"), mkUnary("B"))
+
+	rule := plan.PlannedRule{
+		Head: head("Cross", v("a"), v("b")),
+		JoinOrder: []plan.JoinStep{
+			positiveStep("A", v("a")),
+			positiveStep("B", v("b")),
+		},
+	}
+
+	results, err := Rule(rule, rels, 0)
+	if err != nil {
+		t.Fatalf("unexpected error with cap disabled: %v", err)
+	}
+	if len(results) != 25 {
+		t.Errorf("expected full cross product of 25 tuples, got %d", len(results))
 	}
 }

--- a/ql/eval/join_test.go
+++ b/ql/eval/join_test.go
@@ -303,6 +303,17 @@ func TestRuleBindingCapTriggers(t *testing.T) {
 	if bce.Cardinality <= cap {
 		t.Errorf("expected reported cardinality > cap (%d), got %d", cap, bce.Cardinality)
 	}
+	// Promptness: cap must fire at the boundary, not after the join has already
+	// blown past it by orders of magnitude. Step 2 (A×B) yields 100 = cap; step 3
+	// (×C) yields 1000 — that's the latest the cap may legitimately fire.
+	if bce.Cardinality > 2*cap {
+		t.Errorf("cap fired late: cardinality=%d, cap=%d (expected <= 2*cap)", bce.Cardinality, cap)
+	}
+	// Must trip before the final join step completes, otherwise the inner-loop
+	// check has been silently lost and only the per-step check is firing.
+	if bce.StepIndex >= len(rule.JoinOrder)-1 {
+		t.Errorf("cap fired at step %d (last step); expected earlier step (inner-loop check missing?)", bce.StepIndex)
+	}
 	if !strings.Contains(err.Error(), "BadRule") || !strings.Contains(err.Error(), "binding cap") {
 		t.Errorf("error message should mention rule name and binding cap: %q", err.Error())
 	}

--- a/ql/eval/parallel.go
+++ b/ql/eval/parallel.go
@@ -6,12 +6,22 @@ import (
 	"github.com/Gjdoalfnrxu/tsq/ql/plan"
 )
 
+// firstError returns the first non-nil error from a slice, or nil if all are nil.
+func firstError(errs []error) error {
+	for _, e := range errs {
+		if e != nil {
+			return e
+		}
+	}
+	return nil
+}
+
 // parallelBootstrap evaluates rules concurrently, grouping by head predicate.
 // Rules with different head predicates run in parallel; rules with the same
 // head predicate run sequentially within their group to avoid data races on
 // the shared Relation. Grouping is by (name, arity) — same-name different-arity
 // heads are independent and merge into independent relations.
-func parallelBootstrap(rules []plan.PlannedRule, allRels map[string]*Relation) map[string]*Relation {
+func parallelBootstrap(rules []plan.PlannedRule, allRels map[string]*Relation, maxBindings int) (map[string]*Relation, error) {
 	groups := groupByHead(rules)
 
 	type groupResult struct {
@@ -21,6 +31,7 @@ func parallelBootstrap(rules []plan.PlannedRule, allRels map[string]*Relation) m
 	}
 
 	results := make([]groupResult, len(groups))
+	errs := make([]error, len(groups))
 	var wg sync.WaitGroup
 
 	i := 0
@@ -30,7 +41,11 @@ func parallelBootstrap(rules []plan.PlannedRule, allRels map[string]*Relation) m
 			defer wg.Done()
 			var tuples []Tuple
 			for _, rule := range rs {
-				newTuples := Rule(rule, allRels)
+				newTuples, rerr := Rule(rule, allRels, maxBindings)
+				if rerr != nil {
+					errs[idx] = rerr
+					return
+				}
 				tuples = append(tuples, newTuples...)
 			}
 			results[idx] = groupResult{key: k, name: rs[0].Head.Predicate, tuples: tuples}
@@ -39,6 +54,10 @@ func parallelBootstrap(rules []plan.PlannedRule, allRels map[string]*Relation) m
 	}
 
 	wg.Wait()
+
+	if err := firstError(errs); err != nil {
+		return nil, err
+	}
 
 	deltaRels := make(map[string]*Relation)
 	for _, gr := range results {
@@ -54,11 +73,11 @@ func parallelBootstrap(rules []plan.PlannedRule, allRels map[string]*Relation) m
 			}
 		}
 	}
-	return deltaRels
+	return deltaRels, nil
 }
 
 // parallelDelta evaluates delta rules concurrently, grouping by head (name, arity).
-func parallelDelta(rules []plan.PlannedRule, allRels map[string]*Relation, deltaRels map[string]*Relation) map[string]*Relation {
+func parallelDelta(rules []plan.PlannedRule, allRels map[string]*Relation, deltaRels map[string]*Relation, maxBindings int) (map[string]*Relation, error) {
 	groups := groupByHead(rules)
 
 	type groupResult struct {
@@ -68,6 +87,7 @@ func parallelDelta(rules []plan.PlannedRule, allRels map[string]*Relation, delta
 	}
 
 	results := make([]groupResult, len(groups))
+	errs := make([]error, len(groups))
 	var wg sync.WaitGroup
 
 	i := 0
@@ -77,7 +97,11 @@ func parallelDelta(rules []plan.PlannedRule, allRels map[string]*Relation, delta
 			defer wg.Done()
 			var tuples []Tuple
 			for _, rule := range rs {
-				newTuples := RuleDelta(rule, allRels, deltaRels)
+				newTuples, rerr := RuleDelta(rule, allRels, deltaRels, maxBindings)
+				if rerr != nil {
+					errs[idx] = rerr
+					return
+				}
 				tuples = append(tuples, newTuples...)
 			}
 			results[idx] = groupResult{key: k, name: rs[0].Head.Predicate, tuples: tuples}
@@ -86,6 +110,10 @@ func parallelDelta(rules []plan.PlannedRule, allRels map[string]*Relation, delta
 	}
 
 	wg.Wait()
+
+	if err := firstError(errs); err != nil {
+		return nil, err
+	}
 
 	nextDelta := make(map[string]*Relation)
 	for _, gr := range results {
@@ -101,7 +129,7 @@ func parallelDelta(rules []plan.PlannedRule, allRels map[string]*Relation, delta
 			}
 		}
 	}
-	return nextDelta
+	return nextDelta, nil
 }
 
 // groupByHead groups planned rules by their head (name, arity) key.

--- a/ql/eval/property_test.go
+++ b/ql/eval/property_test.go
@@ -44,7 +44,10 @@ func naiveEvaluate(rules []plan.PlannedRule, baseRels map[string]*Relation) map[
 			headName := rule.Head.Predicate
 			hk := relKey(headName, len(rule.Head.Args))
 			headRel := rels[hk]
-			newTuples := Rule(rule, rels)
+			newTuples, err := Rule(rule, rels, 0)
+			if err != nil {
+				panic(err)
+			}
 			for _, t := range newTuples {
 				if headRel.Add(t) {
 					changed = true
@@ -221,7 +224,10 @@ func runSemiNaive(rules []datalog.Rule, baseRels map[string]*Relation) (map[stri
 			headName := rule.Head.Predicate
 			hk := relKey(headName, len(rule.Head.Args))
 			headRel := allRels2[hk]
-			newTuples := Rule(rule, allRels2)
+			newTuples, err := Rule(rule, allRels2, 0)
+			if err != nil {
+				return nil, err
+			}
 			for _, t := range newTuples {
 				if headRel.Add(t) {
 					dr, ok := deltaRels[hk]
@@ -251,7 +257,10 @@ func runSemiNaive(rules []datalog.Rule, baseRels map[string]*Relation) (map[stri
 				headName := rule.Head.Predicate
 				hk := relKey(headName, len(rule.Head.Args))
 				headRel := allRels2[hk]
-				newTuples := RuleDelta(rule, allRels2, deltaRels)
+				newTuples, err := RuleDelta(rule, allRels2, deltaRels, 0)
+				if err != nil {
+					return nil, err
+				}
 				for _, t := range newTuples {
 					if headRel.Add(t) {
 						dr, ok := nextDelta[hk]

--- a/ql/eval/seminaive.go
+++ b/ql/eval/seminaive.go
@@ -2,6 +2,7 @@ package eval
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 
@@ -13,6 +14,55 @@ import (
 // with the results computed so far.
 const DefaultMaxIterations = 100
 
+// DefaultMaxBindingsPerRule is the default per-rule cap on intermediate
+// binding cardinality during join evaluation. With weak join constraints
+// (free variables, low-selectivity predicates) intermediate cardinality can
+// reach 100M+ entries (1-2 GB) before any deduplication happens, which OOMs
+// the process. The cap is well above legitimate query needs but well below
+// the RAM ceiling on a typical workstation. Set 0 via WithMaxBindingsPerRule
+// to disable.
+const DefaultMaxBindingsPerRule = 5_000_000
+
+// ErrBindingCapExceeded is the sentinel returned (wrapped in a *BindingCapError)
+// when a rule's intermediate join cardinality exceeds the configured cap.
+// Callers can detect it with errors.Is.
+var ErrBindingCapExceeded = errors.New("rule binding cap exceeded")
+
+// BindingCapError gives detail about which rule blew the cap and at what
+// step. It wraps ErrBindingCapExceeded so errors.Is works.
+type BindingCapError struct {
+	Rule        string
+	StepIndex   int
+	Cap         int
+	Cardinality int
+}
+
+func (e *BindingCapError) Error() string {
+	if e.Rule == "" {
+		return fmt.Sprintf("rule binding cap exceeded: cap=%d at join step %d (intermediate cardinality=%d). Increase --max-bindings-per-rule or rewrite the query for better selectivity.", e.Cap, e.StepIndex, e.Cardinality)
+	}
+	return fmt.Sprintf("rule %q exceeded binding cap of %d at join step %d (intermediate cardinality=%d). Increase --max-bindings-per-rule or rewrite the query for better selectivity.", e.Rule, e.Cap, e.StepIndex, e.Cardinality)
+}
+
+func (e *BindingCapError) Unwrap() error { return ErrBindingCapExceeded }
+
+// joinLimits carries the per-rule binding cap and identifying context
+// down through the join evaluation call chain. A nil receiver means no cap.
+type joinLimits struct {
+	maxBindings int    // 0 == unlimited
+	ruleName    string // for error messages; may be empty (e.g. final query)
+}
+
+func (l *joinLimits) check(stepIndex, n int) error {
+	if l == nil || l.maxBindings <= 0 {
+		return nil
+	}
+	if n > l.maxBindings {
+		return &BindingCapError{Rule: l.ruleName, StepIndex: stepIndex, Cap: l.maxBindings, Cardinality: n}
+	}
+	return nil
+}
+
 // ResultSet holds the query results.
 type ResultSet struct {
 	Columns []string // column names (from query select)
@@ -23,8 +73,9 @@ type ResultSet struct {
 type Option func(*evalConfig)
 
 type evalConfig struct {
-	maxIterations int
-	parallel      bool
+	maxIterations      int
+	maxBindingsPerRule int
+	parallel           bool
 }
 
 // WithMaxIterations sets the maximum number of fixpoint iterations per stratum.
@@ -32,6 +83,14 @@ type evalConfig struct {
 // the results computed so far. A value of 0 means no limit.
 func WithMaxIterations(n int) Option {
 	return func(c *evalConfig) { c.maxIterations = n }
+}
+
+// WithMaxBindingsPerRule sets the per-rule cap on intermediate join binding
+// cardinality. If a rule's intermediate cardinality exceeds the cap during
+// evaluation, Evaluate returns a *BindingCapError (wraps ErrBindingCapExceeded).
+// A value of 0 disables the cap.
+func WithMaxBindingsPerRule(n int) Option {
+	return func(c *evalConfig) { c.maxBindingsPerRule = n }
 }
 
 // WithParallel enables parallel evaluation of independent rules within
@@ -43,7 +102,10 @@ func WithParallel() Option {
 
 // Evaluate executes an ExecutionPlan over base facts and returns results.
 func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[string]*Relation, opts ...Option) (*ResultSet, error) {
-	cfg := evalConfig{maxIterations: DefaultMaxIterations}
+	cfg := evalConfig{
+		maxIterations:      DefaultMaxIterations,
+		maxBindingsPerRule: DefaultMaxBindingsPerRule,
+	}
 	for _, o := range opts {
 		o(&cfg)
 	}
@@ -73,7 +135,11 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 		// Bootstrap: evaluate each rule once using full relations as source.
 		var deltaRels map[string]*Relation
 		if cfg.parallel {
-			deltaRels = parallelBootstrap(stratum.Rules, allRels)
+			var perr error
+			deltaRels, perr = parallelBootstrap(stratum.Rules, allRels, cfg.maxBindingsPerRule)
+			if perr != nil {
+				return nil, perr
+			}
 		} else {
 			deltaRels = make(map[string]*Relation)
 			for _, rule := range stratum.Rules {
@@ -82,7 +148,10 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 				hk := relKey(headName, headArity)
 				headRel := allRels[hk]
 
-				newTuples := Rule(rule, allRels)
+				newTuples, rerr := Rule(rule, allRels, cfg.maxBindingsPerRule)
+				if rerr != nil {
+					return nil, rerr
+				}
 				for _, t := range newTuples {
 					if headRel.Add(t) {
 						dr, ok := deltaRels[hk]
@@ -123,7 +192,11 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 			}
 
 			if cfg.parallel {
-				deltaRels = parallelDelta(stratum.Rules, allRels, deltaRels)
+				var perr error
+				deltaRels, perr = parallelDelta(stratum.Rules, allRels, deltaRels, cfg.maxBindingsPerRule)
+				if perr != nil {
+					return nil, perr
+				}
 			} else {
 				nextDelta := make(map[string]*Relation)
 				for _, rule := range stratum.Rules {
@@ -132,7 +205,10 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 					hk := relKey(headName, headArity)
 					headRel := allRels[hk]
 
-					newTuples := RuleDelta(rule, allRels, deltaRels)
+					newTuples, rerr := RuleDelta(rule, allRels, deltaRels, cfg.maxBindingsPerRule)
+					if rerr != nil {
+						return nil, rerr
+					}
 					for _, t := range newTuples {
 						if headRel.Add(t) {
 							dr, ok := nextDelta[hk]
@@ -150,7 +226,10 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 
 		// Evaluate aggregates after fixpoint.
 		for _, agg := range stratum.Aggregates {
-			resultRel := Aggregate(agg, allRels)
+			resultRel, aerr := Aggregate(agg, allRels, cfg.maxBindingsPerRule)
+			if aerr != nil {
+				return nil, aerr
+			}
 			allRels[relKey(resultRel.Name, resultRel.Arity)] = resultRel
 		}
 	}
@@ -160,13 +239,17 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 		return &ResultSet{}, nil
 	}
 
-	return evalQuery(execPlan.Query, allRels), nil
+	return evalQuery(execPlan.Query, allRels, cfg.maxBindingsPerRule)
 }
 
 // evalQuery evaluates the planned query and returns a ResultSet.
-func evalQuery(q *plan.PlannedQuery, allRels map[string]*Relation) *ResultSet {
+func evalQuery(q *plan.PlannedQuery, allRels map[string]*Relation, maxBindings int) (*ResultSet, error) {
 	initial := []binding{make(binding)}
-	bindings := evalJoinSteps(q.JoinOrder, allRels, initial)
+	limits := &joinLimits{maxBindings: maxBindings, ruleName: "<query>"}
+	bindings, err := evalJoinSteps(q.JoinOrder, allRels, initial, limits)
+	if err != nil {
+		return nil, err
+	}
 
 	rs := &ResultSet{}
 
@@ -205,5 +288,5 @@ func evalQuery(q *plan.PlannedQuery, allRels map[string]*Relation) *ResultSet {
 			}
 		}
 	}
-	return rs
+	return rs, nil
 }


### PR DESCRIPTION
Closes #80.

## Summary

`applyPositive` in `ql/eval/join.go` accumulates intermediate join bindings into an unbounded slice. With weak join constraints (free variables, low-selectivity predicates), intermediate cardinality could reach 100M+ entries (1-2 GB) before any deduplication, OOMing the process with no error.

This PR adds a per-rule cap on intermediate binding cardinality, threaded through the eval pipeline as `eval.WithMaxBindingsPerRule(n)` (default `5_000_000`), with a CLI flag `--max-bindings-per-rule N` on `tsq query`.

## Root cause

`applyPositive` is the only join operator that can grow output cardinality past input cardinality (Cartesian product over free vars). The inner `for _, ti := range matchingIdxs` loop appends to `out []binding` with no bound. Anti-joins, comparisons, and builtins are all output ≤ input.

## Fix

- Added `eval.DefaultMaxBindingsPerRule = 5_000_000`, `eval.WithMaxBindingsPerRule(n) Option`, sentinel `eval.ErrBindingCapExceeded`, and concrete `*eval.BindingCapError{Rule, StepIndex, Cap, Cardinality}` (Unwraps to the sentinel for `errors.Is`).
- Threaded a `joinLimits` struct through `Rule()`, `RuleDelta()`, `evalJoinSteps`, `evalJoinStepsWithDelta`, `applyStep`, `applyPositive`, plus `Aggregate()`/`evalLiterals` and `evalQuery`.
- Inner cap check inside `applyPositive`'s tuple loop fires the moment `len(out) > cap` — early termination so we don't continue allocating after detection.
- Per-step cap check after each `applyStep` to also catch growth from the future builtin path.
- Anti-joins, comparisons, and builtins left as-is (output-bounded by input).
- `parallel.go` calls the same `Rule`/`RuleDelta` entry points so it picks up the cap automatically; goroutines now collect errors and `parallelBootstrap`/`parallelDelta` return the first non-nil.
- CLI: new `--max-bindings-per-rule N` flag on `tsq query` plumbed through `compileAndEval` → `eval.NewEvaluator(... eval.WithMaxBindingsPerRule(n))`. `0` disables the cap.

## Test plan

- [x] `TestRuleBindingCapTriggers` — 4-way Cartesian over four 10-tuple unaries with cap=100. Asserts `errors.Is(err, ErrBindingCapExceeded)`, error wraps `*BindingCapError` with rule name `"BadRule"`, cap=100, and reported cardinality > 100. Test runs in milliseconds — proves we error *before* exploding to the 10000-row product.
- [x] `TestRuleBindingCapDisabled` — same shape with cap=0 returns the full 5×5 cross product (25 rows, no error).
- [x] `go build ./...` clean.
- [x] `go test ./... -count=1 -short` — all 661+ tests green (including property tests, semi-naive correctness oracle, parallel evaluator, aggregates).
- [x] Pre-commit hooks (gofmt + golangci-lint --fix) green.

## Risk

- **Behaviour change:** queries that genuinely produce >5M intermediate bindings on any single rule will now error instead of OOMing or hanging. Users can pass `--max-bindings-per-rule 0` to restore the old unbounded behaviour, or raise the cap as needed. The error message includes the rule name and a remediation hint.
- **API surface:** `Rule()`, `RuleDelta()`, and `Aggregate()` signatures changed — these are package-internal call sites and the test suite was updated. Public CLI `tsq query` only gains a flag (additive, default value preserves the new safety behaviour).
- **Aggregate path:** `Aggregate()` and `evalLiterals` now also honour the cap. Same rationale (`evalLiterals` calls the same `applyPositive`); without it, an aggregate body with weak joins would still OOM.
- **No correctness change for valid queries** — when the cap is not hit, evaluation proceeds identically.