### PR TITLE
refactor(rules): migrate taint.go to NamedLiteral builder

### DIFF
--- a/extract/rules/taint.go
+++ b/extract/rules/taint.go
@@ -12,14 +12,24 @@ import (
 // TaintPath is deferred to Phase E — it requires arithmetic (step+1, step < 50)
 // which is not supported in standard Datalog. The current rules cover correctness:
 // TaintedSym, SanitizedEdge, TaintedField, and TaintAlert.
+//
+// Body literals for TaintSource, TaintSink, VarDecl, and ExprMayRef use
+// mustNamedLiteral so column ordering is validated against the schema registry
+// at startup rather than silently breaking on a schema column reorder.
 func TaintRules() []datalog.Rule {
 	return []datalog.Rule{
 		// Rule 1: Taint propagation — base case (identifier sources).
 		// TaintedSym(srcSym, kind) :- TaintSource(srcExpr, kind), ExprMayRef(srcExpr, srcSym).
 		rule("TaintedSym",
 			[]datalog.Term{v("srcSym"), v("kind")},
-			pos("TaintSource", v("srcExpr"), v("kind")),
-			pos("ExprMayRef", v("srcExpr"), v("srcSym")),
+			mustNamedLiteral("TaintSource", map[string]datalog.Term{
+				"srcExpr":    v("srcExpr"),
+				"sourceKind": v("kind"),
+			}),
+			mustNamedLiteral("ExprMayRef", map[string]datalog.Term{
+				"expr": v("srcExpr"),
+				"sym":  v("srcSym"),
+			}),
 		),
 
 		// Rule 1b: Taint propagation — VarDecl init is a taint source (handles
@@ -27,8 +37,14 @@ func TaintRules() []datalog.Rule {
 		// TaintedSym(sym, kind) :- VarDecl(_, sym, initExpr, _), TaintSource(initExpr, kind).
 		rule("TaintedSym",
 			[]datalog.Term{v("sym"), v("kind")},
-			pos("VarDecl", w(), v("sym"), v("initExpr"), w()),
-			pos("TaintSource", v("initExpr"), v("kind")),
+			mustNamedLiteral("VarDecl", map[string]datalog.Term{
+				"sym":      v("sym"),
+				"initExpr": v("initExpr"),
+			}),
+			mustNamedLiteral("TaintSource", map[string]datalog.Term{
+				"srcExpr":    v("initExpr"),
+				"sourceKind": v("kind"),
+			}),
 		),
 
 		// Rule 2: Taint propagation — transitive via FlowStar, blocked by sanitizers.
@@ -71,7 +87,9 @@ func TaintRules() []datalog.Rule {
 			pos("FlowStar", v("srcSym"), v("dstSym")),
 			pos("SymbolType", v("dstSym"), v("typeId")),
 			pos("NonTaintableType", v("typeId")),
-			pos("TaintSource", w(), v("kind")),
+			mustNamedLiteral("TaintSource", map[string]datalog.Term{
+				"sourceKind": v("kind"),
+			}),
 		),
 
 		// Rule 4: Field-sensitive taint — writing tainted value to a field.
@@ -80,7 +98,10 @@ func TaintRules() []datalog.Rule {
 		rule("TaintedField",
 			[]datalog.Term{v("baseSym"), v("fieldName"), v("kind")},
 			pos("FieldWrite", w(), v("baseSym"), v("fieldName"), v("rhsExpr")),
-			pos("ExprMayRef", v("rhsExpr"), v("rhsSym")),
+			mustNamedLiteral("ExprMayRef", map[string]datalog.Term{
+				"expr": v("rhsExpr"),
+				"sym":  v("rhsSym"),
+			}),
 			pos("TaintedSym", v("rhsSym"), v("kind")),
 		),
 
@@ -90,7 +111,10 @@ func TaintRules() []datalog.Rule {
 		rule("TaintedSym",
 			[]datalog.Term{v("readSym"), v("kind")},
 			pos("FieldRead", v("expr"), v("baseSym"), v("fieldName")),
-			pos("ExprMayRef", v("expr"), v("readSym")),
+			mustNamedLiteral("ExprMayRef", map[string]datalog.Term{
+				"expr": v("expr"),
+				"sym":  v("readSym"),
+			}),
 			pos("TaintedField", v("baseSym"), v("fieldName"), v("kind")),
 		),
 
@@ -101,11 +125,23 @@ func TaintRules() []datalog.Rule {
 		//     TaintSink(sinkExpr, sinkKind).
 		rule("TaintAlert",
 			[]datalog.Term{v("srcExpr"), v("sinkExpr"), v("srcKind"), v("sinkKind")},
-			pos("TaintSource", v("srcExpr"), v("srcKind")),
-			pos("ExprMayRef", v("srcExpr"), v("srcSym")),
+			mustNamedLiteral("TaintSource", map[string]datalog.Term{
+				"srcExpr":    v("srcExpr"),
+				"sourceKind": v("srcKind"),
+			}),
+			mustNamedLiteral("ExprMayRef", map[string]datalog.Term{
+				"expr": v("srcExpr"),
+				"sym":  v("srcSym"),
+			}),
 			pos("TaintedSym", v("sinkSym"), v("srcKind")),
-			pos("ExprMayRef", v("sinkExpr"), v("sinkSym")),
-			pos("TaintSink", v("sinkExpr"), v("sinkKind")),
+			mustNamedLiteral("ExprMayRef", map[string]datalog.Term{
+				"expr": v("sinkExpr"),
+				"sym":  v("sinkSym"),
+			}),
+			mustNamedLiteral("TaintSink", map[string]datalog.Term{
+				"sinkExpr": v("sinkExpr"),
+				"sinkKind": v("sinkKind"),
+			}),
 		),
 
 		// Rule 6b: Taint alert for VarDecl-init-based sources.
@@ -125,13 +161,22 @@ func TaintRules() []datalog.Rule {
 		// for security analysis (false positives > false negatives).
 		rule("TaintAlert",
 			[]datalog.Term{v("srcExpr"), v("sinkExpr"), v("srcKind"), v("sinkKind")},
-			pos("TaintSource", v("srcExpr"), v("srcKind")),
-			pos("VarDecl", w(), v("sym"), v("srcExpr"), w()),
+			mustNamedLiteral("TaintSource", map[string]datalog.Term{
+				"srcExpr":    v("srcExpr"),
+				"sourceKind": v("srcKind"),
+			}),
+			mustNamedLiteral("VarDecl", map[string]datalog.Term{
+				"sym":      v("sym"),
+				"initExpr": v("srcExpr"),
+			}),
 			pos("TaintedSym", v("sym"), v("srcKind")),
 			pos("TaintedSym", v("sinkSym"), v("srcKind")),
 			pos("SymInFunction", v("sinkSym"), v("fnId")),
 			pos("ExprInFunction", v("sinkExpr"), v("fnId")),
-			pos("TaintSink", v("sinkExpr"), v("sinkKind")),
+			mustNamedLiteral("TaintSink", map[string]datalog.Term{
+				"sinkExpr": v("sinkExpr"),
+				"sinkKind": v("sinkKind"),
+			}),
 		),
 	}
 }


### PR DESCRIPTION
## Summary

Migrates the literals in `extract/rules/taint.go` to the `NamedLiteral` / `mustNamedLiteral` API shipped in PR #77, mirroring the `localflow.go` style. Salvages the work from the closed PR #75 but uses the merged builder API rather than the parallel `posLit/negLit/cols` helpers from #75.

**Migrated literals:**
- `TaintSource` x5
- `TaintSink` x2
- `VarDecl` x2
- `ExprMayRef` x5

(Issue counts of `VarDecl` x1 and `ExprMayRef` x3 appear stale relative to current `taint.go`; migrated all occurrences for consistency.)

**Negation gap:** not needed. The only `neg()` call in `taint.go` is `SanitizedEdge`, which is outside the issue's migration scope. No `mustNamedNegLiteral` helper was added — the API stays as-is.

## Why

Same eng-review concern (P6) that motivated the `localflow.go` migration: with ~120 positional coupling points across the rule files, any column reorder in `extract/schema/relations.go` produces silent wrong query results. `mustNamedLiteral` validates column names against `schema.Lookup` at startup so drift surfaces immediately.

No behaviour change.

## Tests

- `go build ./...` clean
- `go test -p 1 -count=1 ./...` all green (full suite, including `extract/rules`, `ql/eval`, end-to-end taint integration tests)

No new tests added — the migration is structural and existing taint integration tests cover the preserved semantics, per issue #102 guidance.

Closes #102