### PR TITLE
fix: absolutise extract --dir so tsgo enrichment works with relative paths

### DIFF
--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -141,6 +141,19 @@ func cmdExtract(ctx context.Context, args []string, stdout, stderr io.Writer) in
 		return 1
 	}
 
+	// Absolutise --dir at the CLI boundary (issue #110). The walker stores
+	// file paths verbatim into the File relation; if --dir is relative, every
+	// downstream consumer that needs an absolute path (notably tsgo enrichment,
+	// whose DocumentIdentifier rejects relative paths with "source file not
+	// found") sees relative entries and breaks. Resolving once here keeps the
+	// File relation consistent regardless of how the user invoked the CLI.
+	absDir, err := filepath.Abs(*dir)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: resolve --dir %q: %v\n", *dir, err)
+		return 1
+	}
+	*dir = absDir
+
 	fmt.Fprintf(stderr, "extracting from %s (requires CGO_ENABLED=1 for tree-sitter)...\n", *dir)
 
 	database := db.NewDB()

--- a/extract_relative_dir_integration_test.go
+++ b/extract_relative_dir_integration_test.go
@@ -1,0 +1,94 @@
+// Package integration_test — regression guard for issue #110.
+//
+// `tsq extract --dir <relative>` used to break tsgo type enrichment because
+// the walker stored relative file paths into the File relation and tsgo's
+// DocumentIdentifier rejects relative paths ("source file not found" for
+// every position query). Fixed by absolutising *dir at the CLI boundary in
+// cmdExtract.
+//
+// This test runs `tsq extract` with cwd set to the repo root and --dir set
+// to the *relative* fixture path. Without the fix, the tsgo enrichment
+// summary line reports facts=0 and the Type query returns zero rows. With
+// the fix, both pass.
+package integration_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCLI_ExtractRelativeDir_TsgoEnrichment is the issue #110 regression
+// guard. It is structurally similar to the absolute-path full-project test
+// but invokes the CLI with cmd.Dir = <repo root> and --dir = <relative>,
+// which is the exact failure mode reported in the issue.
+func TestCLI_ExtractRelativeDir_TsgoEnrichment(t *testing.T) {
+	tsgoPath := detectTsgoForTest()
+	if tsgoPath == "" {
+		// The whole point of this test is to verify tsgo enrichment works
+		// with a relative --dir. Without tsgo we cannot observe the bug,
+		// so skip rather than provide false confidence. CI must set
+		// TSGO_PATH (same contract as TestCLI_FullTSProject_EndToEnd).
+		if os.Getenv("CI") != "" {
+			t.Fatal("tsgo not available in CI: install tsgo or set TSGO_PATH so the issue #110 regression guard runs")
+		}
+		t.Skip("tsgo not available; cannot exercise the relative-dir tsgo path")
+	}
+
+	tsq := buildTSQBinary(t)
+	repoRoot := cliRepoRoot(t)
+	relDir := filepath.Join("testdata", "projects", "full-ts-project")
+
+	// Sanity: the relative path resolves to the fixture from the repo root.
+	if _, err := os.Stat(filepath.Join(repoRoot, relDir, "tsconfig.json")); err != nil {
+		t.Fatalf("fixture missing at %s/%s: %v", repoRoot, relDir, err)
+	}
+
+	workDir := t.TempDir()
+	dbFile := filepath.Join(workDir, "rel.db")
+
+	cmd := exec.Command(tsq, "extract", "--dir", relDir, "--output", dbFile)
+	cmd.Dir = repoRoot // <-- this is what makes --dir relative meaningful
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("tsq extract --dir %s (cwd=%s) failed: %v\nstderr: %s",
+			relDir, repoRoot, err, stderr.String())
+	}
+	if _, err := os.Stat(dbFile); err != nil {
+		t.Fatalf("extract produced no output file: %v", err)
+	}
+
+	stderrStr := stderr.String()
+
+	// Pre-fix failure mode: the enrichment summary line reports facts=0
+	// because every getSymbolAtPosition call errored with "source file not
+	// found". Post-fix: facts > 0.
+	if !strings.Contains(stderrStr, "tsgo type enrichment complete:") {
+		t.Fatalf("expected enrichment summary in stderr; got:\n%s", stderrStr)
+	}
+	if strings.Contains(stderrStr, "facts=0 ") {
+		t.Fatalf("issue #110: tsgo produced zero facts when --dir was relative (%s); stderr:\n%s",
+			relDir, stderrStr)
+	}
+
+	// Cross-check via the Type query. ResolvedType is populated only by
+	// tsgo enrichment, so a non-empty result confirms the relative --dir
+	// path actually flowed through to tsgo correctly. We pin "User" exactly
+	// (project-defined type from the fixture) so a stray primitive emission
+	// like "string" can't carry the assertion.
+	q := writeQueryFile(t, workDir, "q_types.ql",
+		"import tsq::types\n\nfrom Type t\nselect t.getDisplayName() as \"name\"\n")
+	out := runCLIQuery(t, tsq, dbFile, "csv", q)
+	rows := dataRows(parseCSV(t, out))
+	if len(rows) == 0 {
+		t.Fatalf("Type query returned zero rows on relative-dir DB; issue #110 not fixed.\nstderr:\n%s\nquery output:\n%s",
+			stderrStr, out)
+	}
+	if !hasRowWithExact(rows, "User") {
+		t.Errorf("issue #110: expected exact-cell type %q in tsgo-derived types; rows: %v", "User", rows)
+	}
+}

