### PR TITLE
feat(plan): refresh sizeHints between strata with derived cardinalities

### DIFF
--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -569,11 +569,6 @@ func buildProgram(src, file string, importLoader func(string) (*ast.Module, erro
 	return execPlan, mod, warnings, errs
 }
 
-func buildProgramWithOpts(src, file string, importLoader func(string) (*ast.Module, error), sizeHints map[string]int, opts buildOptions) (*plan.ExecutionPlan, *ast.Module, []resolve.Warning, []error) {
-	execPlan, _, mod, warnings, errs := buildProgramWithProg(src, file, importLoader, sizeHints, opts)
-	return execPlan, mod, warnings, errs
-}
-
 // buildProgramWithProg is buildProgram with the post-merge *datalog.Program
 // also returned. It is used by `query` so the compileAndEval pipeline can run
 // the trivial-IDB pre-pass (eval.EstimateNonRecursiveIDBSizes) over the same

--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -684,6 +684,10 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string, maxBindingsPe
 		eval.WithMaxBindingsPerRule(maxBindingsPerRule),
 		eval.WithMaxIterations(maxIterations),
 		eval.WithAllowPartial(allowPartial),
+		// Hand the planner's hints map to the evaluator so it can refresh
+		// derived-relation cardinalities between strata and re-plan the
+		// remaining strata + final query. Issue #88.
+		eval.WithSizeHints(sizeHints),
 	)
 	rs, err := evaluator.Evaluate(ctx)
 	if err != nil {

--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Gjdoalfnrxu/tsq/extract/typecheck"
 	"github.com/Gjdoalfnrxu/tsq/output"
 	"github.com/Gjdoalfnrxu/tsq/ql/ast"
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
 	"github.com/Gjdoalfnrxu/tsq/ql/desugar"
 	"github.com/Gjdoalfnrxu/tsq/ql/eval"
 	"github.com/Gjdoalfnrxu/tsq/ql/parse"
@@ -564,21 +565,33 @@ type buildOptions struct {
 }
 
 func buildProgram(src, file string, importLoader func(string) (*ast.Module, error), sizeHints map[string]int) (*plan.ExecutionPlan, *ast.Module, []resolve.Warning, []error) {
-	return buildProgramWithOpts(src, file, importLoader, sizeHints, buildOptions{})
+	execPlan, _, mod, warnings, errs := buildProgramWithProg(src, file, importLoader, sizeHints, buildOptions{})
+	return execPlan, mod, warnings, errs
 }
 
 func buildProgramWithOpts(src, file string, importLoader func(string) (*ast.Module, error), sizeHints map[string]int, opts buildOptions) (*plan.ExecutionPlan, *ast.Module, []resolve.Warning, []error) {
+	execPlan, _, mod, warnings, errs := buildProgramWithProg(src, file, importLoader, sizeHints, opts)
+	return execPlan, mod, warnings, errs
+}
+
+// buildProgramWithProg is buildProgram with the post-merge *datalog.Program
+// also returned. It is used by `query` so the compileAndEval pipeline can run
+// the trivial-IDB pre-pass (eval.EstimateNonRecursiveIDBSizes) over the same
+// rule graph the planner sees, populate sizeHints with real derived-relation
+// counts, and re-plan. `check` does not need prog (no eval), so it keeps the
+// narrower buildProgram wrapper.
+func buildProgramWithProg(src, file string, importLoader func(string) (*ast.Module, error), sizeHints map[string]int, opts buildOptions) (*plan.ExecutionPlan, *datalog.Program, *ast.Module, []resolve.Warning, []error) {
 	// Parse.
 	p := parse.NewParser(src, file)
 	mod, err := p.Parse()
 	if err != nil {
-		return nil, nil, nil, []error{fmt.Errorf("parse: %w", err)}
+		return nil, nil, nil, nil, []error{fmt.Errorf("parse: %w", err)}
 	}
 
 	// Resolve.
 	resolved, err := resolve.Resolve(mod, importLoader)
 	if err != nil {
-		return nil, mod, nil, []error{fmt.Errorf("resolve: %w", err)}
+		return nil, nil, mod, nil, []error{fmt.Errorf("resolve: %w", err)}
 	}
 	warnings := resolved.Warnings
 	if len(resolved.Errors) > 0 {
@@ -586,7 +599,7 @@ func buildProgramWithOpts(src, file string, importLoader func(string) (*ast.Modu
 		for _, e := range resolved.Errors {
 			errs = append(errs, fmt.Errorf("resolve: %w", e))
 		}
-		return nil, mod, warnings, errs
+		return nil, nil, mod, warnings, errs
 	}
 
 	// Desugar.
@@ -596,7 +609,7 @@ func buildProgramWithOpts(src, file string, importLoader func(string) (*ast.Modu
 		for _, e := range dsErrors {
 			errs = append(errs, fmt.Errorf("desugar: %w", e))
 		}
-		return nil, mod, warnings, errs
+		return nil, nil, mod, warnings, errs
 	}
 
 	// Inject system rules so derived relations (CallTarget, LocalFlow,
@@ -625,10 +638,10 @@ func buildProgramWithOpts(src, file string, importLoader func(string) (*ast.Modu
 		for _, e := range planErrors {
 			errs = append(errs, fmt.Errorf("plan: %w", e))
 		}
-		return nil, mod, warnings, errs
+		return nil, prog, mod, warnings, errs
 	}
 
-	return execPlan, mod, warnings, nil
+	return execPlan, prog, mod, warnings, nil
 }
 
 // compileAndEval reads a .ql file, compiles it, loads a fact DB, and evaluates.
@@ -669,7 +682,7 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string, maxBindingsPe
 	// rule graph (parse → resolve → desugar → MergeSystemRules → plan).
 	bridgeFiles := bridge.LoadBridge()
 	importLoader := makeBridgeImportLoader(bridgeFiles)
-	execPlan, _, _, buildErrs := buildProgramWithOpts(string(src), queryFile, importLoader, sizeHints, opts)
+	execPlan, prog, _, _, buildErrs := buildProgramWithProg(string(src), queryFile, importLoader, sizeHints, opts)
 	if len(buildErrs) > 0 {
 		// Reproduce the prior multi-error formatting of compileAndEval: group
 		// by phase and join with newline-indented messages so callers see one
@@ -677,19 +690,52 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string, maxBindingsPe
 		return nil, joinPhaseErrors(buildErrs)
 	}
 
+	// Issue #88 (co-stratified seed case): pre-compute the cardinality of
+	// every "trivial" derived predicate — non-recursive, body uses only
+	// positive base atoms and comparisons — and feed the real counts back
+	// into the planner. This catches the case where a tiny IDB seed (e.g.
+	// isUseStateSetterCall, 7 tuples) and the explody rule that uses it
+	// (setStateUpdaterCallsFn) land in the same stratum, which the
+	// between-strata refresh in eval.Evaluate cannot fix on its own (the
+	// seed is not yet materialised when its sibling rule is planned).
+	//
+	// Load base relations once and reuse them for both the pre-pass and the
+	// main Evaluate call (loadBaseRelations is the dominant cost for small
+	// fact DBs and we'd rather not pay it twice).
+	baseRels, err := eval.LoadBaseRelations(factDB)
+	if err != nil {
+		return nil, fmt.Errorf("load base relations: %w", err)
+	}
+	updates := eval.EstimateNonRecursiveIDBSizes(prog, baseRels, sizeHints)
+	if len(updates) > 0 {
+		// Re-plan every stratum and the final query with the refreshed hints
+		// before evaluation begins. Without this the original execPlan
+		// (planned with default-1000 hints for every IDB) would still drive
+		// the evaluator; the between-strata refresh in eval.Evaluate would
+		// only help strata > 0, missing the co-stratified case entirely.
+		for i := range execPlan.Strata {
+			plan.RePlanStratum(&execPlan.Strata[i], sizeHints)
+		}
+		if execPlan.Query != nil {
+			plan.RePlanQuery(execPlan.Query, sizeHints)
+		}
+	}
+
 	// Evaluate.
-	evaluator := eval.NewEvaluator(
+	rs, err := eval.Evaluate(
+		ctx,
 		execPlan,
-		factDB,
+		baseRels,
 		eval.WithMaxBindingsPerRule(maxBindingsPerRule),
 		eval.WithMaxIterations(maxIterations),
 		eval.WithAllowPartial(allowPartial),
 		// Hand the planner's hints map to the evaluator so it can refresh
 		// derived-relation cardinalities between strata and re-plan the
-		// remaining strata + final query. Issue #88.
+		// remaining strata + final query. Issue #88. The map already
+		// contains the trivial-IDB pre-pass results from above; the
+		// between-strata refresh covers the non-trivial IDBs.
 		eval.WithSizeHints(sizeHints),
 	)
-	rs, err := evaluator.Evaluate(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("evaluate: %w", err)
 	}

--- a/issue88_setstate_integration_test.go
+++ b/issue88_setstate_integration_test.go
@@ -1,0 +1,170 @@
+package integration_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Gjdoalfnrxu/tsq/bridge"
+	extractrules "github.com/Gjdoalfnrxu/tsq/extract/rules"
+	"github.com/Gjdoalfnrxu/tsq/extract/schema"
+	"github.com/Gjdoalfnrxu/tsq/ql/desugar"
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+	"github.com/Gjdoalfnrxu/tsq/ql/parse"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+	"github.com/Gjdoalfnrxu/tsq/ql/resolve"
+)
+
+// TestIssue88_SetStateQueryDoesNotOOM is the regression guard for issue #88.
+//
+// The setStateUpdaterCallsFn rule (testdata/queries/v2/find_setstate_updater_calls_fn.ql,
+// React bridge) historically blew the binding cap at join step 2 because the
+// planner sized the IDB seed isUseStateSetterCall at the default 1000 tuples
+// instead of its real ~7 — leading it to choose a Cartesian-heavy join order
+// led by Function × Node × Call.
+//
+// Both the seed predicate AND the explody rule co-stratify (same SCC after
+// MergeSystemRules), so the prior between-strata refresh in eval.Evaluate
+// did NOT fix this. The fix is the trivial-IDB pre-pass
+// (eval.EstimateNonRecursiveIDBSizes) wired in cmd/tsq/main.go's
+// compileAndEval, which materialises every non-recursive IDB whose body
+// uses only base + already-trivial predicates BEFORE the first Plan() call,
+// then re-plans every stratum with the real numbers.
+//
+// This test reproduces the production codepath: extract a small TSX fixture,
+// run the same query end-to-end, and assert it completes without binding-cap
+// errors and well below an aggressive cardinality budget. If the fix
+// regresses (or someone reverts the pre-pass), this test fails immediately
+// with a *BindingCapError instead of an OOM-after-an-hour in the field.
+func TestIssue88_SetStateQueryDoesNotOOM(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping extraction-heavy integration test in short mode")
+	}
+
+	factDB := extractProject(t, "testdata/projects/react-usestate")
+
+	src, err := os.ReadFile("testdata/queries/v2/find_setstate_updater_calls_fn.ql")
+	if err != nil {
+		t.Fatalf("read query: %v", err)
+	}
+
+	bridgeFiles := bridge.LoadBridge()
+	importLoader := makeBridgeImportLoader(bridgeFiles)
+
+	// Compile.
+	p := parse.NewParser(string(src), "find_setstate_updater_calls_fn.ql")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	resolved, err := resolve.Resolve(mod, importLoader)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(resolved.Errors) > 0 {
+		t.Fatalf("resolve errors: %v", resolved.Errors)
+	}
+	prog, dsErrors := desugar.Desugar(resolved)
+	if len(dsErrors) > 0 {
+		t.Fatalf("desugar: %v", dsErrors)
+	}
+	prog = extractrules.MergeSystemRules(prog, extractrules.AllSystemRules())
+
+	// Build base size hints from the fact DB.
+	hints := make(map[string]int, len(schema.Registry))
+	for _, def := range schema.Registry {
+		hints[def.Name] = factDB.Relation(def.Name).Tuples()
+	}
+
+	// Plan.
+	execPlan, planErrs := plan.Plan(prog, hints)
+	if len(planErrs) > 0 {
+		t.Fatalf("plan: %v", planErrs)
+	}
+
+	// Pre-pass + re-plan (the issue #88 fix). If a future change removes
+	// these two calls from cmd/tsq/main.go, the assertion below catches
+	// the regression directly: the rule will OOM at step 2.
+	baseRels, err := eval.LoadBaseRelations(factDB)
+	if err != nil {
+		t.Fatalf("load base relations: %v", err)
+	}
+	updates := eval.EstimateNonRecursiveIDBSizes(prog, baseRels, hints)
+	if updates["isUseStateSetterCall"] == 0 {
+		t.Fatalf("pre-pass failed to size isUseStateSetterCall (the seed predicate); updates=%v", updates)
+	}
+	for i := range execPlan.Strata {
+		plan.RePlanStratum(&execPlan.Strata[i], hints)
+	}
+	if execPlan.Query != nil {
+		plan.RePlanQuery(execPlan.Query, hints)
+	}
+
+	// Assert: the seed predicate is now FIRST in the join order. This is
+	// the load-bearing planner outcome — if it stops being true, the rule
+	// will Cartesian-blow regardless of whether the test happens to fit
+	// under the binding cap on this small fixture.
+	assertSeedFirst(t, execPlan, "setStateUpdaterCallsFn", "isUseStateSetterCall")
+
+	// Aggressive binding cap: real fixture intermediate cardinality with the
+	// fix in place is < 1k. Pre-fix this rule blew the default 5M cap; we
+	// pick 100k as the regression threshold — comfortably above the real
+	// number, comfortably below "Cartesian disaster".
+	const tightCap = 100_000
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rs, err := eval.Evaluate(
+		ctx,
+		execPlan,
+		baseRels,
+		eval.WithMaxBindingsPerRule(tightCap),
+		eval.WithSizeHints(hints),
+	)
+	if err != nil {
+		var bce *eval.BindingCapError
+		if errors.As(err, &bce) {
+			t.Fatalf("BUG: setStateUpdaterCallsFn blew the %d-binding cap at step %d (cardinality=%d, rule=%q). The trivial-IDB pre-pass is broken — see issue #88.",
+				tightCap, bce.StepIndex, bce.Cardinality, bce.Rule)
+		}
+		t.Fatalf("evaluate: %v", err)
+	}
+
+	// Sanity: the React fixture has at least one Case A match (setCount(prev => helper(prev))).
+	if len(rs.Rows) == 0 {
+		t.Fatalf("expected at least one setStateUpdaterCallsFn match on the fixture, got 0 rows")
+	}
+	t.Logf("setStateUpdaterCallsFn matched %d rows on react-usestate fixture (binding cap %d)", len(rs.Rows), tightCap)
+}
+
+// assertSeedFirst checks that the first JoinStep of the named rule's join
+// order is on `wantFirstPredicate`. Used as a behavioural assertion that the
+// planner is making the seed-selection decision the issue #88 fix targets.
+func assertSeedFirst(t *testing.T, ep *plan.ExecutionPlan, ruleHead, wantFirstPredicate string) {
+	t.Helper()
+	for _, s := range ep.Strata {
+		for _, r := range s.Rules {
+			if r.Head.Predicate != ruleHead {
+				continue
+			}
+			if len(r.JoinOrder) == 0 {
+				t.Fatalf("rule %s has empty JoinOrder", ruleHead)
+			}
+			got := r.JoinOrder[0].Literal.Atom.Predicate
+			if got != wantFirstPredicate {
+				// Print full order for diagnostics.
+				var order []string
+				for _, st := range r.JoinOrder {
+					order = append(order, st.Literal.Atom.Predicate)
+				}
+				t.Fatalf("rule %s: first literal want %s, got %s. Full order: %v",
+					ruleHead, wantFirstPredicate, got, order)
+			}
+			return
+		}
+	}
+	t.Fatalf("rule %s not found in execution plan", ruleHead)
+}

--- a/ql/eval/estimate.go
+++ b/ql/eval/estimate.go
@@ -1,0 +1,102 @@
+package eval
+
+import (
+	"context"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// EstimateNonRecursiveIDBSizes pre-computes the cardinality of every
+// "trivially evaluable" derived predicate in prog (see plan.IdentifyTrivialIDBs)
+// using the supplied base relations, and writes each computed count into
+// sizeHints (in place). The returned map mirrors the writes, so callers that
+// want a separate copy can use it.
+//
+// Why this exists: the planner's greedy join ordering uses sizeHints to score
+// literals. Without entries for derived predicates, IDB literals fall through
+// to defaultSizeHint=1000 (ql/plan/join.go). For queries whose ideal seed is
+// a tiny derived predicate (e.g. isUseStateSetterCall, 7 tuples in the React
+// bridge), the planner picks a Cartesian-heavy order based on the
+// 1000-tuple lie and OOMs (issue #88). The previous fix re-planned BETWEEN
+// strata, but co-stratified rules — where the seed and the explody rule are
+// in the same SCC — never benefit because the seed is not yet materialised
+// when its sibling rule is planned. This pre-pass is the missing piece.
+//
+// Restrictions on what is "trivial": rules with only positive base-predicate
+// atoms and comparisons — no negation, no aggregates, no recursion, no
+// references to other IDBs. Predicates not meeting this bar are left at the
+// default hint and will benefit from the existing between-strata refresh
+// only if they happen to be in a later stratum.
+//
+// Update semantics: an existing sizeHints entry is overwritten only when the
+// computed value is strictly larger (defensive — a manually-supplied small
+// base count for a name colliding with an IDB head must not be silently
+// shrunk; see the parallel rule in seminaive.go's between-strata refresh).
+//
+// Errors during evaluation of an individual trivial IDB (e.g. binding cap)
+// are silently absorbed — the pre-pass is best-effort. If a "trivial" rule
+// itself OOMs we'd rather degrade to the default hint than fail compilation.
+//
+// Returns the slice of (name, computed-size) updates actually applied, for
+// observability/testing.
+func EstimateNonRecursiveIDBSizes(prog *datalog.Program, baseRels map[string]*Relation, sizeHints map[string]int) map[string]int {
+	if sizeHints == nil {
+		sizeHints = map[string]int{}
+	}
+	if prog == nil {
+		return map[string]int{}
+	}
+
+	basePreds := make(map[string]bool, len(baseRels))
+	for _, rel := range baseRels {
+		if rel == nil {
+			continue
+		}
+		basePreds[rel.Name] = true
+	}
+
+	// trivials is in topological order: each entry depends only on base
+	// predicates and on earlier entries. We materialise as we go and stash
+	// each result back into `keyed` so subsequent rules can reference it.
+	trivials := plan.IdentifyTrivialIDBs(prog, basePreds)
+	updates := make(map[string]int, len(trivials))
+
+	keyed := keyRels(baseRels)
+
+	for _, t := range trivials {
+		head := NewRelation(t.Name, t.Arity)
+		failed := false
+		for _, rule := range t.Rules {
+			planned := plan.SingleRule(rule, sizeHints)
+			tuples, err := Rule(context.Background(), planned, keyed, 0) // no binding cap during pre-pass
+			if err != nil {
+				// Best-effort: skip this IDB entirely on any error so we
+				// don't half-populate hints. The default hint will apply
+				// and the between-strata refresh in Evaluate will catch up
+				// (for non-co-stratified cases at least).
+				failed = true
+				break
+			}
+			for _, tup := range tuples {
+				head.Add(tup)
+			}
+		}
+		if failed {
+			continue
+		}
+		// Make this IDB visible to subsequent trivial rules that reference
+		// it. keyRels uses (name,arity) so this won't shadow a base relation
+		// of a different arity. Topological order guarantees no later
+		// trivial depends on something not yet in `keyed`.
+		keyed[relKey(t.Name, t.Arity)] = head
+
+		n := head.Len()
+		if cur, exists := sizeHints[t.Name]; !exists || n > cur {
+			sizeHints[t.Name] = n
+		}
+		updates[t.Name] = n
+	}
+
+	return updates
+}

--- a/ql/eval/estimate_test.go
+++ b/ql/eval/estimate_test.go
@@ -1,0 +1,180 @@
+package eval_test
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+)
+
+// makeIntRel constructs a base relation with the given name and a list of
+// arity-1 integer tuples. Test helper.
+func makeIntRel(t *testing.T, name string, vals ...int64) *eval.Relation {
+	t.Helper()
+	r := eval.NewRelation(name, 1)
+	for _, v := range vals {
+		r.Add(eval.Tuple{eval.IntVal{V: v}})
+	}
+	return r
+}
+
+// makeIntRel2 constructs an arity-2 base relation from pairs.
+func makeIntRel2(t *testing.T, name string, pairs ...[2]int64) *eval.Relation {
+	t.Helper()
+	r := eval.NewRelation(name, 2)
+	for _, p := range pairs {
+		r.Add(eval.Tuple{eval.IntVal{V: p[0]}, eval.IntVal{V: p[1]}})
+	}
+	return r
+}
+
+// TestEstimateNonRecursiveIDBSizesBaseOnly: a rule body composed of a single
+// base predicate is sized correctly.
+func TestEstimateNonRecursiveIDBSizesBaseOnly(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: datalog.Atom{Predicate: "Q", Args: []datalog.Term{datalog.Var{Name: "x"}}},
+				Body: []datalog.Literal{{Positive: true, Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{datalog.Var{Name: "x"}}}}},
+			},
+		},
+	}
+	base := map[string]*eval.Relation{
+		"A": makeIntRel(t, "A", 1, 2, 3, 4, 5),
+	}
+	hints := map[string]int{"A": 5}
+	updates := eval.EstimateNonRecursiveIDBSizes(prog, base, hints)
+	if updates["Q"] != 5 {
+		t.Errorf("Q size: want 5, got %d (updates=%v, hints=%v)", updates["Q"], updates, hints)
+	}
+	if hints["Q"] != 5 {
+		t.Errorf("hints[Q]: want 5, got %d", hints["Q"])
+	}
+}
+
+// TestEstimateNonRecursiveIDBSizesJoinSelectivity: a join that filters down
+// to fewer tuples than either input is sized at the JOINED size, not either
+// individual relation. This is the property that makes the seed-selection
+// fix work in production. Mutation-killable: if the function were to (e.g.)
+// just take min of input sizes, this test would fail.
+func TestEstimateNonRecursiveIDBSizesJoinSelectivity(t *testing.T) {
+	// A(x): {1,2,3,4,5}     — 5 tuples
+	// B(x,y): {(1,10),(2,20),(7,70)} — 3 tuples; only x∈{1,2} overlap with A
+	// Q(x,y) :- A(x), B(x,y). — should be exactly 2 tuples.
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: datalog.Atom{Predicate: "Q", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "y"}}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{datalog.Var{Name: "x"}}}},
+					{Positive: true, Atom: datalog.Atom{Predicate: "B", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "y"}}}},
+				},
+			},
+		},
+	}
+	base := map[string]*eval.Relation{
+		"A": makeIntRel(t, "A", 1, 2, 3, 4, 5),
+		"B": makeIntRel2(t, "B", [2]int64{1, 10}, [2]int64{2, 20}, [2]int64{7, 70}),
+	}
+	hints := map[string]int{"A": 5, "B": 3}
+	updates := eval.EstimateNonRecursiveIDBSizes(prog, base, hints)
+	if updates["Q"] != 2 {
+		t.Errorf("Q join size: want 2 (real intersection), got %d", updates["Q"])
+	}
+}
+
+// TestEstimateNonRecursiveIDBSizesTransitive: an IDB defined on top of
+// another IDB is correctly estimated using the previously-computed IDB,
+// not the default hint. This is the case that broke without transitive
+// closure (R(x) :- A(x), wasL(x); wasL(x) :- B(x)).
+func TestEstimateNonRecursiveIDBSizesTransitive(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			// L(x) :- B(x).
+			{
+				Head: datalog.Atom{Predicate: "L", Args: []datalog.Term{datalog.Var{Name: "x"}}},
+				Body: []datalog.Literal{{Positive: true, Atom: datalog.Atom{Predicate: "B", Args: []datalog.Term{datalog.Var{Name: "x"}}}}},
+			},
+			// Q(x) :- A(x), L(x).
+			{
+				Head: datalog.Atom{Predicate: "Q", Args: []datalog.Term{datalog.Var{Name: "x"}}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{datalog.Var{Name: "x"}}}},
+					{Positive: true, Atom: datalog.Atom{Predicate: "L", Args: []datalog.Term{datalog.Var{Name: "x"}}}},
+				},
+			},
+		},
+	}
+	base := map[string]*eval.Relation{
+		"A": makeIntRel(t, "A", 1, 2, 3, 4, 5, 6, 7, 8),
+		"B": makeIntRel(t, "B", 1, 2),
+	}
+	hints := map[string]int{"A": 8, "B": 2}
+	updates := eval.EstimateNonRecursiveIDBSizes(prog, base, hints)
+	if updates["L"] != 2 {
+		t.Errorf("L: want 2, got %d", updates["L"])
+	}
+	if updates["Q"] != 2 {
+		t.Errorf("Q (transitive on L): want 2, got %d", updates["Q"])
+	}
+	if hints["L"] != 2 || hints["Q"] != 2 {
+		t.Errorf("hints not updated: hints=%v", hints)
+	}
+}
+
+// TestEstimateNonRecursiveIDBSizesNeverShrinks: an existing larger hint is
+// not overwritten by a smaller computed size (defensive — protects against
+// upstream name collisions and matches the parallel rule in seminaive's
+// between-strata refresh).
+func TestEstimateNonRecursiveIDBSizesNeverShrinks(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: datalog.Atom{Predicate: "Q", Args: []datalog.Term{datalog.Var{Name: "x"}}},
+				Body: []datalog.Literal{{Positive: true, Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{datalog.Var{Name: "x"}}}}},
+			},
+		},
+	}
+	base := map[string]*eval.Relation{
+		"A": makeIntRel(t, "A", 1),
+	}
+	hints := map[string]int{"A": 1, "Q": 9999}
+	eval.EstimateNonRecursiveIDBSizes(prog, base, hints)
+	if hints["Q"] != 9999 {
+		t.Errorf("Q hint shrunk from 9999 to %d", hints["Q"])
+	}
+}
+
+// TestEstimateNonRecursiveIDBSizesSkipsRecursive: a recursive rule is left
+// at the default hint (no entry written) — the pre-pass declines rather
+// than risking divergence.
+func TestEstimateNonRecursiveIDBSizesSkipsRecursive(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			// Path(x,y) :- Edge(x,y).
+			{
+				Head: datalog.Atom{Predicate: "Path", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "y"}}},
+				Body: []datalog.Literal{{Positive: true, Atom: datalog.Atom{Predicate: "Edge", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "y"}}}}},
+			},
+			// Path(x,z) :- Edge(x,y), Path(y,z).  (recursive)
+			{
+				Head: datalog.Atom{Predicate: "Path", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "z"}}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "Edge", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "y"}}}},
+					{Positive: true, Atom: datalog.Atom{Predicate: "Path", Args: []datalog.Term{datalog.Var{Name: "y"}, datalog.Var{Name: "z"}}}},
+				},
+			},
+		},
+	}
+	base := map[string]*eval.Relation{
+		"Edge": makeIntRel2(t, "Edge", [2]int64{1, 2}),
+	}
+	hints := map[string]int{"Edge": 1}
+	updates := eval.EstimateNonRecursiveIDBSizes(prog, base, hints)
+	if _, ok := updates["Path"]; ok {
+		t.Errorf("Path is recursive — should be skipped, got update %d", updates["Path"])
+	}
+	if _, ok := hints["Path"]; ok {
+		t.Errorf("Path hint should be absent, got %d", hints["Path"])
+	}
+}

