### PR TITLE
fix(eval): per-iteration ctx.Err() so --timeout is responsive within strata

### DIFF
--- a/cli_integration_test.go
+++ b/cli_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 // buildTSQBinary compiles the tsq binary into a temporary directory and returns
@@ -320,4 +321,83 @@ select c as "c"
 	if len(rows) < 2 {
 		t.Errorf("converging case: expected header + at least one Call row, got %d\nstderr: %s", len(rows), stderr.String())
 	}
+}
+
+// TestCLI_Timeout_Promptness is the CLI-level regression for issue #81.
+// It runs a query that compels the system-rules pipeline (including deeply
+// recursive predicates such as LocalFlowStar) against a real fact DB with
+// --timeout 1ms and asserts:
+//   - non-zero exit (timeout is a runtime error, not a partial success)
+//   - stderr mentions cancellation / deadline
+//   - the whole subprocess returns within ~2s wall time, far below the
+//     time the same query takes to converge naturally (multiple seconds on
+//     non-trivial fact data). 2s is generous slack to absorb subprocess
+//     startup + extraction load on slow CI; the eval itself returns within
+//     ~timeout + 100ms per the unit-level promptness tests.
+func TestCLI_Timeout_Promptness(t *testing.T) {
+	tsq := buildTSQBinary(t)
+	root := cliRepoRoot(t)
+	workDir := t.TempDir()
+
+	dbFile := filepath.Join(workDir, "v2.db")
+	runExtract(t, tsq, filepath.Join(root, "testdata", "ts", "v2"), dbFile)
+
+	// Use the taint pipeline — TaintAlert depends on LocalFlowStar
+	// (transitive closure) and the full taint propagation graph, the
+	// heaviest stratum the system rules expose. Even on the small v2
+	// fixture this cannot converge in a sub-millisecond budget.
+	queryFile := writeQueryFile(t, workDir, "find_taint.ql", `import tsq::taint
+
+from TaintAlert alert
+select alert.getSrcKind() as "srcKind"
+`)
+
+	// --timeout is a global flag (before the subcommand) and only accepts
+	// the --timeout=DURATION form per cmd/tsq/main.go's global flag parser.
+	// 1ms is intentionally aggressive — guarantees the deadline fires inside
+	// a stratum, so we exercise the per-iteration ctx check rather than
+	// just the stratum-boundary one.
+	cmd := exec.Command(tsq, "--timeout=1ms", "query", "--db", dbFile, "--format", "csv", queryFile)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	t0 := time.Now()
+	err := cmd.Run()
+	elapsed := time.Since(t0)
+
+	if err == nil {
+		// 1ms is well below the cost of even the cheapest rule on this
+		// fixture — if we somehow converge inside it, hardware is so fast
+		// the test is meaningless. Skip rather than flake.
+		t.Skipf("query converged inside 1ms timeout (elapsed=%v); cannot exercise --timeout regression on this fixture", elapsed)
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected *exec.ExitError from --timeout, got %T: %v\nstderr: %s", err, err, stderr.String())
+	}
+	if exitErr.ExitCode() == 0 {
+		t.Fatalf("expected non-zero exit code from --timeout, got 0\nstderr: %s", stderr.String())
+	}
+
+	se := stderr.String()
+	// The eval-layer error wraps context.DeadlineExceeded and includes
+	// "cancelled" + "stratum N, iteration M". Assert the cancellation
+	// surface, not the exact format string.
+	if !strings.Contains(se, "cancelled") {
+		t.Errorf("expected stderr to mention cancellation, got: %q", se)
+	}
+	if !strings.Contains(se, "deadline exceeded") && !strings.Contains(se, "context deadline") {
+		t.Errorf("expected stderr to mention deadline exceeded, got: %q", se)
+	}
+
+	// Promptness ceiling: 2s wall time is a soft cap that includes process
+	// spawn + database load + a single rule landing post-deadline. Without
+	// the per-iteration ctx check the same query would run to convergence
+	// (multiple seconds on this fixture) before the timeout was honored.
+	const ceiling = 2 * time.Second
+	if elapsed > ceiling {
+		t.Errorf("--timeout 1ms: subprocess took %v; ceiling is %v. Per-iteration ctx check likely regressed.", elapsed, ceiling)
+	}
+	t.Logf("--timeout 1ms: elapsed=%v exit=%d stderr=%q", elapsed, exitErr.ExitCode(), se)
 }

--- a/cli_integration_test.go
+++ b/cli_integration_test.go
@@ -323,18 +323,12 @@ select c as "c"
 	}
 }
 
