### PR TITLE
fix(plan): hinted-tiny seed strictly beats unhinted constant-arg (#109)

### DIFF
--- a/ql/plan/join.go
+++ b/ql/plan/join.go
@@ -195,6 +195,74 @@ func isTinySeed(lit datalog.Literal, bound map[string]bool, sizeHints map[string
 	return false
 }
 
+// pickTinySeed implements the tiny-seed override (issues #98, #109).
+//
+// Among unplaced eligible literals that qualify as tiny seeds (per
+// isTinySeed), it returns the index of the preferred candidate, or -1 if
+// there is no qualifying candidate.
+//
+// Selection rule:
+//  1. A hinted candidate (sizeHints[pred] known and > 0) strictly beats
+//     an unhinted candidate, regardless of size. This is the issue #109
+//     fix: an unhinted EDB with a discriminative constant arg (which
+//     qualifies as tiny via the constant-arg branch of isTinySeed) could
+//     in reality be 8M rows. We have weaker evidence about its true size
+//     than for a relation with a recorded sizeHint, so we must not let
+//     the unhinted candidate beat a hinted-tiny one. On main this is
+//     masked by the accident that defaultSizeHint (1000) happens to be
+//     larger than every hint that passes the tinySeedThreshold gate; that
+//     accidental masking is precisely what would silently regress under a
+//     refactor that changed defaultUnhintedSize.
+//  2. Among same-hinted-status candidates, the smaller effective size
+//     wins. Unhinted candidates use defaultUnhintedSize for tiebreak.
+//
+// defaultUnhintedSize is parameterised so the regression test for #109
+// can drive it directly and demonstrate that the hinted-preference rule
+// is encoded explicitly rather than emerging from coincidence.
+func pickTinySeed(
+	body []datalog.Literal,
+	placed []bool,
+	bound map[string]bool,
+	sizeHints map[string]int,
+	defaultUnhintedSize int,
+) int {
+	tinyIdx := -1
+	tinySize := 0
+	tinyHinted := false
+	for i, lit := range body {
+		if placed[i] {
+			continue
+		}
+		if !isEligible(lit, bound) {
+			continue
+		}
+		if !isTinySeed(lit, bound, sizeHints) {
+			continue
+		}
+		sz, ok := sizeHints[lit.Atom.Predicate]
+		hinted := ok && sz > 0
+		if !hinted {
+			sz = defaultUnhintedSize
+		}
+		better := false
+		switch {
+		case tinyIdx == -1:
+			better = true
+		case hinted && !tinyHinted:
+			// Hinted strictly beats unhinted regardless of size (#109).
+			better = true
+		case hinted == tinyHinted && sz < tinySize:
+			better = true
+		}
+		if better {
+			tinyIdx = i
+			tinySize = sz
+			tinyHinted = hinted
+		}
+	}
+	return tinyIdx
+}
+
 // orderJoins implements greedy join ordering for a rule body.
 //
 // Selection rule per slot:
@@ -218,30 +286,8 @@ func orderJoins(body []datalog.Literal, sizeHints map[string]int) []JoinStep {
 		bestNegBound := 0
 		bestSize := 0
 
-		// Pass 1 — tiny-seed override (issue #98). Pick the smallest tiny
-		// candidate by known sizeHint (defaultSizeHint when unknown) so that
-		// e.g. a known-7 literal beats an unknown-but-with-constants literal.
-		tinyIdx := -1
-		tinySize := 0
-		for i, lit := range body {
-			if placed[i] {
-				continue
-			}
-			if !isEligible(lit, bound) {
-				continue
-			}
-			if !isTinySeed(lit, bound, sizeHints) {
-				continue
-			}
-			sz, ok := sizeHints[lit.Atom.Predicate]
-			if !ok || sz <= 0 {
-				sz = defaultSizeHint
-			}
-			if tinyIdx == -1 || sz < tinySize {
-				tinyIdx = i
-				tinySize = sz
-			}
-		}
+		// Pass 1 — tiny-seed override (issue #98 + #109). See pickTinySeed.
+		tinyIdx := pickTinySeed(body, placed, bound, sizeHints, defaultSizeHint)
 		if tinyIdx != -1 {
 			bestIdx = tinyIdx
 		} else {

--- a/ql/plan/join_internal_test.go
+++ b/ql/plan/join_internal_test.go
@@ -1,0 +1,96 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// White-box regression for issue #109. Drives pickTinySeed directly with a
+// small defaultUnhintedSize so the unhinted constant-arg candidate would
+// win on size alone — the only thing that prevents regression is the
+// explicit hinted-preference rule. On main (before the fix) this test
+// fails because the size-based tiebreak alone picks Big.
+//
+// Construction:
+//   - Big("k", x):  unhinted, qualifies as tiny via constant-arg branch.
+//   - Tiny("k", x): hint=10 (≤ tinySeedThreshold), qualifies via hint.
+//
+// With defaultUnhintedSize=1, Big's effective size is 1 and Tiny's is
+// 10. Without the hinted-preference rule, Big wins (1 < 10). With the
+// fix, Tiny wins because hinted strictly beats unhinted.
+func TestPickTinySeedHintedBeatsUnhintedWhenUnhintedWouldWinOnSize(t *testing.T) {
+	body := []datalog.Literal{
+		bigConstLit("Big"),
+		bigConstLit("Tiny"),
+	}
+	hints := map[string]int{"Tiny": 10}
+	placed := []bool{false, false}
+	bound := map[string]bool{}
+
+	idx := pickTinySeed(body, placed, bound, hints, 1)
+	if idx == -1 {
+		t.Fatal("expected a tiny-seed pick, got -1")
+	}
+	got := body[idx].Atom.Predicate
+	if got != "Tiny" {
+		t.Errorf("expected Tiny (hinted) to beat Big (unhinted) even when "+
+			"defaultUnhintedSize (1) makes Big's effective size smaller than "+
+			"Tiny's hint (10); got %s", got)
+	}
+}
+
+// Mirror test: when neither candidate is hinted, the size-based tiebreak
+// still applies. Guards against an over-eager fix that would regress the
+// unhinted-vs-unhinted ordering.
+func TestPickTinySeedUnhintedTieBreakBySize(t *testing.T) {
+	body := []datalog.Literal{
+		bigConstLit("A"),
+		bigConstLit("B"),
+	}
+	placed := []bool{false, false}
+	bound := map[string]bool{}
+
+	// Neither hinted. Both qualify via constant-arg. Effective size =
+	// defaultUnhintedSize for both, so first eligible (stable index) wins.
+	idx := pickTinySeed(body, placed, bound, nil, 1000)
+	if idx != 0 {
+		t.Errorf("expected index 0 (A) on stable tie among unhinted, got %d", idx)
+	}
+}
+
+// TestPickTinySeedAmongHintedSmallerWins: when both candidates are
+// hinted, smaller hint wins.
+func TestPickTinySeedAmongHintedSmallerWins(t *testing.T) {
+	body := []datalog.Literal{
+		bigConstLit("Bigger"),
+		bigConstLit("Smaller"),
+	}
+	hints := map[string]int{"Bigger": 20, "Smaller": 5}
+	placed := []bool{false, false}
+	bound := map[string]bool{}
+
+	idx := pickTinySeed(body, placed, bound, hints, 1000)
+	if idx == -1 {
+		t.Fatal("expected a tiny-seed pick, got -1")
+	}
+	if body[idx].Atom.Predicate != "Smaller" {
+		t.Errorf("expected Smaller (hint=5) over Bigger (hint=20), got %s",
+			body[idx].Atom.Predicate)
+	}
+}
+
+// bigConstLit builds a positive literal pred("k", x) — has a constant
+// arg so it qualifies for the tiny-seed constant-arg branch.
+func bigConstLit(pred string) datalog.Literal {
+	return datalog.Literal{
+		Positive: true,
+		Atom: datalog.Atom{
+			Predicate: pred,
+			Args: []datalog.Term{
+				datalog.StringConst{Value: "k"},
+				datalog.Var{Name: "x"},
+			},
+		},
+	}
+}

--- a/ql/plan/join_test.go
+++ b/ql/plan/join_test.go
@@ -381,6 +381,62 @@ func TestJoinTinySeedConstantArgWinsWithoutHint(t *testing.T) {
 	}
 }
 
+// TestJoinHintedTinyBeatsUnhintedConstantArg is the regression for issue
+// #109: when both a hinted-tiny relation and an unhinted-but-constant-arg
+// relation qualify as "tiny seed" candidates for the same slot, the one
+// backed by an explicit size hint must win.
+//
+// Setup matches the issue body exactly:
+//
+//	P(x) :- Big("k", x), Tiny(x).
+//	    Big:  no sizeHint, has a constant arg ("k"). Could in reality be
+//	          an 8M-row EDB with a discriminative constant.
+//	    Tiny: sizeHint=5 — genuinely tiny.
+//
+// Both qualify as tiny seeds (Big via constant-arg branch, Tiny via known
+// hint ≤ threshold). Tiny must win slot 0; Big must land at slot 1.
+//
+// On main this passes only by accident: the tiebreak compares
+// `sz < tinySize` and substitutes defaultSizeHint=1000 for unhinted, so
+// hinted=5 < 1000 wins by coincidence. A future refactor changing that
+// fallback (or an unhinted relation that really is huge) would regress.
+// The fix: prefer hinted candidates explicitly. This test pins that
+// preference even when the unhinted candidate's effective size would be
+// smaller.
+func TestJoinHintedTinyBeatsUnhintedConstantArg(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: atom("P", "x"),
+				Body: []datalog.Literal{
+					posLitConst("Big", "k", "x"),
+					posLit("Tiny", "x"),
+				},
+			},
+		},
+	}
+	hints := map[string]int{"Tiny": 5} // Big intentionally unhinted.
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	r := ep.Strata[0].Rules[0]
+	if len(r.JoinOrder) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(r.JoinOrder))
+	}
+	got := []string{
+		r.JoinOrder[0].Literal.Atom.Predicate,
+		r.JoinOrder[1].Literal.Atom.Predicate,
+	}
+	if got[0] != "Tiny" {
+		t.Errorf("slot 0: expected Tiny (hinted=5) to beat Big (unhinted, constant arg); got %s; full order: %v",
+			got[0], got)
+	}
+	if got[1] != "Big" {
+		t.Errorf("slot 1: expected Big to land last; got %s; full order: %v", got[1], got)
+	}
+}
+
 // TestJoinNegativeLiteralPlacedAfterVarsBound.
 func TestJoinNegativeLiteralPlacedAfterVarsBound(t *testing.T) {
 	// P(x) :- A(x), not B(x).


### PR DESCRIPTION
Closes #109.

## Problem
`isTinySeed` (`ql/plan/join.go`) promotes any literal with a constant arg, even when the relation is unhinted. The `orderJoins` tiebreak uses `defaultSizeHint=1000` for unhinted candidates, so a hinted-tiny relation only beats an unhinted-but-constant-arg one by coincidence — every hint that passes `tinySeedThreshold` happens to be < 1000. A real 8M-row EDB with a discriminative constant could regress this silently if the fallback ever changed.

## Fix
Extract `pickTinySeed` and encode the rule explicitly:
1. **Hinted strictly beats unhinted**, regardless of effective size.
2. Among same hinted-status candidates, smaller size wins.

`defaultUnhintedSize` is parameterised so the white-box test can drive it directly.

## Tests
- **End-to-end** (`join_test.go`): `Tiny(hint=5)` beats `Big("k", x)` unhinted; Big lands last.
- **White-box** (`join_internal_test.go`): with `defaultUnhintedSize=1`, Big's effective size (1) < Tiny's hint (5), yet Tiny still wins — proving the hinted-preference is explicit, not coincidental. Plus stability tests for unhinted-vs-unhinted ties and hinted-vs-hinted ordering.

Tests fail on main without the fix (the white-box one is the load-bearing one — end-to-end passes by accident on main).