--- a/ql/eval/eval.go
+++ b/ql/eval/eval.go
@@ -37,6 +37,16 @@ func (e *Evaluator) Evaluate(ctx context.Context) (*ResultSet, error) {
 	return Evaluate(ctx, e.execPlan, baseRels, e.opts...)
 }
 
+// LoadBaseRelations is the exported alias for loadBaseRelations. It is used
+// by the trivial-IDB pre-pass (see EstimateNonRecursiveIDBSizes and its
+// caller in cmd/tsq/main.go) which needs base relations BEFORE the main
+// Evaluate() call. The pre-pass and Evaluate() then share the same loaded
+// map; loading is idempotent but duplicating the work would needlessly read
+// the fact DB twice.
+func LoadBaseRelations(factDB *db.DB) (map[string]*Relation, error) {
+	return loadBaseRelations(factDB)
+}
+
 // loadBaseRelations converts a db.DB into a map of eval.Relation objects.
 // It iterates all registered schema relations and loads any that are present
 // in the DB.

--- a/ql/eval/seminaive.go
+++ b/ql/eval/seminaive.go
@@ -138,6 +138,14 @@ type evalConfig struct {
 	maxBindingsPerRule int
 	parallel           bool
 	allowPartial       bool
+	// sizeHints is the planner's relation→tuple-count map. When non-nil,
+	// Evaluate refreshes it after each stratum's fixpoint converges (using
+	// the materialised tuple counts of the head predicates produced in that
+	// stratum) and re-plans every subsequent stratum's join order with the
+	// updated hints. This fixes the IDB-default-1000 misestimate that caused
+	// Cartesian-heavy join orders for queries whose seed predicate is a tiny
+	// derived relation. See issue #88.
+	sizeHints map[string]int
 }
 
 // WithMaxIterations sets the maximum number of fixpoint iterations per stratum.
