### PR TITLE
test(integration): full TypeScript project shape end-to-end fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,22 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           cache: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install tsgo
+        run: |
+          npm install -g @typescript/native-preview
+          # @typescript/native-preview ships a `tsgo` binary; export TSGO_PATH
+          # so the integration test's strict CI gate can find it.
+          TSGO_BIN=$(command -v tsgo || true)
+          if [ -z "$TSGO_BIN" ]; then
+            # Fall back to resolving via npm prefix.
+            TSGO_BIN="$(npm prefix -g)/bin/tsgo"
+          fi
+          echo "Using tsgo at: $TSGO_BIN"
+          "$TSGO_BIN" --version
+          echo "TSGO_PATH=$TSGO_BIN" >> "$GITHUB_ENV"
       - name: Build
         run: go build ./...
       - name: Test

--- a/full_ts_project_integration_test.go
+++ b/full_ts_project_integration_test.go
@@ -1,0 +1,283 @@
+// Package integration_test — full TypeScript project shape regression guard.
+//
+// Existing testdata/projects/* fixtures are bare TS file directories: no
+// tsconfig.json, no package.json, no multi-directory structure. None of them
+// exercises the project shape tsq actually encounters in the wild — and
+// tsconfig handling is load-bearing for tsgo enrichment (PR #84, issue #91).
+// This file adds:
+//
+//   - A fully-configured fixture (tsconfig.json with strict + paths, package.json
+//     with realistic deps, src/{components,utils,types}/, tests/) under
+//     testdata/projects/full-ts-project/.
+//   - An end-to-end test that builds the tsq binary, runs `tsq extract` on the
+//     fixture, and runs three representative queries against the resulting DB:
+//     1. Function listing — smoke test.
+//     2. Cross-module imports — verifies imports were extracted across the
+//     multi-directory tree.
+//     3. Tsgo type enrichment — verifies the project's tsconfig was honored
+//     and tsgo populated ResolvedType. Skipped if tsgo is unavailable on
+//     the host (so CI on bare clones is not broken).
+//
+// The tsgo branch additionally documents a real CLI gotcha: relative --dir
+// paths cause every getSymbolAtPosition query to error out because the file
+// paths in the File relation are not absolutised before being passed to tsgo
+// via RegisterFiles. The test passes an absolute --dir to work around this;
+// the gotcha is recorded in the PR body so it can be filed as its own issue.
+package integration_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fullTSProjectDir returns the absolute path to the fixture. tsgo enrichment
+// requires absolute paths end-to-end (see file header).
+func fullTSProjectDir(t *testing.T) string {
+	t.Helper()
+	root := cliRepoRoot(t)
+	abs, err := filepath.Abs(filepath.Join(root, "testdata", "projects", "full-ts-project"))
+	if err != nil {
+		t.Fatalf("abs fixture path: %v", err)
+	}
+	return abs
+}
+
+// detectTsgoForTest mirrors typecheck.DetectTsgo's first two checks (TSGO_PATH
+// env var and `tsgo` in PATH). We deliberately do NOT trigger the npx fallback
+// here — npx --yes can take 10+s and fetch packages, which would slow every
+// test run on hosts without tsgo installed. The type-enrichment assertion is
+// allowed to skip on those hosts; the structural assertions still run.
+func detectTsgoForTest() string {
+	if p := os.Getenv("TSGO_PATH"); p != "" {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	if p, err := exec.LookPath("tsgo"); err == nil {
+		return p
+	}
+	return ""
+}
+
+// runExtractFull runs `tsq extract --dir <abs> --output <db>` and additionally
+// allows the caller to opt out of tsgo (--tsgo off) for the structural pass.
+// It captures stderr so we can assert on the tsgo enrichment summary line.
+func runExtractFull(t *testing.T, tsq, dir, dbFile string, withTsgo bool) string {
+	t.Helper()
+	args := []string{"extract", "--dir", dir, "--output", dbFile}
+	if !withTsgo {
+		args = append(args, "--tsgo", "off")
+	}
+	cmd := exec.Command(tsq, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("tsq extract failed: %v\nstderr: %s", err, stderr.String())
+	}
+	if _, err := os.Stat(dbFile); err != nil {
+		t.Fatalf("extract produced no output file %s: %v", dbFile, err)
+	}
+	return stderr.String()
+}
+
+// dataRows returns rows[1:] (everything past the header), filtering empty rows.
+// CSV output from `tsq query` always has a header, even when there are zero
+// data rows; callers want to assert on the data, not the header.
+func dataRows(rows [][]string) [][]string {
+	if len(rows) <= 1 {
+		return nil
+	}
+	out := make([][]string, 0, len(rows)-1)
+	for _, r := range rows[1:] {
+		if len(r) == 0 {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// hasRowWith reports whether any row contains the given substring in any column.
+// Lets the test pin specific facts (function names, module specifiers,
+// type displays) without coupling to column ordering.
+func hasRowWith(rows [][]string, needle string) bool {
+	for _, row := range rows {
+		for _, cell := range row {
+			if strings.Contains(cell, needle) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestCLI_FullTSProject_EndToEnd extracts the realistic-shape fixture and
+// exercises three representative queries. Sequential (no -parallel) by design
+// — the project guidance says 3GB host, no -race, sequential only.
+func TestCLI_FullTSProject_EndToEnd(t *testing.T) {
+	tsq := buildTSQBinary(t)
+	dir := fullTSProjectDir(t)
+	workDir := t.TempDir()
+
+	// Sanity: the fixture exists. If a future cleanup deletes it, fail loud.
+	if _, err := os.Stat(filepath.Join(dir, "tsconfig.json")); err != nil {
+		t.Fatalf("fixture missing tsconfig.json at %s: %v", dir, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "package.json")); err != nil {
+		t.Fatalf("fixture missing package.json at %s: %v", dir, err)
+	}
+
+	// --------------------------------------------------------------
+	// Pass 1: structural extraction with tsgo OFF.
+	// All structural queries (functions, imports) must work without tsgo.
+	// --------------------------------------------------------------
+	dbFile := filepath.Join(workDir, "full.db")
+	_ = runExtractFull(t, tsq, dir, dbFile, false /*tsgo*/)
+
+	// Query 1 — function listing. Smoke test.
+	q1 := writeQueryFile(t, workDir, "q_functions.ql",
+		"import tsq::functions\n\nfrom Function f\nselect f.getName() as \"name\"\n")
+	out1 := runCLIQuery(t, tsq, dbFile, "csv", q1)
+	rows1 := dataRows(parseCSV(t, out1))
+	if len(rows1) == 0 {
+		t.Fatalf("function-list query returned zero rows; output:\n%s", out1)
+	}
+	// Pin specific names from each src/ subdirectory so a regression in any
+	// directory is caught. These are exported names from the fixture.
+	for _, want := range []string{"UserList", "filterBy", "usersWithRole", "formatUserLabel", "greet"} {
+		if !hasRowWith(rows1, want) {
+			t.Errorf("function-list missing %q in results; got: %v", want, rows1)
+		}
+	}
+
+	// Query 2 — cross-module imports. Verifies the multi-directory import
+	// graph was extracted: components/ imports from utils/ and types/, and
+	// the tests/ directory imports from src/. If the walker only handles a
+	// single directory, this query collapses to one or two rows.
+	q2 := writeQueryFile(t, workDir, "q_imports.ql",
+		"import tsq::imports\n\nfrom ImportBinding ib\nselect ib.getModuleSpec() as \"module\", ib.getImportedName() as \"imported\"\n")
+	out2 := runCLIQuery(t, tsq, dbFile, "csv", q2)
+	rows2 := dataRows(parseCSV(t, out2))
+	if len(rows2) == 0 {
+		t.Fatalf("import query returned zero rows; output:\n%s", out2)
+	}
+	// Cross-directory edges (component → utils, component → types, tests → src):
+	wantImportPairs := []struct {
+		module, imported string
+	}{
+		{"../utils/format", "formatUserLabel"}, // components/UserList.tsx → utils/format.ts
+		{"../utils/filter", "usersWithRole"},   // components/UserList.tsx → utils/filter.ts
+		{"../types/user", "UserRole"},          // components/UserList.tsx → types/user.ts
+		{"./format", "pluck"},                  // utils/filter.ts → utils/format.ts (sibling)
+		{"../src/utils/format", "greet"},       // tests/format.test.ts → src/utils/format.ts
+		{"react", "useState"},                  // external dep
+	}
+	for _, want := range wantImportPairs {
+		found := false
+		for _, row := range rows2 {
+			if len(row) >= 2 && row[0] == want.module && row[1] == want.imported {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected import (%q, %q) not found; rows: %v", want.module, want.imported, rows2)
+		}
+	}
+
+	// --------------------------------------------------------------
+	// Pass 2: tsgo type enrichment. Skip if tsgo is unavailable.
+	//
+	// This is the regression guard for PR #84 / issue #91 against the
+	// realistic project shape: a deep src/ tree, an explicit tsconfig with
+	// strict + paths, multiple .ts and .tsx files.
+	// --------------------------------------------------------------
+	tsgoPath := detectTsgoForTest()
+	if tsgoPath == "" {
+		t.Log("tsgo not available (set TSGO_PATH or install `tsgo` in PATH); structural passes already validated, skipping type-info pass")
+		return
+	}
+	_ = tsgoPath
+
+	tsgoDB := filepath.Join(workDir, "full-tsgo.db")
+	stderr := runExtractFull(t, tsq, dir, tsgoDB, true /*tsgo*/)
+
+	// Tsgo must have used the project's tsconfig. The CLI logs a line of the
+	// form "tsgo: using project <path>" when --tsconfig is auto-discovered.
+	wantTSConfig := filepath.Join(dir, "tsconfig.json")
+	if !strings.Contains(stderr, "tsgo: using project "+wantTSConfig) {
+		t.Errorf("expected stderr to confirm tsgo used %s; got:\n%s", wantTSConfig, stderr)
+	}
+	// And it must have produced non-zero facts. Pre-PR #84, the wire format
+	// bug meant facts=0 even with the tsconfig honored. The post-fix
+	// expectation on this fixture is comfortably > 10.
+	if !strings.Contains(stderr, "tsgo type enrichment complete:") {
+		t.Errorf("expected enrichment summary line in stderr; got:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "facts=0 ") {
+		t.Errorf("tsgo produced zero facts — PR #84 regression or environment problem; stderr:\n%s", stderr)
+	}
+
+	// Query 3 — type-info-derived facts. The Type relation (ResolvedType
+	// under the hood) is populated ONLY by tsgo enrichment. If the tsconfig
+	// were ignored or the wire format regressed, this query returns zero
+	// rows even though Pass 1 passed.
+	q3 := writeQueryFile(t, workDir, "q_types.ql",
+		"import tsq::types\n\nfrom Type t\nselect t.getDisplayName() as \"name\"\n")
+	out3 := runCLIQuery(t, tsq, tsgoDB, "csv", q3)
+	rows3 := dataRows(parseCSV(t, out3))
+	if len(rows3) == 0 {
+		t.Fatalf("type query returned zero rows on tsgo-enriched DB; PR #84 regression?\nstderr from extract:\n%s\nquery output:\n%s", stderr, out3)
+	}
+	// Pin specific type displays. These are facts that can ONLY be derived
+	// by tsgo resolving the project: User comes from the type-only module,
+	// UserRole is a union, T is a generic parameter resolved across files.
+	// At least two of these must appear (we don't hard-pin all three because
+	// tsgo's exact display rendering can vary across upstream versions).
+	wantTypes := []string{"User", "UserRole", "string"}
+	hits := 0
+	for _, want := range wantTypes {
+		if hasRowWith(rows3, want) {
+			hits++
+		}
+	}
+	if hits < 2 {
+		t.Errorf("expected >=2 of %v in tsgo-derived types; rows: %v", wantTypes, rows3)
+	}
+}
+
+// TestCLI_FullTSProject_HasExpectedShape is a fast, tsgo-independent smoke
+// guard that the fixture itself does not regress. If someone deletes a key
+// file from the fixture, this test fails before the heavier extraction test
+// even runs.
+func TestCLI_FullTSProject_HasExpectedShape(t *testing.T) {
+	dir := fullTSProjectDir(t)
+	wantFiles := []string{
+		"tsconfig.json",
+		"package.json",
+		"src/index.ts",
+		"src/types/user.ts",
+		"src/utils/format.ts",
+		"src/utils/filter.ts",
+		"src/components/UserList.tsx",
+		"tests/format.test.ts",
+	}
+	for _, rel := range wantFiles {
+		full := filepath.Join(dir, rel)
+		info, err := os.Stat(full)
+		if err != nil {
+			t.Errorf("fixture missing %s: %v", rel, err)
+			continue
+		}
+		if info.IsDir() {
+			t.Errorf("fixture file %s is a directory", rel)
+		}
+		if info.Size() == 0 {
+			t.Errorf("fixture file %s is empty", rel)
+		}
+	}
+}

--- a/full_ts_project_integration_test.go
+++ b/full_ts_project_integration_test.go
@@ -36,6 +36,11 @@ import (
 
 // fullTSProjectDir returns the absolute path to the fixture. tsgo enrichment
 // requires absolute paths end-to-end (see file header).
+//
+// TODO(#110): remove the filepath.Abs workaround once tsq absolutises *dir in
+// cmdExtract. Today, passing a relative --dir produces relative entries in the
+// File relation, which tsgo's DocumentIdentifier resolution rejects with
+// "source file not found" for every position query.
 func fullTSProjectDir(t *testing.T) string {
 	t.Helper()
 	root := cliRepoRoot(t)
@@ -108,6 +113,21 @@ func hasRowWith(rows [][]string, needle string) bool {
 	for _, row := range rows {
 		for _, cell := range row {
 			if strings.Contains(cell, needle) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasRowWithExact reports whether any row contains a cell that exactly equals
+// needle. Used for type-pass assertions where substring matches would let
+// "User" pass on rows like "UserList", "UserListProps", "UserId" — defeating
+// the point of pinning the type to confirm tsgo resolved it.
+func hasRowWithExact(rows [][]string, needle string) bool {
+	for _, row := range rows {
+		for _, cell := range row {
+			if cell == needle {
 				return true
 			}
 		}
@@ -198,6 +218,14 @@ func TestCLI_FullTSProject_EndToEnd(t *testing.T) {
 	// --------------------------------------------------------------
 	tsgoPath := detectTsgoForTest()
 	if tsgoPath == "" {
+		// On CI the type-enrichment regression guard MUST run. Silently
+		// skipping (the local-dev convenience) would hide PR #84 regressions
+		// from the gate that's supposed to catch them. Until CI installs
+		// tsgo / sets TSGO_PATH, fail loud so the gap is visible rather than
+		// papered over.
+		if os.Getenv("CI") != "" {
+			t.Fatal("tsgo not available in CI: install tsgo or set TSGO_PATH so the type-enrichment regression guard (PR #84 / issue #91) actually runs; refusing to silently skip in CI")
+		}
 		t.Log("tsgo not available (set TSGO_PATH or install `tsgo` in PATH); structural passes already validated, skipping type-info pass")
 		return
 	}
@@ -233,20 +261,23 @@ func TestCLI_FullTSProject_EndToEnd(t *testing.T) {
 	if len(rows3) == 0 {
 		t.Fatalf("type query returned zero rows on tsgo-enriched DB; PR #84 regression?\nstderr from extract:\n%s\nquery output:\n%s", stderr, out3)
 	}
-	// Pin specific type displays. These are facts that can ONLY be derived
-	// by tsgo resolving the project: User comes from the type-only module,
-	// UserRole is a union, T is a generic parameter resolved across files.
-	// At least two of these must appear (we don't hard-pin all three because
-	// tsgo's exact display rendering can vary across upstream versions).
-	wantTypes := []string{"User", "UserRole", "string"}
-	hits := 0
-	for _, want := range wantTypes {
-		if hasRowWith(rows3, want) {
-			hits++
+	// Pin specific type displays. User and UserRole are project-defined types
+	// that can ONLY appear if tsgo actually resolved the fixture's tsconfig
+	// and walked the type-only modules — so they're both REQUIRED, with exact
+	// cell matches (substring would let "User" pass on "UserList",
+	// "UserListProps", "UserId" — none of which prove tsgo enrichment).
+	//
+	// `string` is a primitive sanity check: tsgo emits it for nearly every
+	// literal, so its presence alone proves nothing. We assert it separately
+	// as a sanity hit, never as a substitute for the project-defined pins.
+	requiredExact := []string{"User", "UserRole"}
+	for _, want := range requiredExact {
+		if !hasRowWithExact(rows3, want) {
+			t.Errorf("expected exact-cell type %q in tsgo-derived types (substring matches like UserList do not count); rows: %v", want, rows3)
 		}
 	}
-	if hits < 2 {
-		t.Errorf("expected >=2 of %v in tsgo-derived types; rows: %v", wantTypes, rows3)
+	if !hasRowWith(rows3, "string") {
+		t.Errorf("expected primitive sanity hit %q in tsgo-derived types; rows: %v", "string", rows3)
 	}
 }
 

--- a/testdata/projects/full-ts-project/.gitignore
+++ b/testdata/projects/full-ts-project/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+build/
+*.log
+.DS_Store

--- a/testdata/projects/full-ts-project/package.json
+++ b/testdata/projects/full-ts-project/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "full-ts-project-fixture",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Realistic-shape TypeScript project fixture for tsq integration tests",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@types/lodash": "^4.14.202",
+    "@types/react": "^18.2.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.4.0"
+  }
+}

--- a/testdata/projects/full-ts-project/src/components/UserList.tsx
+++ b/testdata/projects/full-ts-project/src/components/UserList.tsx
@@ -1,0 +1,38 @@
+// React-style component using a hook. Exercises: JSX, hook usage,
+// cross-module call (formatUserLabel from utils/format), generic type
+// parameter on useState, prop typing.
+
+import { useState } from "react";
+import type { User, UserRole } from "../types/user";
+import { formatUserLabel, greet } from "../utils/format";
+import { usersWithRole } from "../utils/filter";
+
+interface UserListProps {
+    users: User[];
+    initialRole?: UserRole;
+    title: string;
+}
+
+export function UserList({ users, initialRole = "viewer", title }: UserListProps) {
+    const [role, setRole] = useState<UserRole>(initialRole);
+    const visible = usersWithRole(users, role);
+    const heading = greet(title);
+
+    return (
+        <section className="user-list">
+            <h2>{heading}</h2>
+            <select value={role} onChange={(e) => setRole(e.target.value as UserRole)}>
+                <option value="admin">Admin</option>
+                <option value="editor">Editor</option>
+                <option value="viewer">Viewer</option>
+            </select>
+            <ul>
+                {visible.map((user) => (
+                    <li key={user.id}>{formatUserLabel(user)}</li>
+                ))}
+            </ul>
+        </section>
+    );
+}
+
+export default UserList;

--- a/testdata/projects/full-ts-project/src/index.ts
+++ b/testdata/projects/full-ts-project/src/index.ts
@@ -1,0 +1,6 @@
+// Barrel re-exports — entry point.
+
+export { UserList } from "./components/UserList";
+export { formatUserLabel, greet, ok, err, pluck } from "./utils/format";
+export { filterBy, usersWithRole, userIds } from "./utils/filter";
+export type { User, UserId, UserRole, Result, Predicate } from "./types/user";

--- a/testdata/projects/full-ts-project/src/types/user.ts
+++ b/testdata/projects/full-ts-project/src/types/user.ts
@@ -1,0 +1,19 @@
+// Type-only module — no runtime exports.
+// Exercises: type alias, generic, union, exported types referenced cross-module.
+
+export type UserId = string;
+
+export type UserRole = "admin" | "editor" | "viewer";
+
+export interface User {
+    id: UserId;
+    name: string;
+    email: string;
+    role: UserRole;
+}
+
+export type Result<T, E = Error> =
+    | { ok: true; value: T }
+    | { ok: false; error: E };
+
+export type Predicate<T> = (value: T) => boolean;

--- a/testdata/projects/full-ts-project/src/utils/filter.ts
+++ b/testdata/projects/full-ts-project/src/utils/filter.ts
@@ -1,0 +1,17 @@
+// Exercises: cross-module import (calls into format.ts), generic predicate type,
+// re-export pattern.
+
+import type { Predicate, User, UserRole } from "../types/user";
+import { pluck } from "./format";
+
+export function filterBy<T>(items: T[], predicate: Predicate<T>): T[] {
+    return items.filter(predicate);
+}
+
+export function usersWithRole(users: User[], role: UserRole): User[] {
+    return filterBy(users, (u) => u.role === role);
+}
+
+export function userIds(users: User[]): string[] {
+    return pluck(users, "id");
+}

--- a/testdata/projects/full-ts-project/src/utils/format.ts
+++ b/testdata/projects/full-ts-project/src/utils/format.ts
@@ -1,0 +1,26 @@
+// Exported util module — pure functions consumed by components.
+// Exercises: exported function, generic, default param, type-only import.
+
+import type { User, Result } from "../types/user";
+
+export function formatUserLabel(user: User): string {
+    return `${user.name} <${user.email}>`;
+}
+
+export function ok<T>(value: T): Result<T> {
+    return { ok: true, value };
+}
+
+export function err<T, E = Error>(error: E): Result<T, E> {
+    return { ok: false, error };
+}
+
+export function pluck<T, K extends keyof T>(items: T[], key: K): T[K][] {
+    return items.map((item) => item[key]);
+}
+
+export const DEFAULT_GREETING = "Hello";
+
+export function greet(name: string, greeting: string = DEFAULT_GREETING): string {
+    return `${greeting}, ${name}!`;
+}

--- a/testdata/projects/full-ts-project/tests/format.test.ts
+++ b/testdata/projects/full-ts-project/tests/format.test.ts
@@ -1,0 +1,29 @@
+// Vitest-style test file. Exercises: import from src under test path,
+// cross-module function call.
+
+import { describe, it, expect } from "vitest";
+import { greet, formatUserLabel, pluck } from "../src/utils/format";
+import type { User } from "../src/types/user";
+
+describe("format utils", () => {
+    it("greets with default", () => {
+        expect(greet("world")).toBe("Hello, world!");
+    });
+
+    it("greets with custom prefix", () => {
+        expect(greet("world", "Hi")).toBe("Hi, world!");
+    });
+
+    it("formats a user label", () => {
+        const u: User = { id: "u1", name: "Ada", email: "ada@example.com", role: "admin" };
+        expect(formatUserLabel(u)).toBe("Ada <ada@example.com>");
+    });
+
+    it("plucks a field", () => {
+        const users: User[] = [
+            { id: "u1", name: "Ada", email: "a@x", role: "admin" },
+            { id: "u2", name: "Bob", email: "b@x", role: "viewer" },
+        ];
+        expect(pluck(users, "name")).toEqual(["Ada", "Bob"]);
+    });
+});

--- a/testdata/projects/full-ts-project/tsconfig.json
+++ b/testdata/projects/full-ts-project/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@components/*": ["src/components/*"],
+      "@utils/*": ["src/utils/*"],
+      "@types/*": ["src/types/*"]
+    }
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist", "build"]
+}


### PR DESCRIPTION
## Gap

Every `testdata/projects/*` fixture today is a bare TS file directory — no `tsconfig.json`, no `package.json`, no multi-directory layout. Nothing in the test corpus exercises the project shape tsq actually meets in the wild.

That gap matters because tsconfig handling is load-bearing for tsgo enrichment:

- **PR #84** (`fix(typecheck): pass tsconfig.json location to tsgo backend`) made `cmdExtract` thread an auto-discovered tsconfig through to the enricher; without it the live tsgo binary returns zero facts.
- **Issue #91** tracks tsconfig location handling more broadly.

There is currently no end-to-end regression guard that the CLI honours a real project's `tsconfig.json` and that the resulting fact DB contains tsgo-derived type information.

## What this PR adds

### Fixture: `testdata/projects/full-ts-project/` (~5.6 KB, 9 files)

- `tsconfig.json` — strict, target ES2022, jsx `react-jsx`, baseUrl/paths, include/exclude
- `package.json` — `react`, `lodash` deps; `typescript`, `vitest`, `@types/*` devDeps
- `src/types/user.ts` — type-only module: type alias, union, generic `Result<T,E>`, `Predicate<T>`
- `src/utils/format.ts` — exported pure functions, generic `pluck<T,K extends keyof T>`, default-param fn
- `src/utils/filter.ts` — cross-module call into `format.ts`, generic predicate
- `src/components/UserList.tsx` — React component with `useState<UserRole>`, JSX, prop typing, calls into both util modules
- `src/index.ts` — barrel re-exports
- `tests/format.test.ts` — vitest-style file importing from `../src/...`
- `.gitignore` — `node_modules/`, `dist/`, `build/`

`node_modules` is intentionally not vendored. tsgo's bundled stdlib is enough to type-check this fixture without `npm install`.

### Test: `full_ts_project_integration_test.go`

Two tests, both sequential (no `-race`, no `-parallel`):

1. **`TestCLI_FullTSProject_HasExpectedShape`** — fast guard that the fixture files exist and are non-empty.
2. **`TestCLI_FullTSProject_EndToEnd`** — builds the `tsq` binary, runs `tsq extract --dir <abs> --output <db>`, then exercises three queries:
   - **Function listing** (smoke) — pins `UserList`, `filterBy`, `usersWithRole`, `formatUserLabel`, `greet`.
   - **Cross-module imports** — pins specific `(module, imported)` pairs spanning every cross-directory edge: `components/` → `utils/`, `components/` → `types/`, `utils/filter.ts` → `utils/format.ts`, `tests/` → `src/`, plus the external `react` import.
   - **Tsgo type enrichment** — asserts the stderr line `tsgo: using project <abs-tsconfig-path>`, asserts the enrichment summary does not say `facts=0`, and asserts the `Type` relation contains tsgo-derived display names (`User`, `UserRole`, `string`). The `Type` relation is populated only by tsgo enrichment, so a regression in PR #84's wire-format fix or in tsconfig auto-discovery breaks this query, not the structural ones.

The tsgo pass is gracefully skipped (with a `t.Log`, test still PASS) when neither `TSGO_PATH` nor `tsgo` in `PATH` is available, so CI on bare clones is not broken. It runs by default on dev hosts where tsgo is installed.

## Setup gotcha discovered while building this

Relative `--dir` paths break tsgo enrichment end-to-end. The `File` relation stores file paths verbatim from the walker; `enrichWithTsgo` passes those into `RegisterFiles`/`EnrichFile` without absolutising; tsgo's `DocumentIdentifier` resolution returns `"source file not found"` for every position query. With `--dir testdata/projects/full-ts-project` you get `facts=0 symbolQueries=24 (errors=24)`; with `--dir $(pwd)/testdata/projects/full-ts-project` you get `facts=22 symbolQueries=24 (errors=0)`.

The test sidesteps this by always passing an absolute `--dir`. The bug itself is unrelated to this PR's scope and should be filed/fixed separately — likely by absolutising `*dir` in `cmdExtract` before it reaches the walker.

## How to run locally

```
TSGO_PATH=/path/to/tsgo go test -p 1 -count=1 -run TestCLI_FullTSProject -v .
```

Without `TSGO_PATH`, the structural assertions still run; the type-info pass logs a skip note.