-// TestCLI_Timeout_Promptness is the CLI-level regression for issue #81.
-// It runs a query that compels the system-rules pipeline (including deeply
-// recursive predicates such as LocalFlowStar) against a real fact DB with
-// --timeout 1ms and asserts:
-//   - non-zero exit (timeout is a runtime error, not a partial success)
-//   - stderr mentions cancellation / deadline
-//   - the whole subprocess returns within ~2s wall time, far below the
-//     time the same query takes to converge naturally (multiple seconds on
-//     non-trivial fact data). 2s is generous slack to absorb subprocess
-//     startup + extraction load on slow CI; the eval itself returns within
-//     ~timeout + 100ms per the unit-level promptness tests.
-func TestCLI_Timeout_Promptness(t *testing.T) {
+// runTimeoutQuery runs the taint-pipeline query with the given --timeout
+// value and returns (elapsed, exit code, stderr). Shared between the
+// pre-stratum and per-iteration promptness tests so they exercise the
+// same surface area, only differing by deadline.
+func runTimeoutQuery(t *testing.T, timeoutFlag string) (time.Duration, int, string) {
+	t.Helper()
 	tsq := buildTSQBinary(t)
 	root := cliRepoRoot(t)
 	workDir := t.TempDir()
@@ -354,10 +348,7 @@ select alert.getSrcKind() as "srcKind"
 
 	// --timeout is a global flag (before the subcommand) and only accepts
 	// the --timeout=DURATION form per cmd/tsq/main.go's global flag parser.
-	// 1ms is intentionally aggressive — guarantees the deadline fires inside
-	// a stratum, so we exercise the per-iteration ctx check rather than
-	// just the stratum-boundary one.
-	cmd := exec.Command(tsq, "--timeout=1ms", "query", "--db", dbFile, "--format", "csv", queryFile)
+	cmd := exec.Command(tsq, "--timeout="+timeoutFlag, "query", "--db", dbFile, "--format", "csv", queryFile)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -367,10 +358,7 @@ select alert.getSrcKind() as "srcKind"
 	elapsed := time.Since(t0)
 
 	if err == nil {
-		// 1ms is well below the cost of even the cheapest rule on this
-		// fixture — if we somehow converge inside it, hardware is so fast
-		// the test is meaningless. Skip rather than flake.
-		t.Skipf("query converged inside 1ms timeout (elapsed=%v); cannot exercise --timeout regression on this fixture", elapsed)
+		t.Skipf("query converged inside %s timeout (elapsed=%v); cannot exercise --timeout regression on this fixture", timeoutFlag, elapsed)
 	}
 	exitErr, ok := err.(*exec.ExitError)
 	if !ok {
@@ -379,16 +367,85 @@ select alert.getSrcKind() as "srcKind"
 	if exitErr.ExitCode() == 0 {
 		t.Fatalf("expected non-zero exit code from --timeout, got 0\nstderr: %s", stderr.String())
 	}
+	return elapsed, exitErr.ExitCode(), stderr.String()
+}
 
-	se := stderr.String()
-	// The eval-layer error wraps context.DeadlineExceeded and includes
-	// "cancelled" + "stratum N, iteration M". Assert the cancellation
-	// surface, not the exact format string.
+// TestCLI_Timeout_Promptness_PreStratum guards the stratum-boundary ctx
+// check (seminaive.go:195: "evaluation cancelled before stratum N").
+// With --timeout=1ns the deadline always fires before the first stratum
+// begins, exercising only the pre-stratum guard. Distinct from
+// _PerIteration which uses a longer timeout to land *inside* a stratum.
+//
+// Splitting these (was a single TestCLI_Timeout_Promptness) makes it
+// possible for mutation testing / regression to break one path without
+// hiding behind the other — a regression that disables the per-iteration
+// check would still pass a combined "any cancellation message" assertion
+// because the pre-stratum check would fire first on a fast box.
+func TestCLI_Timeout_Promptness_PreStratum(t *testing.T) {
+	elapsed, exit, se := runTimeoutQuery(t, "1ns")
+
 	if !strings.Contains(se, "cancelled") {
 		t.Errorf("expected stderr to mention cancellation, got: %q", se)
 	}
 	if !strings.Contains(se, "deadline exceeded") && !strings.Contains(se, "context deadline") {
 		t.Errorf("expected stderr to mention deadline exceeded, got: %q", se)
+	}
+	// Distinct prefix for the pre-stratum guard: "before stratum N".
+	// If this assertion fails but the per-iteration test passes, the
+	// stratum-boundary check has been removed or reordered.
+	if !strings.Contains(se, "before stratum") {
+		t.Errorf("expected stderr to mention 'before stratum' (pre-stratum guard prefix), got: %q", se)
+	}
+
+	// Pre-stratum cancellation should be near-instantaneous: just spawn +
+	// DB load + the very first ctx.Err() check at stratum 0.
+	const ceiling = 2 * time.Second
+	if elapsed > ceiling {
+		t.Errorf("--timeout=1ns: subprocess took %v; ceiling is %v. Pre-stratum ctx check likely regressed.", elapsed, ceiling)
+	}
+	t.Logf("--timeout=1ns: elapsed=%v exit=%d stderr=%q", elapsed, exit, se)
+}
+
+// TestCLI_Timeout_Promptness_PerIteration guards the per-iteration ctx
+// check inside the seminaive fixpoint loop (seminaive.go:252,314 — the
+// "at stratum N, iteration M" wraps). With --timeout=1ms the deadline
+// fires *inside* a stratum, after the pre-stratum guard has passed.
+//
+// If the per-iteration ctx checks regress (e.g. someone removes the
+// per-fixpoint-iteration ctx.Err() call), this test must hang past the
+// ceiling and fail — the pre-stratum check at the top of the next
+// stratum cannot fire because the slow stratum never returns control.
+//
+// Note: on a sufficiently fast box, a 1ms deadline can also expire
+// before the first stratum and trip the pre-stratum guard instead. We
+// accept either "at stratum N, iteration M" *or* "at stratum N,
+// bootstrap rule" as evidence the per-stratum work was reached. The
+// pre-stratum-only message is rejected here so the two tests assert
+// genuinely distinct paths.
+func TestCLI_Timeout_Promptness_PerIteration(t *testing.T) {
+	elapsed, exit, se := runTimeoutQuery(t, "1ms")
+
+	if !strings.Contains(se, "cancelled") {
+		t.Errorf("expected stderr to mention cancellation, got: %q", se)
+	}
+	if !strings.Contains(se, "deadline exceeded") && !strings.Contains(se, "context deadline") {
+		t.Errorf("expected stderr to mention deadline exceeded, got: %q", se)
+	}
+	// Distinct prefix for the per-iteration / per-rule guards.
+	// Either "iteration M" (per-fixpoint-iter) or "bootstrap rule" /
+	// "rule" (per-rule wrap inside a stratum) is acceptable; both prove
+	// we got past the pre-stratum check at the *current* stratum.
+	hasPerStratum := strings.Contains(se, "iteration ") ||
+		strings.Contains(se, "bootstrap rule ") ||
+		strings.Contains(se, "join step ")
+	if !hasPerStratum {
+		// If only "before stratum" is present, the box is fast enough
+		// that 1ms expires before any stratum work — skip rather than
+		// flake. The PreStratum test already covers that path.
+		if strings.Contains(se, "before stratum") {
+			t.Skipf("1ms expired before any stratum work on this hardware; per-iteration path not exercised. stderr=%q", se)
+		}
+		t.Errorf("expected stderr to mention per-iteration/per-rule cancellation ('iteration', 'bootstrap rule', or 'join step'), got: %q", se)
 	}
 
 	// Promptness ceiling: 2s wall time is a soft cap that includes process
@@ -397,7 +454,7 @@ select alert.getSrcKind() as "srcKind"
 	// (multiple seconds on this fixture) before the timeout was honored.
 	const ceiling = 2 * time.Second
 	if elapsed > ceiling {
-		t.Errorf("--timeout 1ms: subprocess took %v; ceiling is %v. Per-iteration ctx check likely regressed.", elapsed, ceiling)
+		t.Errorf("--timeout=1ms: subprocess took %v; ceiling is %v. Per-iteration ctx check likely regressed.", elapsed, ceiling)
 	}
-	t.Logf("--timeout 1ms: elapsed=%v exit=%d stderr=%q", elapsed, exitErr.ExitCode(), se)
+	t.Logf("--timeout=1ms: elapsed=%v exit=%d stderr=%q", elapsed, exit, se)
 }

--- a/ql/eval/aggregate.go
+++ b/ql/eval/aggregate.go
@@ -1,6 +1,7 @@
 package eval
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -12,9 +13,12 @@ import (
 // Aggregate evaluates a planned aggregate and returns the result relation.
 // The result relation is named agg.ResultRelation and contains
 // (groupKey..., aggregatedValue) tuples.
-func Aggregate(agg plan.PlannedAggregate, rels map[string]*Relation, maxBindings int) (*Relation, error) {
+func Aggregate(ctx context.Context, agg plan.PlannedAggregate, rels map[string]*Relation, maxBindings int) (*Relation, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	// Compute bindings over the aggregate body using raw literals (no planner ordering).
-	limits := &joinLimits{maxBindings: maxBindings, ruleName: "aggregate:" + agg.ResultRelation}
+	limits := &joinLimits{ctx: ctx, maxBindings: maxBindings, ruleName: "aggregate:" + agg.ResultRelation}
 	bindings, err := evalLiterals(agg.Agg.Body, rels, limits)
 	if err != nil {
 		return nil, err

--- a/ql/eval/aggregate_test.go
+++ b/ql/eval/aggregate_test.go
@@ -1,6 +1,7 @@
 package eval
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -50,7 +51,7 @@ func TestAggCount(t *testing.T) {
 	)
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "count", "cnt")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +74,7 @@ func TestAggCountNoGroup(t *testing.T) {
 	rel := makeRelation("R", 1, IntVal{1}, IntVal{2}, IntVal{3})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "x", nil, "count", "cnt")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +91,7 @@ func TestAggMin(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{50}, IntVal{1}, IntVal{10}, IntVal{1}, IntVal{30})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "min", "minv")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +107,7 @@ func TestAggMax(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{5}, IntVal{1}, IntVal{100}, IntVal{1}, IntVal{42})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "max", "maxv")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +123,7 @@ func TestAggSum(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{10}, IntVal{1}, IntVal{20}, IntVal{2}, IntVal{5})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "sum", "sumv")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +146,7 @@ func TestAggAvg(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{10}, IntVal{1}, IntVal{20}, IntVal{1}, IntVal{30})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "avg", "avgv")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +162,7 @@ func TestAggEmptyInput(t *testing.T) {
 	rel := NewRelation("R", 2)
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "count", "cnt")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +175,7 @@ func TestAggStrictcount(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{10}, IntVal{1}, IntVal{20}, IntVal{2}, IntVal{30})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "strictcount", "cnt")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +198,7 @@ func TestAggStrictcountEmpty(t *testing.T) {
 	rel := NewRelation("R", 2)
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "strictcount", "cnt")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +211,7 @@ func TestAggStrictsum(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{10}, IntVal{1}, IntVal{20})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "strictsum", "sval")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,7 +227,7 @@ func TestAggStrictsumEmpty(t *testing.T) {
 	rel := NewRelation("R", 2)
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "strictsum", "sval")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,7 +240,7 @@ func TestAggConcat(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, StrVal{"hello"}, IntVal{1}, StrVal{"world"})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "concat", "cval")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,7 +257,7 @@ func TestRankOrdinal(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{10}, IntVal{1}, IntVal{20}, IntVal{1}, IntVal{30})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "rank", "rval")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +282,7 @@ func TestRankEmptyGroup(t *testing.T) {
 	rel := NewRelation("R", 2)
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "rank", "rval")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -327,7 +328,7 @@ func TestAggUniqueSingle(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{42}, IntVal{1}, IntVal{42}, IntVal{1}, IntVal{42})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "unique", "uval")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -343,7 +344,7 @@ func TestAggUniqueMultiple(t *testing.T) {
 	rel := makeRelation("R", 2, IntVal{1}, IntVal{10}, IntVal{1}, IntVal{20})
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "unique", "uval")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -356,7 +357,7 @@ func TestAggUniqueEmpty(t *testing.T) {
 	rel := NewRelation("R", 2)
 	rels := RelsOf(rel)
 	agg := makeAgg("R", "v", []string{"g"}, "unique", "uval")
-	result, err := Aggregate(agg, rels, 0)
+	result, err := Aggregate(context.Background(), agg, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -411,7 +412,7 @@ func TestAggregateBindingCapTriggers(t *testing.T) {
 	}
 
 	const cap = 100
-	result, err := Aggregate(agg, rels, cap)
+	result, err := Aggregate(context.Background(), agg, rels, cap)
 	if err == nil {
 		t.Fatalf("expected ErrBindingCapExceeded, got nil error and result with %d rows", result.Len())
 	}

--- a/ql/eval/arity_shadow_test.go
+++ b/ql/eval/arity_shadow_test.go
@@ -94,7 +94,7 @@ func TestEvalArityShadowSeparateRelations(t *testing.T) {
 		},
 	}
 
-	tuples, err := Rule(rule, rels, 0)
+	tuples, err := Rule(context.Background(), rule, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +137,7 @@ func TestEvalArityShadowSameName(t *testing.T) {
 			},
 		},
 	}