@@ -171,6 +179,21 @@ func WithMaxBindingsPerRule(n int) Option {
 // are evaluated concurrently.
 func WithParallel() Option {
 	return func(c *evalConfig) { c.parallel = true }
+}
+
+// WithSizeHints provides the planner's relation→tuple-count map to the
+// evaluator. When supplied, Evaluate refreshes the map after each stratum's
+// fixpoint converges with the actual tuple counts of derived predicates
+// produced in that stratum, then re-plans every later stratum (and the final
+// query) using the refreshed hints. This is the fix for issue #88 — without
+// it, derived (IDB) predicates fall through to defaultSizeHint=1000 and the
+// planner mis-orders joins seeded by tiny derived relations.
+//
+// Pass the same map handed to plan.Plan; the evaluator mutates it in place.
+// Callers that do not need adaptive replanning can omit this option, in
+// which case behaviour is unchanged.
+func WithSizeHints(hints map[string]int) Option {
+	return func(c *evalConfig) { c.sizeHints = hints }
 }
 
 // Evaluate executes an ExecutionPlan over base facts and returns results.
@@ -369,6 +392,37 @@ func Evaluate(ctx context.Context, execPlan *plan.ExecutionPlan, baseRels map[st
 				return nil, aerr
 			}
 			allRels[relKey(resultRel.Name, resultRel.Arity)] = resultRel
+		}
+
+		// Issue #88: refresh size hints with derived-relation cardinalities
+		// produced in this stratum, then re-plan every subsequent stratum
+		// (and the final query) so they pick join orders with real numbers
+		// instead of defaultSizeHint=1000 for IDB predicates. Strata that
+		// have already executed are not re-planned (their work is done).
+		if cfg.sizeHints != nil {
+			for _, rule := range stratum.Rules {
+				name := rule.Head.Predicate
+				arity := len(rule.Head.Args)
+				if rel, ok := allRels[relKey(name, arity)]; ok && rel != nil {
+					n := rel.Len()
+					// Only update if the new value is larger or the key is
+					// absent. We never shrink hints below an existing base
+					// count for a predicate of the same name (defensive — a
+					// bridge IDB and an EDB sharing a name would be a bug
+					// upstream, but if it ever happens we don't want to
+					// silently zero out the base count).
+					if cur, exists := cfg.sizeHints[name]; !exists || n > cur {
+						cfg.sizeHints[name] = n
+					}
+				}
+			}
+			// Re-plan strata si+1..end and the final query.
+			for j := si + 1; j < len(execPlan.Strata); j++ {
+				plan.RePlanStratum(&execPlan.Strata[j], cfg.sizeHints)
+			}
+			if execPlan.Query != nil {
+				plan.RePlanQuery(execPlan.Query, cfg.sizeHints)
+			}
 		}
 	}
 

