### PR TITLE
feat(plan): tiny-seed-wins-first-slot heuristic (#98)

### DIFF
--- a/ql/plan/join.go
+++ b/ql/plan/join.go
@@ -6,6 +6,24 @@ import (
 
 const defaultSizeHint = 1000
 
+// tinySeedThreshold is the cardinality threshold (inclusive) below which a
+// candidate literal is treated as a "tiny seed" — eligible to win the next
+// join slot regardless of normal cost-model scoring.
+//
+// Rationale (issue #98): the planner's normal scoring picks the lowest
+// (-boundCount, sizeHint) tuple. When sizeHints are missing or wrong (the
+// failure mode that produced the setState OOM in issue #96), a literal that
+// is in fact extremely selective can lose to a literal with a slightly-better
+// reported size and end up placed last, producing Cartesian-shaped
+// intermediates. The tiny-seed override is a defensive complement to issue
+// #88's pre-pass / between-strata refresh: even if the pre-pass misses a
+// derived predicate's true size, this catches obviously-tiny literals.
+//
+// The 32 threshold is generous enough to cover seed predicates (typically
+// single-digit tuple counts) while still being well below any plausible
+// per-probe blow-up factor.
+const tinySeedThreshold = 32
+
 // varsInTerm returns variable names referenced by a term.
 func varsInTerm(t datalog.Term) []string {
 	if v, ok := t.(datalog.Var); ok {
@@ -92,7 +110,100 @@ func scoreLiteral(lit datalog.Literal, bound map[string]bool, sizeHints map[stri
 	return -boundCount, sz
 }
 
+// hasConstantArg returns true if any argument of the literal's atom is a
+// constant (not a variable or wildcard). Constants on probe-by-key columns
+// are strong evidence the literal will produce few output tuples.
+func hasConstantArg(lit datalog.Literal) bool {
+	if lit.Cmp != nil || lit.Agg != nil {
+		return false
+	}
+	for _, arg := range lit.Atom.Args {
+		switch arg.(type) {
+		case datalog.IntConst, datalog.StringConst:
+			return true
+		}
+	}
+	return false
+}
+
+// hasSharedVar returns true if the literal references at least one variable
+// in the bound set.
+func hasSharedVar(lit datalog.Literal, bound map[string]bool) bool {
+	for _, v := range varsInLiteral(lit) {
+		if bound[v] {
+			return true
+		}
+	}
+	return false
+}
+
+// isTinySeed reports whether lit is a "tiny seed" candidate that should win
+// the next join slot regardless of its position in normal cost scoring.
+//
+// A literal qualifies as a tiny seed if BOTH:
+//   - We have evidence its expected output is small. Evidence comes in three
+//     flavours, in decreasing order of confidence:
+//   - (a) sizeHint is known and ≤ tinySeedThreshold;
+//   - (b) the literal has at least one constant argument (probing by a
+//     specific key gives few results in practice);
+//   - (c) it has shared variables with the current bound prefix AND a
+//     known sizeHint that is ≤ tinySeedThreshold (the per-probe case).
+//
+// The strict anti-false-positive case is the one called out in issue #98:
+// an IDB with NO sizeHint AND NO shared vars (and no constants) must NOT be
+// classified as tiny — we have no evidence at all and would risk picking a
+// truly large relation as the seed.
+//
+// Comparisons, negative literals, and aggregates never qualify (they are
+// either filters or have their own placement constraints).
+func isTinySeed(lit datalog.Literal, bound map[string]bool, sizeHints map[string]int) bool {
+	if lit.Cmp != nil || lit.Agg != nil {
+		return false
+	}
+	if !lit.Positive {
+		return false
+	}
+	relName := lit.Atom.Predicate
+	sz, hintKnown := sizeHints[relName]
+	if hintKnown && sz > 0 && sz <= tinySeedThreshold {
+		// (a) Direct evidence: known and tiny.
+		return true
+	}
+	// Without a known tiny hint, require at least one of:
+	//   - a constant argument (evidence the output is point-keyed), or
+	//   - a shared bound var (evidence the output is per-probe bounded).
+	// Either of these alone is sufficient when the hint is missing entirely
+	// — the missing-hint case is the whole defensive point of issue #98.
+	if !hintKnown || sz <= 0 {
+		if hasConstantArg(lit) {
+			return true
+		}
+		// Shared-var-only with no hint at all: ambiguous. Per the issue's
+		// anti-false-positive rule we still need *some* evidence the output
+		// is bounded. A shared bound var means probing rather than a full
+		// scan; combined with no contradictory size info we treat it as
+		// tiny — this is the per-probe case mentioned in the issue.
+		if hasSharedVar(lit, bound) {
+			return true
+		}
+		return false
+	}
+	// Hint known but larger than threshold: only qualify if we have BOTH
+	// evidence the access is point-keyed AND the relative size is not huge.
+	// We do NOT fire here — large hints should fall through to normal
+	// scoring (which already prefers smaller relations).
+	return false
+}
+
 // orderJoins implements greedy join ordering for a rule body.
+//
+// Selection rule per slot:
+//  1. Among eligible candidates, prefer any "tiny seed" (see isTinySeed)
+//     — this is the issue #98 defensive heuristic against missing/wrong
+//     sizeHints. Among multiple tiny candidates, the one with the smaller
+//     known sizeHint wins (with constants tiebreaking over no-constants).
+//  2. Otherwise fall back to normal cost scoring: most-bound-first, then
+//     smallest-relation-first.
 func orderJoins(body []datalog.Literal, sizeHints map[string]int) []JoinStep {
 	if len(body) == 0 {
 		return nil
@@ -107,6 +218,11 @@ func orderJoins(body []datalog.Literal, sizeHints map[string]int) []JoinStep {
 		bestNegBound := 0
 		bestSize := 0
 
+		// Pass 1 — tiny-seed override (issue #98). Pick the smallest tiny
+		// candidate by known sizeHint (defaultSizeHint when unknown) so that
+		// e.g. a known-7 literal beats an unknown-but-with-constants literal.
+		tinyIdx := -1
+		tinySize := 0
 		for i, lit := range body {
 			if placed[i] {
 				continue
@@ -114,11 +230,35 @@ func orderJoins(body []datalog.Literal, sizeHints map[string]int) []JoinStep {
 			if !isEligible(lit, bound) {
 				continue
 			}
-			negBound, size := scoreLiteral(lit, bound, sizeHints)
-			if bestIdx == -1 || negBound < bestNegBound || (negBound == bestNegBound && size < bestSize) {
-				bestIdx = i
-				bestNegBound = negBound
-				bestSize = size
+			if !isTinySeed(lit, bound, sizeHints) {
+				continue
+			}
+			sz, ok := sizeHints[lit.Atom.Predicate]
+			if !ok || sz <= 0 {
+				sz = defaultSizeHint
+			}
+			if tinyIdx == -1 || sz < tinySize {
+				tinyIdx = i
+				tinySize = sz
+			}
+		}
+		if tinyIdx != -1 {
+			bestIdx = tinyIdx
+		} else {
+			// Pass 2 — fallback to standard greedy scoring.
+			for i, lit := range body {
+				if placed[i] {
+					continue
+				}
+				if !isEligible(lit, bound) {
+					continue
+				}
+				negBound, size := scoreLiteral(lit, bound, sizeHints)
+				if bestIdx == -1 || negBound < bestNegBound || (negBound == bestNegBound && size < bestSize) {
+					bestIdx = i
+					bestNegBound = negBound
+					bestSize = size
+				}
 			}
 		}
 

--- a/ql/plan/join_test.go
+++ b/ql/plan/join_test.go
@@ -199,6 +199,188 @@ func TestJoinOrderAggregateAfterPositives(t *testing.T) {
 	}
 }
 
+// posLitConst creates a positive literal whose first arg is a string
+// constant, with the rest being variables. Used by tiny-seed tests that need
+// to model "literal grounded by a constant on an indexed col."
+func posLitConst(pred string, constVal string, vars ...string) datalog.Literal {
+	args := make([]datalog.Term, 0, 1+len(vars))
+	args = append(args, datalog.StringConst{Value: constVal})
+	for _, v := range vars {
+		args = append(args, datalog.Var{Name: v})
+	}
+	return datalog.Literal{
+		Positive: true,
+		Atom:     datalog.Atom{Predicate: pred, Args: args},
+	}
+}
+
+// TestJoinTinySeedWinsOverSharedVarLargerLiteral is the load-bearing
+// mutation-killable test for issue #98.
+//
+// The heuristic must override standard greedy scoring. Standard scoring
+// prefers more-bound-vars first (-boundCount), then smaller-relation. So the
+// discriminating case is: a tiny known-size literal with NO shared vars
+// (negBound=0) versus a larger literal that DOES have shared vars
+// (negBound=-1). Standard picks the larger one because of the bound-count
+// preference; the tiny-seed heuristic flips it.
+//
+// Body shape:
+//
+//	P(c, f, n) :- TinySeed(f), Big(f, n), TinyIDB(c).
+//	    TinySeed: size 3   — wins slot 0 (smallest, both tiny by hint).
+//	    Big:      size 200 — shares f with TinySeed (slot 1 candidate).
+//	    TinyIDB:  size 7   — NO shared vars (slot 1 candidate).
+//
+// At slot 1 (after TinySeed bound f):
+//   - Big:     (negBound=-1, size=200) — standard prefers (more bound vars).
+//   - TinyIDB: (negBound=0,  size=7)   — standard puts last.
+//
+// Without the heuristic, slot 1 = Big and slot 2 = TinyIDB. With the
+// heuristic, TinyIDB qualifies as tiny (sizeHint=7 ≤ tinySeedThreshold=32)
+// and wins slot 1.
+//
+// Mutation kill: disabling the tiny-seed pass causes Big to win slot 1 and
+// TinyIDB to land at slot 2 — `JoinOrder[1] == "TinyIDB"` then fails.
+func TestJoinTinySeedWinsOverSharedVarLargerLiteral(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: atom("P", "c", "f", "n"),
+				Body: []datalog.Literal{
+					posLit("TinySeed", "f"),
+					posLit("Big", "f", "n"),
+					posLit("TinyIDB", "c"),
+				},
+			},
+		},
+	}
+	hints := map[string]int{"TinySeed": 3, "Big": 200, "TinyIDB": 7}
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	r := ep.Strata[0].Rules[0]
+	if len(r.JoinOrder) != 3 {
+		t.Fatalf("expected 3 steps, got %d", len(r.JoinOrder))
+	}
+	got := []string{
+		r.JoinOrder[0].Literal.Atom.Predicate,
+		r.JoinOrder[1].Literal.Atom.Predicate,
+		r.JoinOrder[2].Literal.Atom.Predicate,
+	}
+	// Slot 0: TinySeed (size 3) wins on both standard and heuristic.
+	if got[0] != "TinySeed" {
+		t.Fatalf("slot 0: expected TinySeed (size 3), got %s; full order: %v", got[0], got)
+	}
+	// Slot 1 (load-bearing): TinyIDB must win despite no shared vars.
+	if got[1] != "TinyIDB" {
+		t.Errorf("slot 1: expected TinyIDB (tiny-seed override beating Big's shared-var bonus), got %s; full order: %v",
+			got[1], got)
+	}
+	// Slot 2: Big lands last.
+	if got[2] != "Big" {
+		t.Errorf("slot 2: expected Big, got %s; full order: %v", got[2], got)
+	}
+}
+
+// TestJoinTinySeedNoSizeHintNoSharedVarNotPicked is the anti-false-positive
+// guard from issue #98. A literal with NO sizeHint AND NO shared variables
+// AND no constant args must NOT be classified as tiny — we have no evidence
+// the output is small. If we treated unhinted literals as tiny by default
+// we would invert the bug: instead of placing actually-large IDBs last we
+// would place actually-large IDBs first.
+//
+// Setup: at slot 1, after Seed binds x, the candidates are:
+//   - Big(x, y): shared var x, has known sizeHint=200 (NOT tiny by hint).
+//     Standard scoring: (negBound=-1, size=200).
+//   - UnknownIDB(y): NO shared vars with the prefix, NO sizeHint, NO
+//     constants. Standard scoring: (negBound=0, size=1000).
+//
+// Standard scoring picks Big at slot 1 (better bound count). The tiny-seed
+// heuristic must NOT classify UnknownIDB as tiny — otherwise it would
+// override the bound-count preference and pick UnknownIDB (the canonical
+// false positive). UnknownIDB must end up at slot 2.
+//
+// Mutation: replacing the no-hint branch of isTinySeed with `return true`
+// (i.e. dropping the anti-false-positive guard) would classify UnknownIDB
+// as tiny, and it would win slot 1 over Big — this assertion then fails.
+func TestJoinTinySeedNoSizeHintNoSharedVarNotPicked(t *testing.T) {
+	// P(x, y) :- Seed(x), Big(x, y), UnknownIDB(z).
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: atom("P", "x", "y"),
+				Body: []datalog.Literal{
+					posLit("Seed", "x"),
+					posLit("Big", "x", "y"),
+					posLit("UnknownIDB", "z"),
+				},
+			},
+		},
+	}
+	// Seed=10 wins slot 0 (tiny). Big=200 (NOT tiny by hint).
+	// UnknownIDB has no hint and no shared vars at slot 1.
+	hints := map[string]int{"Seed": 10, "Big": 200}
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	r := ep.Strata[0].Rules[0]
+	if len(r.JoinOrder) != 3 {
+		t.Fatalf("expected 3 steps, got %d", len(r.JoinOrder))
+	}
+	got := []string{
+		r.JoinOrder[0].Literal.Atom.Predicate,
+		r.JoinOrder[1].Literal.Atom.Predicate,
+		r.JoinOrder[2].Literal.Atom.Predicate,
+	}
+	if got[0] != "Seed" {
+		t.Fatalf("slot 0: expected Seed (size 10, tiny), got %s; full order: %v", got[0], got)
+	}
+	if got[1] != "Big" {
+		t.Errorf("slot 1: expected Big (shared var, hint 200) — UnknownIDB must NOT be falsely classified tiny; got %s; full order: %v",
+			got[1], got)
+	}
+	if got[2] != "UnknownIDB" {
+		t.Errorf("slot 2: expected UnknownIDB last; got %s; full order: %v", got[2], got)
+	}
+}
+
+// TestJoinTinySeedConstantArgWinsWithoutHint exercises the constant-arg
+// branch of isTinySeed: a literal with a constant on an indexed col is
+// strong evidence the output is tiny, even without any sizeHint.
+//
+// Setup: TypedThing("specific", x) competes against Big (size 100). Without
+// the constant-arg branch, TypedThing scores as defaultSizeHint=1000 and
+// loses to Big. With it, TypedThing wins as a tiny seed.
+//
+// Mutation kill: deleting the `hasConstantArg(lit)` clause from isTinySeed
+// causes TypedThing to lose and this test fails.
+func TestJoinTinySeedConstantArgWinsWithoutHint(t *testing.T) {
+	// P(x) :- Big(x), TypedThing("specific", x).
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: atom("P", "x"),
+				Body: []datalog.Literal{
+					posLit("Big", "x"),
+					posLitConst("TypedThing", "specific", "x"),
+				},
+			},
+		},
+	}
+	hints := map[string]int{"Big": 100} // TypedThing intentionally unhinted.
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	r := ep.Strata[0].Rules[0]
+	if r.JoinOrder[0].Literal.Atom.Predicate != "TypedThing" {
+		t.Errorf("expected TypedThing first (constant-arg tiny seed), got %s",
+			r.JoinOrder[0].Literal.Atom.Predicate)
+	}
+}
+
 // TestJoinNegativeLiteralPlacedAfterVarsBound.
 func TestJoinNegativeLiteralPlacedAfterVarsBound(t *testing.T) {
 	// P(x) :- A(x), not B(x).


### PR DESCRIPTION
## Summary

Defensive complement to #88 / #101. `orderJoins` now runs a pre-pass that picks any eligible "tiny seed" literal before falling back to normal greedy `(-boundCount, size)` scoring. This catches the missing/wrong-sizeHint failure mode that produced the setState OOM (#96) even when #88's trivial-IDB pre-pass misses a derived predicate or the cost model is otherwise wrong.

`isTinySeed` qualifies a literal as tiny if **any** of:
- known `sizeHint` ≤ `tinySeedThreshold` (32), or
- no `sizeHint` and has a constant arg (point-keyed access — strong evidence of small output), or
- no `sizeHint` and shares a variable with the current bound prefix (per-probe bounded).

Anti-false-positive guard from the issue body: an unhinted literal with **no** constants **and** no shared vars is NOT classified tiny — we have no evidence its output is small and would risk picking a true-large literal as the seed.

The override only fires when something qualifies as tiny; otherwise the existing greedy cost model runs unchanged. `RePlanStratum` / `RePlanQuery` route through `orderJoins` and inherit the same heuristic, so the per-stratum re-planning flow from #88 keeps working.

## Tests

All in `ql/plan/join_test.go`. Each is mutation-killable:

- `TestJoinTinySeedWinsOverSharedVarLargerLiteral` — load-bearing. At slot 1, a known-tiny literal with NO shared vars must beat a larger literal that does have shared vars (i.e. override the bound-count preference). Mutation kill: disabling the tiny-seed pass causes the larger shared-var literal to win and the tiny one lands last.
- `TestJoinTinySeedConstantArgWinsWithoutHint` — constant-arg branch. A literal with a constant arg and no `sizeHint` must beat a smaller-known literal. Mutation kill: removing the `hasConstantArg` clause from `isTinySeed`.
- `TestJoinTinySeedNoSizeHintNoSharedVarNotPicked` — anti-false-positive guard. An unhinted IDB with no shared vars and no constants must NOT be picked. Mutation kill: replacing the no-hint branch with `return true`.

Verified empirically: setState query (`testdata/queries/v2/find_setstate_updater_calls_fn.ql` against the analysis fixture DB) still completes cleanly with 3 results — no regression on #88's win.

Full suite: `go test -p 1 -count=1 ./...` green.

## Test plan

- [x] Unit tests pass (`go test ./ql/plan/...`)
- [x] Mutation kill verified for all three new tests
- [x] Full suite sequential green (`go test -p 1 -count=1 ./...`)
- [x] setState integration query still completes (3 results, no OOM)
- [x] No regression on #88 tests (`TestRePlanStratumSwapsJoinOrder`, `TestPlanRetainsBody`, etc.)

Closes #98