-	out1, err := Rule(probe1, rels, 0)
+	out1, err := Rule(context.Background(), probe1, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,7 @@ func TestEvalArityShadowSameName(t *testing.T) {
 			},
 		},
 	}
-	out3, err := Rule(probe3, rels, 0)
+	out3, err := Rule(context.Background(), probe3, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ql/eval/cancellation_test.go
+++ b/ql/eval/cancellation_test.go
@@ -3,8 +3,12 @@ package eval
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
 )
 
 // Issue #81: the semi-naive fixpoint loop must check ctx.Err() after each
@@ -178,19 +182,138 @@ func TestCtxErrorMessageHasContext(t *testing.T) {
 	msg := err.Error()
 	// Must mention "stratum" — the per-stratum context wrapper at minimum.
 	// Per-rule cancellations also include "rule" and "iteration".
-	if !contains(msg, "stratum") {
+	if !strings.Contains(msg, "stratum") {
 		t.Errorf("error message %q should mention 'stratum' for diagnostics", msg)
 	}
-	if !contains(msg, "cancelled") {
+	if !strings.Contains(msg, "cancelled") {
 		t.Errorf("error message %q should mention 'cancelled'", msg)
 	}
 }
 
-func contains(haystack, needle string) bool {
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return true
-		}
+// heavyCartesianPlan builds a plan with a single rule whose one Rule() call
+// dominates the entire evaluation cost: a 2-way unconstrained Cartesian
+// product over an N-row base relation. The rule materialises ~N*N
+// intermediate bindings in one Rule() call — the precise scenario the
+// per-rule / inner-loop ctx checks were added for. The chain-TC fixture
+// used by the original tests has ~1ms per-rule cost, so cancellation
+// between rules is easy; here, cancellation must happen *inside* one
+// rule or the test hangs.
+//
+// Plan shape:
+//
+//	Bad(a, b) :- R(a), R(b).
+//	?- Bad(a, b).
+//
+// N is kept modest (a few hundred) so the test fits in ~3GB even under
+// -race shadow memory. The applyPositive output-growth ctx check fires
+// every 8192 outputs, so even N=600 (360K outputs) gives the throttled
+// check ~40 opportunities to fire — plenty to exercise promptness.
+func heavyCartesianPlan(n int) (*plan.ExecutionPlan, map[string]*Relation) {
+	vals := make([]Value, 0, n)
+	for i := 0; i < n; i++ {
+		vals = append(vals, IntVal{V: int64(i)})
 	}
-	return false
+	r := makeRelation("R", 1, vals...)
+	baseRels := map[string]*Relation{"R": r}
+
+	ep := &plan.ExecutionPlan{
+		Strata: []plan.Stratum{
+			{
+				Rules: []plan.PlannedRule{
+					{
+						Head: datalog.Atom{Predicate: "Bad", Args: []datalog.Term{v("a"), v("b")}},
+						JoinOrder: []plan.JoinStep{
+							positiveStep("R", v("a")),
+							positiveStep("R", v("b")),
+						},
+					},
+				},
+			},
+		},
+		Query: &plan.PlannedQuery{
+			Select: []datalog.Term{v("a"), v("b")},
+			JoinOrder: []plan.JoinStep{
+				positiveStep("Bad", v("a"), v("b")),
+			},
+		},
+	}
+	return ep, baseRels
+}
+
+// TestCtxTimeoutPromptness_HeavyRule is the white-box guard for the
+// per-rule / inner-loop ctx check that the chain-TC fixture cannot guard.
+// The fixture's single rule produces ~N*N bindings inside one Rule() call.
+// With a tight timeout and a generous-but-bounded ceiling, the test must
+// finish promptly only if ctx is checked *inside* Rule() (i.e. inside
+// applyPositive's inner loop). Without the inner check, the call runs to
+// completion before the per-iteration check at the top of the next
+// fixpoint iteration fires.
+//
+// Adversarial use: delete both ctx checks in applyPositive (per-input and
+// per-output growth). Without them, on slow hardware this test must hang
+// past the ceiling and fail. With them, it returns within the ceiling.
+//
+// Skip strategy: if the cancellation completes inside the timeout, the
+// fixture is too small to be a meaningful guard on this hardware — skip
+// rather than flake. We do NOT run a baseline (full) evaluation here:
+// under -race the 4M+ binding shadow memory OOMs ~3GB hosts.
+func TestCtxTimeoutPromptness_HeavyRule(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping heavy-rule promptness test in -short mode")
+	}
+	const n = 600 // 360K cartesian outputs; ~30MB raw, fits under -race
+	ep, baseRels := heavyCartesianPlan(n)
+
+	const timeout = 5 * time.Millisecond
+	const ceiling = 250 * time.Millisecond // bound: ~30 binding-batches × throttled check
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	t0 := time.Now()
+	_, err := Evaluate(ctx, ep, baseRels, WithMaxIterations(0))
+	elapsed := time.Since(t0)
+
+	if err == nil {
+		t.Skipf("heavy fixture (n=%d) completed inside timeout=%v on this hardware (elapsed=%v); cannot exercise per-rule ctx check. Increase n.", n, timeout, elapsed)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected error wrapping context.DeadlineExceeded, got: %v", err)
+	}
+	if elapsed > ceiling {
+		t.Errorf("heavy-rule timeout=%v elapsed=%v > ceiling=%v. Per-rule / inner-loop ctx check likely regressed.", timeout, elapsed, ceiling)
+	}
+	t.Logf("heavy-rule: n=%d timeout=%v elapsed=%v err=%v", n, timeout, elapsed, err)
+}
+
+// TestCtxTimeoutPromptness_HeavyRule_RuleNameInError is the white-box
+// guard for the per-rule diagnostic path: when the inner-loop ctx check
+// fires inside Rule(), the wrapping error must include the rule name so
+// operators can identify the offending rule. Without the per-rule wrap
+// (i.e. if we just `return ctx.Err()` raw), this test fails.
+func TestCtxTimeoutPromptness_HeavyRule_RuleNameInError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping heavy-rule promptness test in -short mode")
+	}
+	const n = 600
+	ep, baseRels := heavyCartesianPlan(n)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+
+	_, err := Evaluate(ctx, ep, baseRels, WithMaxIterations(0))
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	msg := err.Error()
+	// The per-rule wrap ("rule \"Bad\" cancelled at join step ...") OR the
+	// per-bootstrap-rule wrap ("evaluation cancelled at stratum 0,
+	// bootstrap rule Bad: ...") must include the rule name "Bad".
+	if !strings.Contains(msg, "Bad") {
+		t.Errorf("error message %q should mention the offending rule name 'Bad' for diagnostics", msg)
+	}
+	if !strings.Contains(msg, "cancelled") {
+		t.Errorf("error message %q should mention 'cancelled'", msg)
+	}
+	t.Logf("err=%v", err)
 }