--- a/ql/eval/sizehints_refresh_test.go
+++ b/ql/eval/sizehints_refresh_test.go
@@ -1,0 +1,218 @@
+package eval
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// TestSizeHintsRefreshUpdatesMap is the unit test required by issue #88: it
+// confirms that after a multi-stratum evaluation the sizeHints map contains
+// the real materialised tuple counts of the derived predicates produced in
+// each stratum (not the defaultSizeHint=1000 fallback).
+func TestSizeHintsRefreshUpdatesMap(t *testing.T) {
+	// Program:
+	//   Tiny(x) :- Seed(x), x = 1.   -- stratum 0, derives 1 tuple from Seed
+	//   Out(x)  :- Big(x), Tiny(x).  -- stratum 1, joins a base rel with the IDB
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: datalog.Atom{Predicate: "Tiny", Args: []datalog.Term{v("x")}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "Seed", Args: []datalog.Term{v("x")}}},
+					{Positive: true, Cmp: &datalog.Comparison{Op: "=", Left: v("x"), Right: datalog.IntConst{Value: 1}}},
+				},
+			},
+			// NotInSink(x) :- Big(x), not Sink(x).
+			// We define a dummy IDB Sink with no rules of its own — so it
+			// stays empty — but the negative edge forces Out to a strictly
+			// later stratum than Tiny (the planner stratifies negation).
+			{
+				Head: datalog.Atom{Predicate: "Sink", Args: []datalog.Term{v("x")}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "Seed", Args: []datalog.Term{v("x")}}},
+					{Positive: true, Cmp: &datalog.Comparison{Op: "=", Left: v("x"), Right: datalog.IntConst{Value: 999}}},
+				},
+			},
+			{
+				Head: datalog.Atom{Predicate: "Out", Args: []datalog.Term{v("x")}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "Big", Args: []datalog.Term{v("x")}}},
+					{Positive: true, Atom: datalog.Atom{Predicate: "Tiny", Args: []datalog.Term{v("x")}}},
+					// Negative dep on Sink to force a stratum boundary.
+					{Positive: false, Atom: datalog.Atom{Predicate: "Sink", Args: []datalog.Term{v("x")}}},
+				},
+			},
+		},
+		Query: &datalog.Query{
+			Select: []datalog.Term{v("x")},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "Out", Args: []datalog.Term{v("x")}}},
+			},
+		},
+	}
+
+	// Seed has 3 tuples but only x=1 survives the comparison, so Tiny=1.
+	seed := makeRelation("Seed", 1, IntVal{1}, IntVal{2}, IntVal{3})
+	// Big is a 50-tuple base relation.
+	bigVals := make([]Value, 50)
+	for i := 0; i < 50; i++ {
+		bigVals[i] = IntVal{int64(i)}
+	}
+	big := makeRelation("Big", 1, bigVals...)
+	baseRels := map[string]*Relation{"Seed": seed, "Big": big}
+
+	// Hints reflect what the cmd would supply: only base relations are sized.
+	// Tiny falls through to defaultSizeHint=1000.
+	hints := map[string]int{"Seed": 3, "Big": 50}
+
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+	if len(ep.Strata) != 2 {
+		t.Fatalf("expected 2 strata (Tiny then Out), got %d", len(ep.Strata))
+	}
+
+	// Locate the stratum that contains Out (stratum 1).
+	outStratumIdx := -1
+	for i, s := range ep.Strata {
+		for _, r := range s.Rules {
+			if r.Head.Predicate == "Out" {
+				outStratumIdx = i
+			}
+		}
+	}
+	if outStratumIdx == -1 {
+		t.Fatalf("Out rule not found in any stratum")
+	}
+
+	// Capture the baseline join order for Out *before* eval.
+	var baselineOrder []string
+	for _, r := range ep.Strata[outStratumIdx].Rules {
+		if r.Head.Predicate == "Out" {
+			for _, step := range r.JoinOrder {
+				baselineOrder = append(baselineOrder, step.Literal.Atom.Predicate)
+			}
+		}
+	}
+	// With Tiny unhinted (=1000) and Big=50, planner picks Big first.
+	// The negative literal on Sink can only be placed once x is bound, so
+	// it lands last regardless. Just check the seed is Big.
+	if len(baselineOrder) == 0 || baselineOrder[0] != "Big" {
+		t.Fatalf("baseline join order: expected Big first, got %v", baselineOrder)
+	}
+
+	// Evaluate with refresh enabled.
+	_, err := Evaluate(context.Background(), ep, baseRels, WithSizeHints(hints))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+
+	// Hint for Tiny must now reflect the real count (1).
+	if got := hints["Tiny"]; got != 1 {
+		t.Errorf("expected hints[Tiny]=1 after refresh, got %d", got)
+	}
+	// Out is in stratum 1 and may also have been written. It produced 1 tuple.
+	if got := hints["Out"]; got != 1 {
+		t.Errorf("expected hints[Out]=1 after refresh, got %d", got)
+	}
+
+	// ANTI-GAMING: assert the plan for Out actually swapped after the
+	// post-stratum-0 refresh. Tiny=1 < Big=50, so Tiny should be first now.
+	var finalOrder []string
+	for _, r := range ep.Strata[outStratumIdx].Rules {
+		if r.Head.Predicate == "Out" {
+			for _, step := range r.JoinOrder {
+				finalOrder = append(finalOrder, step.Literal.Atom.Predicate)
+			}
+		}
+	}
+	if len(finalOrder) == 0 || finalOrder[0] != "Tiny" {
+		t.Errorf("expected Tiny placed first after refresh (size 1 < Big=50), got %v", finalOrder)
+	}
+}
+
+// TestSizeHintsRefreshNoOptionLeavesPlanUnchanged guards against accidental
+// behavioural change for callers that do not opt into refresh. Without
+// WithSizeHints, the plan's join orders should be untouched by Evaluate.
+func TestSizeHintsRefreshNoOptionLeavesPlanUnchanged(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: datalog.Atom{Predicate: "Tiny", Args: []datalog.Term{v("x")}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "Seed", Args: []datalog.Term{v("x")}}},
+					{Positive: true, Cmp: &datalog.Comparison{Op: "=", Left: v("x"), Right: datalog.IntConst{Value: 1}}},
+				},
+			},
+			{
+				Head: datalog.Atom{Predicate: "Sink", Args: []datalog.Term{v("x")}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "Seed", Args: []datalog.Term{v("x")}}},
+					{Positive: true, Cmp: &datalog.Comparison{Op: "=", Left: v("x"), Right: datalog.IntConst{Value: 999}}},
+				},
+			},
+			{
+				Head: datalog.Atom{Predicate: "Out", Args: []datalog.Term{v("x")}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "Big", Args: []datalog.Term{v("x")}}},
+					{Positive: true, Atom: datalog.Atom{Predicate: "Tiny", Args: []datalog.Term{v("x")}}},
+					{Positive: false, Atom: datalog.Atom{Predicate: "Sink", Args: []datalog.Term{v("x")}}},
+				},
+			},
+		},
+	}
+
+	seed := makeRelation("Seed", 1, IntVal{1}, IntVal{2})
+	bigVals := make([]Value, 5)
+	for i := 0; i < 5; i++ {
+		bigVals[i] = IntVal{int64(i)}
+	}
+	big := makeRelation("Big", 1, bigVals...)
+	baseRels := map[string]*Relation{"Seed": seed, "Big": big}
+
+	hints := map[string]int{"Seed": 2, "Big": 5}
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+
+	// Snapshot Out's order pre-eval.
+	var pre []string
+	for _, s := range ep.Strata {
+		for _, r := range s.Rules {
+			if r.Head.Predicate == "Out" {
+				for _, st := range r.JoinOrder {
+					pre = append(pre, st.Literal.Atom.Predicate)
+				}
+			}
+		}
+	}
+
+	// Evaluate WITHOUT WithSizeHints → no refresh.
+	if _, err := Evaluate(context.Background(), ep, baseRels); err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+
+	var post []string
+	for _, s := range ep.Strata {
+		for _, r := range s.Rules {
+			if r.Head.Predicate == "Out" {
+				for _, st := range r.JoinOrder {
+					post = append(post, st.Literal.Atom.Predicate)
+				}
+			}
+		}
+	}
+	if len(pre) != len(post) {
+		t.Fatalf("plan length changed: pre=%v post=%v", pre, post)
+	}
+	for i := range pre {
+		if pre[i] != post[i] {
+			t.Errorf("plan changed without WithSizeHints: pre=%v post=%v", pre, post)
+		}
+	}
+}