--- a/full_ts_project_integration_test.go
+++ b/full_ts_project_integration_test.go
@@ -18,11 +18,14 @@
 //     and tsgo populated ResolvedType. Skipped if tsgo is unavailable on
 //     the host (so CI on bare clones is not broken).
 //
-// The tsgo branch additionally documents a real CLI gotcha: relative --dir
-// paths cause every getSymbolAtPosition query to error out because the file
-// paths in the File relation are not absolutised before being passed to tsgo
-// via RegisterFiles. The test passes an absolute --dir to work around this;
-// the gotcha is recorded in the PR body so it can be filed as its own issue.
+// Historical note: the tsgo branch documented a CLI gotcha (issue #110) where
+// relative --dir paths broke every getSymbolAtPosition query because file
+// paths in the File relation were not absolutised before being handed to tsgo
+// via RegisterFiles. The fix lives in cmdExtract (absolutise *dir at the CLI
+// boundary), and the dedicated regression guard is
+// TestCLI_ExtractRelativeDir_TsgoEnrichment in
+// extract_relative_dir_integration_test.go. This test now uses the fixture
+// path as-is without a workaround.
 package integration_test
 
 import (
@@ -34,21 +37,15 @@ import (
 	"testing"
 )
 
-// fullTSProjectDir returns the absolute path to the fixture. tsgo enrichment
-// requires absolute paths end-to-end (see file header).
-//
-// TODO(#110): remove the filepath.Abs workaround once tsq absolutises *dir in
-// cmdExtract. Today, passing a relative --dir produces relative entries in the
-// File relation, which tsgo's DocumentIdentifier resolution rejects with
-// "source file not found" for every position query.
+// fullTSProjectDir returns the path to the fixture, joined off the repo root.
+// cliRepoRoot is already absolute (resolved from runtime.Caller), so this is
+// absolute by construction — no filepath.Abs needed. Issue #110 (CLI now
+// absolutises --dir) means this test would still pass if the path were
+// relative, but keeping it absolute matches the rest of the integration suite.
 func fullTSProjectDir(t *testing.T) string {
 	t.Helper()
 	root := cliRepoRoot(t)
-	abs, err := filepath.Abs(filepath.Join(root, "testdata", "projects", "full-ts-project"))
-	if err != nil {
-		t.Fatalf("abs fixture path: %v", err)
-	}
-	return abs
+	return filepath.Join(root, "testdata", "projects", "full-ts-project")
 }
 
 // detectTsgoForTest mirrors typecheck.DetectTsgo's first two checks (TSGO_PATH


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

Closes #110.

## Root cause

`cmd/tsq/main.go::cmdExtract` passed `*dir` to the walker as-is. The walker stores file paths verbatim into the `File` relation, so a relative `--dir` produced relative entries. `enrichWithTsgo` then handed those relative paths to `enricher.RegisterFiles` / `EnrichFile`. tsgo's `DocumentIdentifier` resolution rejects relative paths with `"source file not found"` for every position query — observed as `facts=0 symbolQueries=24 (errors=24)` on the full-ts-project fixture.

`resolveTSConfig` already absolutises `--tsconfig`. `--dir` did not get the same treatment.

## Fix

Resolve `*dir` via `filepath.Abs` at the CLI boundary in `cmdExtract`, immediately after `fs.Parse`. This is the cleanest layer to fix it: every downstream consumer of the `File` relation (not just tsgo) gets the benefit, the `File` relation stays internally consistent regardless of how the user invoked the CLI, and the change is one absolute call in one place.

Considered fixing inside `enrichWithTsgo` instead (absolutising the paths read out of the `File` relation) — rejected because it leaves the relation full of relative paths and pushes the same fix-up onto every future consumer.

## Tests

New regression guard: `TestCLI_ExtractRelativeDir_TsgoEnrichment` in `extract_relative_dir_integration_test.go`. Runs `tsq extract` with `cmd.Dir = <repo root>` and `--dir = testdata/projects/full-ts-project` (relative). Asserts:

- enrichment summary line appears
- stderr does NOT contain `facts=0`
- the `Type` query returns rows including an exact-cell `User` (project-defined type, only present if tsgo actually resolved the fixture's tsconfig)

### Mutation kill

Stashed the fix, ran the new test → `FAIL` with the exact pre-fix signature:

```
tsgo type enrichment complete: facts=0 symbolQueries=24 (errors=24) typeQueries=0 (errors=0)
warning: tsgo answered 24 symbol queries but produced zero type facts
```

Restored the fix, re-ran the test → `PASS`. The test exercises the bug, not a tautology.

## Cleanup

Dropped the `filepath.Abs` workaround and `TODO(#110)` in `full_ts_project_integration_test.go::fullTSProjectDir`. `cliRepoRoot` already returns an absolute path, so a plain `filepath.Join` is sufficient. Updated the file header comment to point at the new regression test instead of describing the gotcha as unfixed.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test -p 1 -count=1 ./...` all packages pass (with `TSGO_PATH` set so the new test runs in full)

Adversarial review pending — do not merge yet.