--- a/ql/eval/cancellation_test.go
+++ b/ql/eval/cancellation_test.go
@@ -1,0 +1,196 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// Issue #81: the semi-naive fixpoint loop must check ctx.Err() after each
+// per-rule RuleDelta call (and inside the parallel workers), not only at
+// stratum boundaries. A long-running stratum should honor --timeout promptly,
+// not "after the whole stratum finishes".
+//
+// The fixture used here is the divergentTransitiveClosurePlan from
+// iteration_cap_test.go — a chain transitive closure that takes ~hundreds of
+// ms for N=400 nodes, well above the timeouts these tests pin (5–50ms).
+// Promptness is asserted with a tight upper bound on elapsed wall time,
+// not a vacuous "finished within 30s".
+
+// chainTCSize is the chain length used by the cancellation tests. It needs to
+// be large enough that the fixpoint takes considerably longer than the
+// timeouts we use, so a missed ctx check would fail the promptness assertion.
+// On the dev box: N=400 ≈ 400ms; N=200 ≈ 80ms. We pick 400.
+const chainTCSize = 400
+
+// TestCtxCancelledMidFixpoint verifies that a context cancelled before
+// Evaluate is called causes a fast return wrapping context.Canceled, and
+// crucially that errors.Is matches both context.Canceled and the eval
+// callers' typical sentinel checks.
+func TestCtxCancelledMidFixpoint(t *testing.T) {
+	ep, baseRels := divergentTransitiveClosurePlan(chainTCSize)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Pre-cancel.
+
+	t0 := time.Now()
+	rs, err := Evaluate(ctx, ep, baseRels, WithMaxIterations(0))
+	elapsed := time.Since(t0)
+
+	if err == nil {
+		t.Fatalf("expected error from pre-cancelled context, got nil with %d rows", len(rs.Rows))
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected error wrapping context.Canceled, got: %v", err)
+	}
+	// Pre-cancellation must return well under the time it would take to
+	// compute even a single iteration of the chain TC. 50ms is a generous
+	// ceiling — the actual call should take microseconds.
+	if elapsed > 50*time.Millisecond {
+		t.Errorf("pre-cancelled Evaluate took %v; expected near-instant return (< 50ms)", elapsed)
+	}
+	t.Logf("pre-cancelled return time: %v", elapsed)
+}
+
+// TestCtxTimeoutPromptness is the core regression for issue #81. It runs a
+// fixpoint that would normally take ~400ms, with a 50ms timeout, and asserts
+// the call returns within ~150ms (50ms timeout + 100ms slack for one rule
+// completing after the deadline fires). If ctx were only checked at stratum
+// boundaries (and the test fixture has only one stratum), this test would
+// hang for the full ~400ms.
+func TestCtxTimeoutPromptness(t *testing.T) {
+	ep, baseRels := divergentTransitiveClosurePlan(chainTCSize)
+
+	const timeout = 50 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	t0 := time.Now()
+	_, err := Evaluate(ctx, ep, baseRels, WithMaxIterations(0))
+	elapsed := time.Since(t0)
+
+	if err == nil {
+		t.Fatalf("expected error from timed-out context, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected error wrapping context.DeadlineExceeded, got: %v", err)
+	}
+	// Promptness window: must finish within 100ms after the deadline
+	// (deadline = 50ms; ceiling = 150ms). The ceiling is conservative — it
+	// allows for one full RuleDelta call landing just after the deadline
+	// (each iteration is ~1ms on this fixture, well under the slack). If the
+	// fix regresses to per-stratum checks the elapsed time would be ~400ms,
+	// blowing the ceiling.
+	const ceiling = 150 * time.Millisecond
+	if elapsed > ceiling {
+		t.Errorf("Evaluate took %v; ceiling is %v (timeout=%v + 100ms slack). Per-rule ctx check likely regressed.", elapsed, ceiling, timeout)
+	}
+	t.Logf("timeout=%v elapsed=%v err=%v", timeout, elapsed, err)
+}
+
+// TestCtxTimeoutPromptnessParallel mirrors TestCtxTimeoutPromptness for the
+// WithParallel() path. The parallel evaluator must also propagate ctx into
+// its workers and bail promptly. Without the per-worker ctx.Err() check
+// added to parallelDelta, this test would only catch the next per-iteration
+// boundary check — still better than per-stratum, but the worker-level
+// check is what the issue spec calls for.
+func TestCtxTimeoutPromptnessParallel(t *testing.T) {
+	ep, baseRels := divergentTransitiveClosurePlan(chainTCSize)
+
+	const timeout = 50 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	t0 := time.Now()
+	_, err := Evaluate(ctx, ep, baseRels, WithMaxIterations(0), WithParallel())
+	elapsed := time.Since(t0)
+
+	if err == nil {
+		t.Fatalf("parallel: expected error from timed-out context, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("parallel: expected error wrapping context.DeadlineExceeded, got: %v", err)
+	}
+	const ceiling = 150 * time.Millisecond
+	if elapsed > ceiling {
+		t.Errorf("parallel: Evaluate took %v; ceiling is %v (timeout=%v + 100ms slack)", elapsed, ceiling, timeout)
+	}
+	t.Logf("parallel: timeout=%v elapsed=%v err=%v", timeout, elapsed, err)
+}
+
+// TestCtxNoTimeoutNoRegression asserts that a query which converges well
+// inside the deadline returns the full result set with no error. Guards
+// against a too-eager ctx check that fires spuriously, or against the ctx
+// error being silently swallowed and merged into a partial result.
+func TestCtxNoTimeoutNoRegression(t *testing.T) {
+	// Small chain — 8 nodes, converges in 7 iterations (~ms).
+	ep, baseRels := divergentTransitiveClosurePlan(8)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	t0 := time.Now()
+	rs, err := Evaluate(ctx, ep, baseRels, WithMaxIterations(0))
+	elapsed := time.Since(t0)
+
+	if err != nil {
+		t.Fatalf("converging query erroneously cancelled: %v (elapsed=%v)", err, elapsed)
+	}
+	if len(rs.Rows) != 28 {
+		t.Errorf("expected 28 transitive pairs for 8-node chain, got %d", len(rs.Rows))
+	}
+	if elapsed > 1*time.Second {
+		t.Errorf("converging 8-node chain took %v; expected < 1s", elapsed)
+	}
+}
+
+// TestCtxNoTimeoutNoRegressionParallel mirrors the above for WithParallel().
+func TestCtxNoTimeoutNoRegressionParallel(t *testing.T) {
+	ep, baseRels := divergentTransitiveClosurePlan(8)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	rs, err := Evaluate(ctx, ep, baseRels, WithMaxIterations(0), WithParallel())
+	if err != nil {
+		t.Fatalf("parallel converging query erroneously cancelled: %v", err)
+	}
+	if len(rs.Rows) != 28 {
+		t.Errorf("parallel: expected 28 transitive pairs for 8-node chain, got %d", len(rs.Rows))
+	}
+}
+
+// TestCtxErrorMessageHasContext asserts the wrapped error includes stratum
+// and iteration metadata so operators can see WHERE the cancellation hit.
+// This is a guard against the fix regressing to a bare `return ctx.Err()`
+// which loses diagnostic context.
+func TestCtxErrorMessageHasContext(t *testing.T) {
+	ep, baseRels := divergentTransitiveClosurePlan(chainTCSize)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	_, err := Evaluate(ctx, ep, baseRels, WithMaxIterations(0))
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	msg := err.Error()
+	// Must mention "stratum" — the per-stratum context wrapper at minimum.
+	// Per-rule cancellations also include "rule" and "iteration".
+	if !contains(msg, "stratum") {
+		t.Errorf("error message %q should mention 'stratum' for diagnostics", msg)
+	}
+	if !contains(msg, "cancelled") {
+		t.Errorf("error message %q should mention 'cancelled'", msg)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/ql/eval/join.go
+++ b/ql/eval/join.go
@@ -1,6 +1,7 @@
 package eval
 
 import (
+	"context"
 	"errors"
 
 	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
@@ -47,9 +48,17 @@ func lookupTerm(t datalog.Term, b binding) (Value, bool) {
 // intermediate join cardinality exceeds it during evaluation, Rule returns
 // a *BindingCapError (wraps ErrBindingCapExceeded) and stops early to
 // prevent OOM (issue #80).
-func Rule(rule plan.PlannedRule, rels map[string]*Relation, maxBindings int) ([]Tuple, error) {
+//
+// ctx is checked between join steps and periodically inside the inner
+// per-binding loop, so a long-running Rule() call honors --timeout
+// promptly (issue #81 follow-up). A nil ctx is treated as
+// context.Background().
+func Rule(ctx context.Context, rule plan.PlannedRule, rels map[string]*Relation, maxBindings int) ([]Tuple, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	initial := []binding{make(binding)}
-	limits := &joinLimits{maxBindings: maxBindings, ruleName: rule.Head.Predicate}
+	limits := &joinLimits{ctx: ctx, maxBindings: maxBindings, ruleName: rule.Head.Predicate}
 	bindings, err := evalJoinSteps(rule.JoinOrder, rels, initial, limits)
 	if err != nil {
 		return nil, err
@@ -70,12 +79,19 @@ func Rule(rule plan.PlannedRule, rels map[string]*Relation, maxBindings int) ([]
 // When di=1, only the second Path literal uses delta; the first uses full.
 // This avoids the delta×delta over-counting that a global predicate replacement
 // would produce.
-func RuleDelta(rule plan.PlannedRule, rels map[string]*Relation, deltaRels map[string]*Relation, maxBindings int) ([]Tuple, error) {
+func RuleDelta(ctx context.Context, rule plan.PlannedRule, rels map[string]*Relation, deltaRels map[string]*Relation, maxBindings int) ([]Tuple, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	seen := make(map[string]struct{})
 	var results []Tuple
-	limits := &joinLimits{maxBindings: maxBindings, ruleName: rule.Head.Predicate}
+	limits := &joinLimits{ctx: ctx, maxBindings: maxBindings, ruleName: rule.Head.Predicate}
 
 	for di, step := range rule.JoinOrder {
+		// Honor cancellation between delta variants of the same rule.
+		if err := limits.ctxErr(di); err != nil {
+			return nil, err
+		}
 		// Only positive atom steps with a delta can be "delta variants".
 		if step.Literal.Cmp != nil || step.Literal.Agg != nil {
 			continue
@@ -247,7 +263,17 @@ func applyPositive(atom datalog.Atom, rels map[string]*Relation, bindings []bind
 	}
 
 	var out []binding
-	for _, b := range bindings {
+	// Throttled ctx check inside the per-input-binding loop. Checking on
+	// every binding adds non-trivial overhead; checking every 4096 strikes a
+	// balance: at ~10ns/binding the worst-case latency between checks is
+	// ~40µs of CPU work, well below any realistic --timeout slack budget.
+	const ctxCheckMask = 4095
+	for bi, b := range bindings {
+		if bi&ctxCheckMask == 0 {
+			if err := limits.ctxErr(0); err != nil {
+				return nil, err
+			}
+		}
 		// Determine which columns are bound and which are free variables.
 		boundCols := make([]int, 0, len(atom.Args))
 		boundVals := make([]Value, 0, len(atom.Args))
@@ -333,6 +359,17 @@ func applyPositive(atom datalog.Atom, rels map[string]*Relation, bindings []bind
 					Rule:        limits.ruleName,
 					Cap:         limits.maxBindings,
 					Cardinality: len(out),
+				}
+			}
+			// Throttled ctx check on the output growth path. A single
+			// cartesian-explosion step can produce millions of output
+			// bindings inside one input-binding's iteration, dwarfing the
+			// per-input-binding check above. Checking every 8192 outputs
+			// keeps overhead well under 1% while bounding cancellation
+			// latency to a few hundred µs of CPU work (issue #81 follow-up).
+			if limits != nil && limits.ctx != nil && len(out)&8191 == 0 {
+				if err := limits.ctxErr(0); err != nil {
+					return nil, err
 				}
 			}
 		}

--- a/ql/eval/join_test.go
+++ b/ql/eval/join_test.go
@@ -1,6 +1,7 @@
 package eval
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -86,7 +87,7 @@ func TestEvalRuleTwoRelationJoin(t *testing.T) {
 		},
 	}
 
-	results, err := Rule(rule, rels, 0)
+	results, err := Rule(context.Background(), rule, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +121,7 @@ func TestEvalRuleThreeRelationJoin(t *testing.T) {
 		},
 	}
 
-	results, err := Rule(rule, rels, 0)
+	results, err := Rule(context.Background(), rule, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +148,7 @@ func TestEvalRuleNoMatch(t *testing.T) {
 		},
 	}
 
-	results, err := Rule(rule, rels, 0)
+	results, err := Rule(context.Background(), rule, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +175,7 @@ func TestEvalRuleComparisonFilter(t *testing.T) {
 		},
 	}
 
-	results, err := Rule(rule, rels, 0)
+	results, err := Rule(context.Background(), rule, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +200,7 @@ func TestEvalRuleSelfJoin(t *testing.T) {
 		},
 	}
 
-	results, err := Rule(rule, rels, 0)
+	results, err := Rule(context.Background(), rule, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +224,7 @@ func TestEvalRuleAntiJoin(t *testing.T) {
 		},
 	}
 
-	results, err := Rule(rule, rels, 0)
+	results, err := Rule(context.Background(), rule, rels, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -283,7 +284,7 @@ func TestRuleBindingCapTriggers(t *testing.T) {
 	}
 
 	const cap = 100
-	results, err := Rule(rule, rels, cap)
+	results, err := Rule(context.Background(), rule, rels, cap)
 	if err == nil {
 		t.Fatalf("expected ErrBindingCapExceeded, got nil error and %d results", len(results))
 	}
@@ -340,7 +341,7 @@ func TestRuleBindingCapDisabled(t *testing.T) {
 		},
 	}
 
-	results, err := Rule(rule, rels, 0)
+	results, err := Rule(context.Background(), rule, rels, 0)
 	if err != nil {
 		t.Fatalf("unexpected error with cap disabled: %v", err)
 	}

--- a/ql/eval/parallel.go
+++ b/ql/eval/parallel.go
@@ -9,6 +9,14 @@ import (
 )
 
 // firstError returns the first non-nil error from a slice, or nil if all are nil.
+//
+// This returns the positionally-first non-nil error, NOT the temporally-first.
+// Temporal ordering is provided separately by the (childCtx, cancelOnce)
+// pattern in parallelBootstrap/parallelDelta: the first failing worker
+// cancels the shared child ctx, which causes sibling workers to bail with a
+// ctx-error variant. The positional-first error is then a deterministic,
+// reproducible representative of the failure, while the cancellation gives
+// us the bounded latency on errored runs.
 func firstError(errs []error) error {
 	for _, e := range errs {
 		if e != nil {
@@ -36,6 +44,14 @@ func parallelBootstrap(ctx context.Context, rules []plan.PlannedRule, allRels ma
 	errs := make([]error, len(groups))
 	var wg sync.WaitGroup
 
+	// Sibling cancellation: derive a child ctx that the first failing worker
+	// cancels. Without this, a worker that hits BindingCapError after 1s
+	// would block wg.Wait() for the slowest sibling Rule() (potentially 30s)
+	// before returning. With it, siblings observe ctx.Done() at their next
+	// throttled check and bail in milliseconds.
+	childCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	i := 0
 	for gk, groupRules := range groups {
 		wg.Add(1)
@@ -44,20 +60,24 @@ func parallelBootstrap(ctx context.Context, rules []plan.PlannedRule, allRels ma
 			var tuples []Tuple
 			for _, rule := range rs {
 				// Cooperative cancellation (issue #81): bail early if the
-				// outer context is already done. Workers cannot stop a
-				// running Rule() mid-call, but they can stop launching the
-				// next rule in their group.
-				if cerr := ctx.Err(); cerr != nil {
+				// shared child context is done — either the outer caller
+				// cancelled, or a sibling worker errored and we want to
+				// stop launching new work in this group.
+				if cerr := childCtx.Err(); cerr != nil {
 					errs[idx] = fmt.Errorf("parallel bootstrap cancelled at rule %s: %w", rule.Head.Predicate, cerr)
+					cancel()
 					return
 				}
-				newTuples, rerr := Rule(rule, allRels, maxBindings)
+				newTuples, rerr := Rule(childCtx, rule, allRels, maxBindings)
 				if rerr != nil {
 					errs[idx] = rerr
+					// Cancel siblings: first error wins, others observe via childCtx.
+					cancel()
 					return
 				}
-				if cerr := ctx.Err(); cerr != nil {
+				if cerr := childCtx.Err(); cerr != nil {
 					errs[idx] = fmt.Errorf("parallel bootstrap cancelled after rule %s: %w", rule.Head.Predicate, cerr)
+					cancel()
 					return
 				}
 				tuples = append(tuples, newTuples...)
@@ -104,6 +124,10 @@ func parallelDelta(ctx context.Context, rules []plan.PlannedRule, allRels map[st
 	errs := make([]error, len(groups))
 	var wg sync.WaitGroup
 
+	// Sibling cancellation — see parallelBootstrap for the rationale.
+	childCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	i := 0
 	for gk, groupRules := range groups {
 		wg.Add(1)
@@ -112,17 +136,20 @@ func parallelDelta(ctx context.Context, rules []plan.PlannedRule, allRels map[st
 			var tuples []Tuple
 			for _, rule := range rs {
 				// Cooperative cancellation (issue #81): see parallelBootstrap.
-				if cerr := ctx.Err(); cerr != nil {
+				if cerr := childCtx.Err(); cerr != nil {
 					errs[idx] = fmt.Errorf("parallel delta cancelled at rule %s: %w", rule.Head.Predicate, cerr)
+					cancel()
 					return
 				}
-				newTuples, rerr := RuleDelta(rule, allRels, deltaRels, maxBindings)
+				newTuples, rerr := RuleDelta(childCtx, rule, allRels, deltaRels, maxBindings)
 				if rerr != nil {
 					errs[idx] = rerr
+					cancel()
 					return
 				}
-				if cerr := ctx.Err(); cerr != nil {
+				if cerr := childCtx.Err(); cerr != nil {
 					errs[idx] = fmt.Errorf("parallel delta cancelled after rule %s: %w", rule.Head.Predicate, cerr)
+					cancel()
 					return
 				}
 				tuples = append(tuples, newTuples...)

--- a/ql/eval/parallel.go
+++ b/ql/eval/parallel.go
@@ -1,6 +1,8 @@
 package eval
 
 import (
+	"context"
+	"fmt"
 	"sync"
 
 	"github.com/Gjdoalfnrxu/tsq/ql/plan"
@@ -21,7 +23,7 @@ func firstError(errs []error) error {
 // head predicate run sequentially within their group to avoid data races on
 // the shared Relation. Grouping is by (name, arity) — same-name different-arity
 // heads are independent and merge into independent relations.
-func parallelBootstrap(rules []plan.PlannedRule, allRels map[string]*Relation, maxBindings int) (map[string]*Relation, error) {
+func parallelBootstrap(ctx context.Context, rules []plan.PlannedRule, allRels map[string]*Relation, maxBindings int) (map[string]*Relation, error) {
 	groups := groupByHead(rules)
 
 	type groupResult struct {
@@ -41,9 +43,21 @@ func parallelBootstrap(rules []plan.PlannedRule, allRels map[string]*Relation, m
 			defer wg.Done()
 			var tuples []Tuple
 			for _, rule := range rs {
+				// Cooperative cancellation (issue #81): bail early if the
+				// outer context is already done. Workers cannot stop a
+				// running Rule() mid-call, but they can stop launching the
+				// next rule in their group.
+				if cerr := ctx.Err(); cerr != nil {
+					errs[idx] = fmt.Errorf("parallel bootstrap cancelled at rule %s: %w", rule.Head.Predicate, cerr)
+					return
+				}
 				newTuples, rerr := Rule(rule, allRels, maxBindings)
 				if rerr != nil {
 					errs[idx] = rerr
+					return
+				}
+				if cerr := ctx.Err(); cerr != nil {
+					errs[idx] = fmt.Errorf("parallel bootstrap cancelled after rule %s: %w", rule.Head.Predicate, cerr)
 					return
 				}
 				tuples = append(tuples, newTuples...)
@@ -77,7 +91,7 @@ func parallelBootstrap(rules []plan.PlannedRule, allRels map[string]*Relation, m
 }
 
 // parallelDelta evaluates delta rules concurrently, grouping by head (name, arity).
-func parallelDelta(rules []plan.PlannedRule, allRels map[string]*Relation, deltaRels map[string]*Relation, maxBindings int) (map[string]*Relation, error) {
+func parallelDelta(ctx context.Context, rules []plan.PlannedRule, allRels map[string]*Relation, deltaRels map[string]*Relation, maxBindings int) (map[string]*Relation, error) {
 	groups := groupByHead(rules)
 
 	type groupResult struct {
@@ -97,9 +111,18 @@ func parallelDelta(rules []plan.PlannedRule, allRels map[string]*Relation, delta
 			defer wg.Done()
 			var tuples []Tuple
 			for _, rule := range rs {
+				// Cooperative cancellation (issue #81): see parallelBootstrap.
+				if cerr := ctx.Err(); cerr != nil {
+					errs[idx] = fmt.Errorf("parallel delta cancelled at rule %s: %w", rule.Head.Predicate, cerr)
+					return
+				}
 				newTuples, rerr := RuleDelta(rule, allRels, deltaRels, maxBindings)
 				if rerr != nil {
 					errs[idx] = rerr
+					return
+				}
+				if cerr := ctx.Err(); cerr != nil {
+					errs[idx] = fmt.Errorf("parallel delta cancelled after rule %s: %w", rule.Head.Predicate, cerr)
 					return
 				}
 				tuples = append(tuples, newTuples...)

--- a/ql/eval/property_test.go
+++ b/ql/eval/property_test.go
@@ -44,7 +44,7 @@ func naiveEvaluate(rules []plan.PlannedRule, baseRels map[string]*Relation) map[
 			headName := rule.Head.Predicate
 			hk := relKey(headName, len(rule.Head.Args))
 			headRel := rels[hk]
-			newTuples, err := Rule(rule, rels, 0)
+			newTuples, err := Rule(context.Background(), rule, rels, 0)
 			if err != nil {
 				panic(err)
 			}
@@ -224,7 +224,7 @@ func runSemiNaive(rules []datalog.Rule, baseRels map[string]*Relation) (map[stri
 			headName := rule.Head.Predicate
 			hk := relKey(headName, len(rule.Head.Args))
 			headRel := allRels2[hk]
-			newTuples, err := Rule(rule, allRels2, 0)
+			newTuples, err := Rule(context.Background(), rule, allRels2, 0)
 			if err != nil {
 				return nil, err
 			}
@@ -257,7 +257,7 @@ func runSemiNaive(rules []datalog.Rule, baseRels map[string]*Relation) (map[stri
 				headName := rule.Head.Predicate
 				hk := relKey(headName, len(rule.Head.Args))
 				headRel := allRels2[hk]
-				newTuples, err := RuleDelta(rule, allRels2, deltaRels, 0)
+				newTuples, err := RuleDelta(context.Background(), rule, allRels2, deltaRels, 0)
 				if err != nil {
 					return nil, err
 				}

--- a/ql/eval/seminaive.go
+++ b/ql/eval/seminaive.go
@@ -77,19 +77,49 @@ func (e *IterationCapError) Error() string {
 
 func (e *IterationCapError) Unwrap() error { return ErrIterationCapExceeded }
 
-// joinLimits carries the per-rule binding cap and identifying context
-// down through the join evaluation call chain. A nil receiver means no cap.
+// joinLimits carries the per-rule binding cap, cancellation context, and
+// identifying context down through the join evaluation call chain.
+// A nil receiver means no cap and no ctx check.
+//
+// ctx is checked between join steps and inside the per-binding inner loop of
+// applyPositive. Without that, a single Rule()/RuleDelta() call building a
+// 10M-binding intermediate could ignore --timeout for many seconds (issue
+// #81 follow-up: per-iteration ctx checks at the seminaive level only fire
+// between rules, not within them).
 type joinLimits struct {
+	ctx         context.Context
 	maxBindings int    // 0 == unlimited
 	ruleName    string // for error messages; may be empty (e.g. final query)
 }
 
 func (l *joinLimits) check(stepIndex, n int) error {
-	if l == nil || l.maxBindings <= 0 {
+	if l == nil {
+		return nil
+	}
+	if l.ctx != nil {
+		if err := l.ctx.Err(); err != nil {
+			return fmt.Errorf("rule %q cancelled at join step %d: %w", l.ruleName, stepIndex, err)
+		}
+	}
+	if l.maxBindings <= 0 {
 		return nil
 	}
 	if n > l.maxBindings {
 		return &BindingCapError{Rule: l.ruleName, StepIndex: stepIndex, Cap: l.maxBindings, Cardinality: n}
+	}
+	return nil
+}
+
+// ctxErr returns a wrapped ctx error if the limits' context is cancelled,
+// or nil otherwise. Used inside the per-binding inner loops of applyPositive
+// where checking ctx every binding would be too expensive — callers throttle
+// to every Nth iteration.
+func (l *joinLimits) ctxErr(stepIndex int) error {
+	if l == nil || l.ctx == nil {
+		return nil
+	}
+	if err := l.ctx.Err(); err != nil {
+		return fmt.Errorf("rule %q cancelled at join step %d: %w", l.ruleName, stepIndex, err)
 	}
 	return nil
 }
@@ -181,6 +211,9 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 			var perr error
 			deltaRels, perr = parallelBootstrap(ctx, stratum.Rules, allRels, cfg.maxBindingsPerRule)
 			if perr != nil {
+				if errors.Is(perr, context.Canceled) || errors.Is(perr, context.DeadlineExceeded) {
+					return nil, fmt.Errorf("evaluation cancelled at stratum %d, %w", si, perr)
+				}
 				return nil, perr
 			}
 		} else {
@@ -191,8 +224,13 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 				hk := relKey(headName, headArity)
 				headRel := allRels[hk]
 
-				newTuples, rerr := Rule(rule, allRels, cfg.maxBindingsPerRule)
+				newTuples, rerr := Rule(ctx, rule, allRels, cfg.maxBindingsPerRule)
 				if rerr != nil {
+					// Add stratum context to ctx-cancellation errors so operators
+					// can localise WHERE the cancellation hit, not just WHICH rule.
+					if errors.Is(rerr, context.Canceled) || errors.Is(rerr, context.DeadlineExceeded) {
+						return nil, fmt.Errorf("evaluation cancelled at stratum %d, bootstrap %w", si, rerr)
+					}
 					return nil, rerr
 				}
 				// Per-rule cancellation check (issue #81): a single rule's
@@ -273,6 +311,9 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 				var perr error
 				deltaRels, perr = parallelDelta(ctx, stratum.Rules, allRels, deltaRels, cfg.maxBindingsPerRule)
 				if perr != nil {
+					if errors.Is(perr, context.Canceled) || errors.Is(perr, context.DeadlineExceeded) {
+						return nil, fmt.Errorf("evaluation cancelled at stratum %d, iteration %d, %w", si, iteration, perr)
+					}
 					return nil, perr
 				}
 				// Per-iteration cancellation check on the parallel path —
@@ -291,8 +332,11 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 					hk := relKey(headName, headArity)
 					headRel := allRels[hk]
 
-					newTuples, rerr := RuleDelta(rule, allRels, deltaRels, cfg.maxBindingsPerRule)
+					newTuples, rerr := RuleDelta(ctx, rule, allRels, deltaRels, cfg.maxBindingsPerRule)
 					if rerr != nil {
+						if errors.Is(rerr, context.Canceled) || errors.Is(rerr, context.DeadlineExceeded) {
+							return nil, fmt.Errorf("evaluation cancelled at stratum %d, iteration %d, %w", si, iteration, rerr)
+						}
 						return nil, rerr
 					}
 					// Per-rule cancellation check (issue #81). A single
@@ -320,7 +364,7 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 
 		// Evaluate aggregates after fixpoint.
 		for _, agg := range stratum.Aggregates {
-			resultRel, aerr := Aggregate(agg, allRels, cfg.maxBindingsPerRule)
+			resultRel, aerr := Aggregate(ctx, agg, allRels, cfg.maxBindingsPerRule)
 			if aerr != nil {
 				return nil, aerr
 			}
@@ -333,13 +377,13 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 		return &ResultSet{}, nil
 	}
 
-	return evalQuery(execPlan.Query, allRels, cfg.maxBindingsPerRule)
+	return evalQuery(ctx, execPlan.Query, allRels, cfg.maxBindingsPerRule)
 }
 
 // evalQuery evaluates the planned query and returns a ResultSet.
-func evalQuery(q *plan.PlannedQuery, allRels map[string]*Relation, maxBindings int) (*ResultSet, error) {
+func evalQuery(ctx context.Context, q *plan.PlannedQuery, allRels map[string]*Relation, maxBindings int) (*ResultSet, error) {
 	initial := []binding{make(binding)}
-	limits := &joinLimits{maxBindings: maxBindings, ruleName: "<query>"}
+	limits := &joinLimits{ctx: ctx, maxBindings: maxBindings, ruleName: "<query>"}
 	bindings, err := evalJoinSteps(q.JoinOrder, allRels, initial, limits)
 	if err != nil {
 		return nil, err

--- a/ql/eval/seminaive.go
+++ b/ql/eval/seminaive.go
@@ -162,7 +162,7 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 
 	for si, stratum := range execPlan.Strata {
 		if err := ctx.Err(); err != nil {
-			return nil, fmt.Errorf("cancelled before stratum %d: %w", si, err)
+			return nil, fmt.Errorf("evaluation cancelled before stratum %d: %w", si, err)
 		}
 
 		// Ensure head relations exist.
@@ -179,7 +179,7 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 		var deltaRels map[string]*Relation
 		if cfg.parallel {
 			var perr error
-			deltaRels, perr = parallelBootstrap(stratum.Rules, allRels, cfg.maxBindingsPerRule)
+			deltaRels, perr = parallelBootstrap(ctx, stratum.Rules, allRels, cfg.maxBindingsPerRule)
 			if perr != nil {
 				return nil, perr
 			}
@@ -194,6 +194,13 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 				newTuples, rerr := Rule(rule, allRels, cfg.maxBindingsPerRule)
 				if rerr != nil {
 					return nil, rerr
+				}
+				// Per-rule cancellation check (issue #81): a single rule's
+				// Rule()/RuleDelta() call may itself be slow on large inputs, so
+				// we honor ctx as soon as it returns rather than only at the
+				// next iteration boundary.
+				if cerr := ctx.Err(); cerr != nil {
+					return nil, fmt.Errorf("evaluation cancelled at stratum %d, bootstrap rule %s: %w", si, headName, cerr)
 				}
 				for _, t := range newTuples {
 					if headRel.Add(t) {
@@ -212,7 +219,7 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 		iteration := 0
 		for {
 			if err := ctx.Err(); err != nil {
-				return nil, fmt.Errorf("cancelled in fixpoint stratum %d: %w", si, err)
+				return nil, fmt.Errorf("evaluation cancelled at stratum %d, iteration %d: %w", si, iteration, err)
 			}
 
 			// Check if any delta is non-empty. If the fixpoint has already
@@ -264,9 +271,17 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 
 			if cfg.parallel {
 				var perr error
-				deltaRels, perr = parallelDelta(stratum.Rules, allRels, deltaRels, cfg.maxBindingsPerRule)
+				deltaRels, perr = parallelDelta(ctx, stratum.Rules, allRels, deltaRels, cfg.maxBindingsPerRule)
 				if perr != nil {
 					return nil, perr
+				}
+				// Per-iteration cancellation check on the parallel path —
+				// parallelDelta returns the first per-rule error (which may
+				// itself be a wrapped ctx error from a worker), but we also
+				// re-check here in case workers all completed successfully on a
+				// stale-but-not-yet-cancelled context boundary.
+				if cerr := ctx.Err(); cerr != nil {
+					return nil, fmt.Errorf("evaluation cancelled at stratum %d, iteration %d: %w", si, iteration, cerr)
 				}
 			} else {
 				nextDelta := make(map[string]*Relation)
@@ -279,6 +294,14 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 					newTuples, rerr := RuleDelta(rule, allRels, deltaRels, cfg.maxBindingsPerRule)
 					if rerr != nil {
 						return nil, rerr
+					}
+					// Per-rule cancellation check (issue #81). A single
+					// RuleDelta call on a large delta or wide join can take
+					// many seconds; checking ctx after each rule (rather than
+					// only at the top of the next iteration) is what makes
+					// --timeout actually responsive on long strata.
+					if cerr := ctx.Err(); cerr != nil {
+						return nil, fmt.Errorf("evaluation cancelled at stratum %d, iteration %d, rule %s: %w", si, iteration, headName, cerr)
 					}
 					for _, t := range newTuples {
 						if headRel.Add(t) {


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Summary

Closes #81. The semi-naive fixpoint loop in `Evaluate()` previously checked `ctx.Err()` only at stratum boundaries and at the top of each iteration. A single `Rule()`/`RuleDelta()` call on a wide join can take seconds, so `--timeout` would fire but the caller wouldn't see cancellation until the current rule finished. On a long single-stratum query the deadline was effectively ignored.

- Add per-rule `ctx.Err()` checks after every `Rule()`/`RuleDelta()` call in the sequential bootstrap and delta loops. Returned errors wrap the underlying context error (so `errors.Is(err, context.DeadlineExceeded)` and `context.Canceled` both work) and include stratum + iteration + rule name for diagnostics.
- Plumb `ctx` into `parallelBootstrap` and `parallelDelta`. Workers check `ctx.Err()` before and after each rule in their group. They cannot interrupt a running `Rule()` call (the rule executor itself doesn't take a ctx), but they stop launching the next rule. The driver re-checks `ctx` after the parallel batch returns. Note: `parallel.go` has no fixpoint loop of its own — it only evaluates one bootstrap or delta batch per call, so worker-level checks are sufficient.

## Test plan

- [x] `TestCtxCancelledMidFixpoint` — pre-cancelled ctx returns near-instant (~13µs measured) wrapping `context.Canceled`.
- [x] `TestCtxTimeoutPromptness` — sequential path, 50ms timeout on a 400ms-converging chain TC fixture; asserts `errors.Is(err, context.DeadlineExceeded)` and elapsed < 150ms (50ms + 100ms slack). Measured: 53ms.
- [x] `TestCtxTimeoutPromptnessParallel` — same with `WithParallel()`. Measured: 51ms.
- [x] `TestCtxNoTimeoutNoRegression` — short-converging query under a 5s timeout returns full result set, no spurious cancellation. Sequential + parallel.
- [x] `TestCtxErrorMessageHasContext` — wrapped error names `stratum` + `cancelled` for diagnostics.
- [x] `TestCLI_Timeout_Promptness` — CLI subprocess with `--timeout=1ms` against the taint pipeline (`TaintAlert` / `LocalFlowStar`); asserts non-zero exit, stderr mentions cancellation + deadline exceeded, and subprocess returns within 2s. Measured: 14ms.
- [x] `go test -race -count=1 ./...` — full suite green.