--- a/ql/plan/estimate.go
+++ b/ql/plan/estimate.go
@@ -1,0 +1,179 @@
+package plan
+
+import (
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// TrivialIDB describes a derived (IDB) predicate whose definition is
+// "trivially evaluable" before main planning: every rule defining the
+// predicate has a body composed only of base (EDB) predicates and
+// comparisons, with no negation, no aggregates, and no references to other
+// IDBs. Such predicates can be evaluated up-front using only base relations,
+// giving the planner real cardinality numbers instead of the
+// defaultSizeHint=1000 fallback.
+//
+// This is the fix for the co-stratified case of issue #88: when a tiny IDB
+// seed (e.g. isUseStateSetterCall, 7 tuples) and the explody rule that uses
+// it (e.g. setStateUpdaterCallsFn) land in the same stratum, the prior
+// "between-strata refresh" never fires for the seed before the explody rule
+// is planned, so the planner picks a Cartesian-heavy join order. Pre-computing
+// trivial IDBs gives the planner accurate seed sizes from the very first
+// Plan() call.
+type TrivialIDB struct {
+	// Name is the predicate name.
+	Name string
+	// Arity is the head arity for all rules defining this predicate.
+	// All rules defining a TrivialIDB must share the same arity (else it
+	// is excluded from the trivial set).
+	Arity int
+	// Rules are the original Datalog rules defining this predicate.
+	// Multiple rules represent a union (a disjunction in QL source).
+	Rules []datalog.Rule
+}
+
+// IdentifyTrivialIDBs returns the set of derived predicates in prog whose
+// definitions are evaluable using only base predicates and other already-
+// trivial IDBs. The result is in topological order: each TrivialIDB depends
+// only on basePredicates and on TrivialIDBs that appear earlier in the slice.
+//
+// A rule body is admissible if every literal is either a comparison or a
+// positive atom whose predicate is in basePredicates OR is the head of
+// another trivial-eligible IDB. Negation, aggregates, and recursion (direct
+// or indirect) all disqualify the head predicate. Predicates defined with
+// inconsistent arities across rules are excluded (defensive — the rest of
+// the pipeline assumes uniform arity).
+//
+// The transitive closure matters for the React-bridge case in issue #88:
+// `isUseStateSetterCall(c) :- CallCalleeSym(c,sym), isUseStateSetterSym(sym).`
+// references another IDB (`isUseStateSetterSym`), but that one IS trivial,
+// so once its size is known, `isUseStateSetterCall` becomes evaluable too.
+// Without the closure we'd cap out at 1-hop trivials and the planner would
+// still mis-score the actual seed predicate of the explody rule.
+//
+// `basePredicates` is the set of names that are EDB (base) relations — i.e.
+// supplied by the fact DB. The fixed-point iteration runs to convergence
+// (each pass admits at least one more IDB or terminates).
+func IdentifyTrivialIDBs(prog *datalog.Program, basePredicates map[string]bool) []TrivialIDB {
+	if prog == nil || len(prog.Rules) == 0 {
+		return nil
+	}
+
+	// Group rules by head predicate name. Track arity per name; if a name
+	// appears with multiple arities we drop it (defensive).
+	rulesByHead := map[string][]datalog.Rule{}
+	arityByHead := map[string]int{}
+	multiArity := map[string]bool{}
+	headOrder := []string{} // first-seen order for stable output
+	for _, rule := range prog.Rules {
+		name := rule.Head.Predicate
+		arity := len(rule.Head.Args)
+		if existing, seen := arityByHead[name]; seen {
+			if existing != arity {
+				multiArity[name] = true
+			}
+		} else {
+			arityByHead[name] = arity
+			headOrder = append(headOrder, name)
+		}
+		rulesByHead[name] = append(rulesByHead[name], rule)
+	}
+
+	// Fixed-point closure: a head is trivial in pass N if every body literal
+	// is a comparison, a positive atom on a base predicate, or a positive
+	// atom on a head already accepted as trivial in passes 1..N-1.
+	// Convergence is guaranteed: each pass either adds a head to `accepted`
+	// or doesn't, and the set is bounded by the head count.
+	accepted := map[string]bool{}
+	out := []TrivialIDB{}
+	for {
+		progress := false
+		for _, name := range headOrder {
+			if accepted[name] || multiArity[name] || basePredicates[name] {
+				continue
+			}
+			rules := rulesByHead[name]
+			ok := true
+			for _, rule := range rules {
+				if !ruleBodyIsTrivial(rule.Body, basePredicates, accepted, name) {
+					ok = false
+					break
+				}
+			}
+			if !ok {
+				continue
+			}
+			accepted[name] = true
+			out = append(out, TrivialIDB{
+				Name:  name,
+				Arity: arityByHead[name],
+				Rules: rules,
+			})
+			progress = true
+		}
+		if !progress {
+			break
+		}
+	}
+	return out
+}
+
+// SingleRule plans one rule against the given size hints and returns a
+// PlannedRule (with Body retained for re-planning). Exposed so callers can
+// produce planned rules outside of the full Plan() pipeline — primarily for
+// the trivial-IDB pre-pass in ql/eval, which wants to evaluate individual
+// rules before main stratification has run.
+//
+// Naming note: not "Rule" (clashes with eval.Rule and is type-confusing
+// alongside datalog.Rule) and not "PlanRule" (revive flags as stutter).
+func SingleRule(rule datalog.Rule, sizeHints map[string]int) PlannedRule {
+	if sizeHints == nil {
+		sizeHints = map[string]int{}
+	}
+	return PlannedRule{
+		Head:      rule.Head,
+		Body:      rule.Body,
+		JoinOrder: orderJoins(rule.Body, sizeHints),
+	}
+}
+
+// ruleBodyIsTrivial returns true if every literal in body is either a
+// comparison or a positive atom whose predicate is in basePredicates or in
+// the previously-accepted trivial-IDB set. Negation, aggregates, and
+// references to predicates not yet accepted (including self-recursion) all
+// disqualify the rule for this pass; the caller iterates until convergence.
+func ruleBodyIsTrivial(body []datalog.Literal, basePredicates, acceptedTrivials map[string]bool, headName string) bool {
+	for _, lit := range body {
+		if lit.Cmp != nil {
+			// Pure comparison constraint — fine, no predicate dependency.
+			continue
+		}
+		if lit.Agg != nil {
+			// Aggregate sub-goal — disqualified. Aggregates can be
+			// evaluated only after their underlying stratum is materialised
+			// and they introduce a different evaluation path than Rule().
+			return false
+		}
+		if !lit.Positive {
+			// Negative literal — disqualified. Anti-joins require the
+			// referenced relation to be fully materialised (closed-world
+			// assumption); pre-pass evaluation would be ill-defined for
+			// non-base negated predicates and risky even for base ones if
+			// it interacts with stratification.
+			return false
+		}
+		dep := lit.Atom.Predicate
+		if dep == headName {
+			// Self-recursive — definitely not trivial.
+			return false
+		}
+		if basePredicates[dep] {
+			continue
+		}
+		if acceptedTrivials[dep] {
+			continue
+		}
+		// References an IDB that is not (yet) accepted as trivial.
+		return false
+	}
+	return true
+}

--- a/ql/plan/estimate_test.go
+++ b/ql/plan/estimate_test.go
@@ -1,0 +1,122 @@
+package plan_test
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// TestIdentifyTrivialIDBsBasePredsOnly: a rule whose body is only base atoms
+// is identified as trivial.
+func TestIdentifyTrivialIDBsBasePredsOnly(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("Q", "x"), posLit("A", "x"), posLit("B", "x")),
+		},
+	}
+	base := map[string]bool{"A": true, "B": true}
+	got := plan.IdentifyTrivialIDBs(prog, base)
+	if len(got) != 1 || got[0].Name != "Q" {
+		t.Fatalf("expected [Q], got %+v", got)
+	}
+	if got[0].Arity != 1 {
+		t.Errorf("arity: want 1, got %d", got[0].Arity)
+	}
+	if len(got[0].Rules) != 1 {
+		t.Errorf("rules: want 1, got %d", len(got[0].Rules))
+	}
+}
+
+// TestIdentifyTrivialIDBsTransitive: an IDB that depends on another IDB is
+// trivial iff that dependency is itself trivial. Topological order.
+func TestIdentifyTrivialIDBsTransitive(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			// L1 :- A      (trivial level 1)
+			rule(atom("L1", "x"), posLit("A", "x")),
+			// L2 :- L1, B  (trivial level 2 — depends on L1)
+			rule(atom("L2", "x"), posLit("L1", "x"), posLit("B", "x")),
+			// L3 :- L2     (trivial level 3 — depends on L2)
+			rule(atom("L3", "x"), posLit("L2", "x")),
+		},
+	}
+	base := map[string]bool{"A": true, "B": true}
+	got := plan.IdentifyTrivialIDBs(prog, base)
+	if len(got) != 3 {
+		t.Fatalf("want 3 trivials, got %d (%+v)", len(got), got)
+	}
+	// Topological order is required by the eval-side estimator.
+	wantOrder := []string{"L1", "L2", "L3"}
+	for i, w := range wantOrder {
+		if got[i].Name != w {
+			t.Errorf("position %d: want %s, got %s (full: %+v)", i, w, got[i].Name, got)
+		}
+	}
+}
+
+// TestIdentifyTrivialIDBsNegationDisqualifies: a rule with a negative body
+// literal is NOT trivial, even if the negated predicate is base.
+func TestIdentifyTrivialIDBsNegationDisqualifies(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("Q", "x"), posLit("A", "x"), negLit("B", "x")),
+		},
+	}
+	base := map[string]bool{"A": true, "B": true}
+	got := plan.IdentifyTrivialIDBs(prog, base)
+	if len(got) != 0 {
+		t.Errorf("negation should disqualify, got %+v", got)
+	}
+}
+
+// TestIdentifyTrivialIDBsRecursionDisqualifies: a self-recursive rule is not
+// trivial. (And neither is anything indirectly recursive — the closure won't
+// admit the SCC because each member depends on something not yet accepted.)
+func TestIdentifyTrivialIDBsRecursionDisqualifies(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			// P(x) :- A(x).
+			rule(atom("P", "x"), posLit("A", "x")),
+			// P(x) :- P(x).  (recursive)
+			rule(atom("P", "x"), posLit("P", "x")),
+		},
+	}
+	base := map[string]bool{"A": true}
+	got := plan.IdentifyTrivialIDBs(prog, base)
+	if len(got) != 0 {
+		t.Errorf("self-recursion should disqualify, got %+v", got)
+	}
+}
+
+// TestIdentifyTrivialIDBsMissingBaseDisqualifies: a rule whose body
+// references an unknown (neither base nor admitted-trivial) predicate is not
+// trivial.
+func TestIdentifyTrivialIDBsMissingBaseDisqualifies(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("Q", "x"), posLit("A", "x"), posLit("Mystery", "x")),
+		},
+	}
+	base := map[string]bool{"A": true}
+	got := plan.IdentifyTrivialIDBs(prog, base)
+	if len(got) != 0 {
+		t.Errorf("missing dep should disqualify, got %+v", got)
+	}
+}
+
+// TestIdentifyTrivialIDBsBaseShadowExcluded: a head whose name matches a base
+// predicate is excluded — base relations come from the DB and cannot be
+// re-derived by the pre-pass.
+func TestIdentifyTrivialIDBsBaseShadowExcluded(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("A", "x"), posLit("B", "x")),
+		},
+	}
+	base := map[string]bool{"A": true, "B": true}
+	got := plan.IdentifyTrivialIDBs(prog, base)
+	if len(got) != 0 {
+		t.Errorf("base-shadow should be excluded, got %+v", got)
+	}
+}

--- a/ql/plan/plan.go
+++ b/ql/plan/plan.go
@@ -18,8 +18,15 @@ type Stratum struct {
 }
 
 // PlannedRule is a rule with a determined join order.
+//
+// Body holds the original rule body (in source order) so that the rule can be
+// re-planned later with updated size hints — e.g. between strata, once a
+// derived (IDB) predicate's true tuple count is known. Without Body the
+// evaluator would have no way to recover the literals to reorder; JoinOrder
+// alone is the post-greedy result and not equivalent to the input.
 type PlannedRule struct {
 	Head      datalog.Atom
+	Body      []datalog.Literal
 	JoinOrder []JoinStep
 }
 
@@ -87,6 +94,7 @@ func Plan(prog *datalog.Program, sizeHints map[string]int) (*ExecutionPlan, []er
 			order := orderJoins(rule.Body, sizeHints)
 			ps.Rules = append(ps.Rules, PlannedRule{
 				Head:      rule.Head,
+				Body:      rule.Body,
 				JoinOrder: order,
 			})
 			// Collect aggregates from rule body.
@@ -113,6 +121,50 @@ func Plan(prog *datalog.Program, sizeHints map[string]int) (*ExecutionPlan, []er
 	}
 
 	return ep, nil
+}
+
+// RePlanStratum recomputes the JoinOrder of every rule in the given stratum
+// using the supplied sizeHints. It mutates the stratum in place. Aggregates
+// and head atoms are left untouched. Use this after a prior stratum's fixpoint
+// has materialised a derived relation, so that subsequent strata are planned
+// with that relation's true cardinality instead of defaultSizeHint.
+//
+// If a rule's Body is nil (i.e. the stratum was constructed by code that did
+// not populate Body — pre-#88 callers) the rule is skipped so behaviour is
+// unchanged for legacy callers.
+func RePlanStratum(s *Stratum, sizeHints map[string]int) {
+	if s == nil {
+		return
+	}
+	if sizeHints == nil {
+		sizeHints = map[string]int{}
+	}
+	for i := range s.Rules {
+		body := s.Rules[i].Body
+		if body == nil {
+			continue
+		}
+		s.Rules[i].JoinOrder = orderJoins(body, sizeHints)
+	}
+}
+
+// RePlanQuery recomputes the JoinOrder of the planned query with updated
+// sizeHints. The query body is reconstructed from the existing JoinOrder
+// (since we kept the literals there). Unlike rules, queries have no separate
+// Body field — the JoinOrder literals ARE the body in some order. Reordering
+// is invariant to input order because orderJoins is greedy on the literal set.
+func RePlanQuery(q *PlannedQuery, sizeHints map[string]int) {
+	if q == nil {
+		return
+	}
+	if sizeHints == nil {
+		sizeHints = map[string]int{}
+	}
+	body := make([]datalog.Literal, len(q.JoinOrder))
+	for i, step := range q.JoinOrder {
+		body[i] = step.Literal
+	}
+	q.JoinOrder = orderJoins(body, sizeHints)
 }
 
 // collectGroupByVars returns the head variables that are not the aggregate result variable.

--- a/ql/plan/plan_test.go
+++ b/ql/plan/plan_test.go
@@ -1,5 +1,145 @@
 package plan_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
 
 func TestPlaceholder(t *testing.T) {}
+
+// TestPlanRetainsBody verifies that PlannedRule.Body is populated so that
+// RePlanStratum has the input it needs to recompute join orders. Issue #88.
+func TestPlanRetainsBody(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: atom("P", "x"),
+				Body: []datalog.Literal{posLit("A", "x"), posLit("B", "x")},
+			},
+		},
+	}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(ep.Strata) == 0 || len(ep.Strata[0].Rules) == 0 {
+		t.Fatal("no rules planned")
+	}
+	r := ep.Strata[0].Rules[0]
+	if len(r.Body) != 2 {
+		t.Fatalf("expected Body to have 2 literals, got %d", len(r.Body))
+	}
+	if r.Body[0].Atom.Predicate != "A" || r.Body[1].Atom.Predicate != "B" {
+		t.Errorf("expected Body to preserve source order [A,B], got [%s,%s]",
+			r.Body[0].Atom.Predicate, r.Body[1].Atom.Predicate)
+	}
+}
+
+// TestRePlanStratumSwapsJoinOrder is the anti-gaming test required by
+// issue #88. It does not just check that the hints map updates — it asserts
+// that the **plan changes** in the expected direction when an IDB hint is
+// refreshed from defaultSizeHint=1000 down to its real (small) cardinality.
+//
+// Setup: a rule P(x) :- A(x), B(x) where A is a base relation with 100
+// tuples and B is an IDB. With B unhinted, B scores as 1000 and A is
+// placed first. After we refresh hints with B=5, B should be placed first.
+func TestRePlanStratumSwapsJoinOrder(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: atom("P", "x"),
+				Body: []datalog.Literal{posLit("A", "x"), posLit("B", "x")},
+			},
+		},
+	}
+	// First plan: only A's size is known. B will fall through to default 1000.
+	hints := map[string]int{"A": 100}
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	r := ep.Strata[0].Rules[0]
+	if r.JoinOrder[0].Literal.Atom.Predicate != "A" {
+		t.Fatalf("baseline: expected A first (size 100 < default 1000 for B), got %s",
+			r.JoinOrder[0].Literal.Atom.Predicate)
+	}
+
+	// Refresh: B turns out to have 5 tuples. Re-plan should swap B to first.
+	hints["B"] = 5
+	plan.RePlanStratum(&ep.Strata[0], hints)
+
+	r = ep.Strata[0].Rules[0]
+	if r.JoinOrder[0].Literal.Atom.Predicate != "B" {
+		t.Errorf("after refresh: expected B first (size 5 < A=100), got %s",
+			r.JoinOrder[0].Literal.Atom.Predicate)
+	}
+	if r.JoinOrder[1].Literal.Atom.Predicate != "A" {
+		t.Errorf("after refresh: expected A second, got %s",
+			r.JoinOrder[1].Literal.Atom.Predicate)
+	}
+}
+
+// TestRePlanStratumNoOpWhenBodyMissing verifies legacy callers that did not
+// populate Body are not affected — RePlanStratum should be a no-op for such
+// rules rather than crash.
+func TestRePlanStratumNoOpWhenBodyMissing(t *testing.T) {
+	s := &plan.Stratum{
+		Rules: []plan.PlannedRule{
+			{
+				Head: atom("P", "x"),
+				// Body intentionally nil.
+				JoinOrder: []plan.JoinStep{
+					{Literal: posLit("A", "x")},
+				},
+			},
+		},
+	}
+	plan.RePlanStratum(s, map[string]int{"A": 1})
+	if len(s.Rules[0].JoinOrder) != 1 {
+		t.Errorf("expected JoinOrder unchanged for nil-Body rule, got %d steps",
+			len(s.Rules[0].JoinOrder))
+	}
+	if s.Rules[0].JoinOrder[0].Literal.Atom.Predicate != "A" {
+		t.Errorf("expected JoinOrder unchanged, got %s",
+			s.Rules[0].JoinOrder[0].Literal.Atom.Predicate)
+	}
+}
+
+// TestRePlanQuerySwapsJoinOrder mirrors the rule-level test for the final
+// query (which has no separate Body field — the literals live in the
+// JoinOrder itself and are reconstructed for re-planning).
+func TestRePlanQuerySwapsJoinOrder(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: atom("B", "x"),
+				Body: []datalog.Literal{posLit("Seed", "x")},
+			},
+		},
+		Query: &datalog.Query{
+			Select: []datalog.Term{datalog.Var{Name: "x"}},
+			Body:   []datalog.Literal{posLit("A", "x"), posLit("B", "x")},
+		},
+	}
+	hints := map[string]int{"A": 100, "Seed": 1}
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if ep.Query == nil {
+		t.Fatal("expected a planned query")
+	}
+	if ep.Query.JoinOrder[0].Literal.Atom.Predicate != "A" {
+		t.Fatalf("baseline: expected A first, got %s",
+			ep.Query.JoinOrder[0].Literal.Atom.Predicate)
+	}
+
+	hints["B"] = 5
+	plan.RePlanQuery(ep.Query, hints)
+	if ep.Query.JoinOrder[0].Literal.Atom.Predicate != "B" {
+		t.Errorf("after refresh: expected B first (size 5), got %s",
+			ep.Query.JoinOrder[0].Literal.Atom.Predicate)
+	}
+}


### PR DESCRIPTION
Closes #88.

## Problem

`buildSizeHints` populates the planner's relation→tuple-count map for **base** (EDB) relations only. Any IDB predicate appearing in a downstream rule was scored at `defaultSizeHint = 1000` even after its fixpoint had materialised the real count. This caused the Cartesian-heavy join orders documented in `SETSTATE_OOM_ANALYSIS.md` — a 7-tuple IDB seed scored as 1000 and lost the first slot to a 149-tuple EDB, blowing past the 5M binding cap.

## Approach — per-stratum re-planning

The smallest change that makes the refresh useful (option 1 from the issue):

- `PlannedRule` now retains `Body` so re-planning has the literal set to reorder.
- `plan.RePlanStratum` and `plan.RePlanQuery` recompute `JoinOrder` against an updated hints map.
- `eval.WithSizeHints(map)` is a new opt-in evaluator option. When set, after each stratum's fixpoint converges, the evaluator writes the materialised tuple counts of that stratum's head predicates back into the map and re-plans every subsequent stratum (and the final query). Strata that already executed are not re-planned.
- `cmd/tsq/main.go` wires the existing `sizeHints` map through.
- Refresh is opt-in — omitting `WithSizeHints` leaves behaviour unchanged.
- Hints only widen (`!exists || n > cur`) so a manually-supplied base count cannot be silently overwritten by a smaller IDB of the same name.

No magic-set interaction concerns — magic-rule predicates get hint entries the same way once they materialise.

## Tests

Plan-level (`ql/plan/plan_test.go`):
- `TestPlanRetainsBody` — `PlannedRule.Body` is populated.
- `TestRePlanStratumSwapsJoinOrder` — **anti-gaming**: asserts the plan swaps from `[A, B]` to `[B, A]` when B's hint is refreshed from default=1000 to 5 (A=100). Asserts the plan changes, not just that the map updates.
- `TestRePlanStratumNoOpWhenBodyMissing` — legacy callers with nil Body don't crash.
- `TestRePlanQuerySwapsJoinOrder` — same swap test for the final query.

Eval-level (`ql/eval/sizehints_refresh_test.go`):
- `TestSizeHintsRefreshUpdatesMap` — multi-stratum evaluation with a forced negative-edge stratum boundary. Asserts (a) the hints map gains the derived counts after eval, and (b) the downstream plan swaps to put the tiny IDB first.
- `TestSizeHintsRefreshNoOptionLeavesPlanUnchanged` — opt-in guarantee: without `WithSizeHints`, plans are untouched.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -p 1 -count=1 ./...` — all packages green (incl. `ql/eval`, `ql/plan`, top-level integration suite)