### PR TITLE
fix: surface magic-set augmented-program planning failures (#112)

### DIFF
--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -423,6 +423,7 @@ func cmdQuery(ctx context.Context, args []string, stdout, stderr io.Writer) int 
 	maxIterations := fs.Int("max-iterations", eval.DefaultMaxIterations, "max semi-naive fixpoint iterations per stratum before erroring (0 = unlimited; see issue #79)")
 	allowPartial := fs.Bool("allow-partial", false, "if --max-iterations is hit, log a warning and return partial results instead of erroring (legacy behaviour)")
 	magicSets := fs.Bool("magic-sets", false, "enable the magic-set query rewrite (default: disabled, opt-in for one release). Magic sets prune irrelevant tuples on selective queries against recursive predicates (e.g. taint with a constant source), often 10-1000x speedup when bindings are inferable. Default-off until we have benchmark evidence that the transform fires on real workloads without regression (issue #87).")
+	magicSetsStrict := fs.Bool("magic-sets-strict", false, "fail (rather than silently falling back to plain Plan) if the magic-set augmented program cannot be planned. Use in CI to surface transform regressions; ignored when --magic-sets is off. See issue #112.")
 	// Deprecated alias: --no-magic-sets used to gate the default-on behaviour.
 	// Kept as a no-op flag so existing scripts don't break; it has no effect now
 	// that magic sets are opt-in. Will be removed once a release has shipped.
@@ -452,7 +453,7 @@ func cmdQuery(ctx context.Context, args []string, stdout, stderr io.Writer) int 
 	}
 
 	// Read and compile the query.
-	bopts := buildOptions{useMagicSets: *magicSets}
+	bopts := buildOptions{useMagicSets: *magicSets, magicSetsStrict: *magicSetsStrict, warnOut: stderr}
 	if *verbose {
 		bopts.verboseOut = stderr
 	}
@@ -573,8 +574,10 @@ func cmdCheck(args []string, stdout, stderr io.Writer) int {
 // Zero value disables magic sets (preserving the prior plan.Plan behaviour)
 // and emits no verbose logging.
 type buildOptions struct {
-	useMagicSets bool
-	verboseOut   io.Writer // if non-nil, magic-set-fired diagnostics are written here
+	useMagicSets    bool
+	magicSetsStrict bool      // when true, surfaces magic-set planning errors instead of silently falling back (issue #112)
+	verboseOut      io.Writer // if non-nil, magic-set-fired diagnostics (verbose) are written here
+	warnOut         io.Writer // if non-nil, magic-set-fallback warnings (always-on) are written here
 }
 
 func buildProgram(src, file string, importLoader func(string) (*ast.Module, error), sizeHints map[string]int) (*plan.ExecutionPlan, *ast.Module, []resolve.Warning, []error) {
@@ -632,10 +635,19 @@ func buildProgramWithProg(src, file string, importLoader func(string) (*ast.Modu
 	var planErrors []error
 	if opts.useMagicSets {
 		var inf plan.QueryBindingInference
-		execPlan, inf, planErrors = plan.WithMagicSetAuto(prog, sizeHints)
-		if opts.verboseOut != nil && len(inf.Bindings) > 0 {
+		execPlan, inf, planErrors = plan.WithMagicSetAutoOpts(prog, sizeHints, plan.MagicSetOptions{Strict: opts.magicSetsStrict})
+		switch {
+		case inf.Fallback:
+			// Always surface a fallback warning to warnOut (not gated on
+			// --verbose). Silent fallback was the bug in issue #112; the
+			// observability fix is unconditional. The strict path returns
+			// an error instead and never reaches this branch.
+			if opts.warnOut != nil {
+				fmt.Fprintf(opts.warnOut, "warning: magic-set transform produced an unplannable program; fell back to plain Plan (reason: %v)\n", inf.FallbackReason)
+			}
+		case opts.verboseOut != nil && len(inf.Bindings) > 0:
 			fmt.Fprintf(opts.verboseOut, "magic-set: transform applied; bindings=%v seed_rules=%d\n", inf.Bindings, len(inf.SeedRules))
-		} else if opts.verboseOut != nil {
+		case opts.verboseOut != nil:
 			fmt.Fprintln(opts.verboseOut, "magic-set: no inferable query bindings; using plain plan")
 		}
 	} else {

--- a/ql/plan/magicset_infer.go
+++ b/ql/plan/magicset_infer.go
@@ -23,6 +23,8 @@
 package plan
 
 import (
+	"fmt"
+
 	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
 )
 
@@ -34,6 +36,28 @@ type QueryBindingInference struct {
 	// SeedRules are zero- or N-body rules that derive magic_<pred> facts at
 	// evaluation time using the query body's own context.
 	SeedRules []datalog.Rule
+	// Fallback is true if WithMagicSetAuto inferred bindings but the
+	// augmented (magic-rewritten + seeded) program failed to plan, causing
+	// a silent fallback to plain Plan(prog). Distinguishes "no bindings to
+	// infer" (Fallback=false, Bindings=nil) from "bindings inferred but the
+	// transform produced an unplannable program" (Fallback=true,
+	// Bindings=nil). See issue #112.
+	Fallback bool
+	// FallbackReason carries the first planning error returned by the
+	// augmented program when Fallback is true. nil otherwise.
+	FallbackReason error
+}
+
+// MagicSetOptions controls WithMagicSetAutoOpts behaviour.
+//
+// Strict, when true, suppresses the silent fallback: if the augmented
+// program fails to plan, the planning errors are returned to the caller
+// rather than being swallowed in favour of plain Plan(prog). Use this in
+// tests and CI to detect transform regressions that would otherwise be
+// invisible (issue #112). Default (zero value) preserves the historical
+// silent-fallback behaviour for production use.
+type MagicSetOptions struct {
+	Strict bool
 }
 
 // InferQueryBindings analyses prog.Query and returns the binding map and the
@@ -222,7 +246,26 @@ func IDBPredicates(prog *datalog.Program) map[string]bool {
 // Returns the plan, the inference (so callers can log what fired), and any
 // planning errors. If no bindings are inferable, falls back to plain Plan and
 // returns an inference with empty Bindings.
+//
+// This is the non-strict, backwards-compatible entry point: planning errors
+// from the augmented program are silently swallowed in favour of plain Plan.
+// See WithMagicSetAutoOpts for strict-mode usage that surfaces those errors
+// (issue #112).
 func WithMagicSetAuto(prog *datalog.Program, sizeHints map[string]int) (*ExecutionPlan, QueryBindingInference, []error) {
+	return WithMagicSetAutoOpts(prog, sizeHints, MagicSetOptions{})
+}
+
+// WithMagicSetAutoOpts is the configurable form of WithMagicSetAuto.
+//
+// When opts.Strict is false (default), behaviour is identical to
+// WithMagicSetAuto: any planning error on the augmented program triggers a
+// silent fallback to plain Plan, with QueryBindingInference.Fallback=true
+// and .FallbackReason populated so callers can observe the regression.
+//
+// When opts.Strict is true, planning errors from the augmented program are
+// returned to the caller rather than triggering fallback. Use this in tests
+// and CI to detect transform-soundness regressions (issue #112).
+func WithMagicSetAutoOpts(prog *datalog.Program, sizeHints map[string]int, opts MagicSetOptions) (*ExecutionPlan, QueryBindingInference, []error) {
 	idb := IDBPredicates(prog)
 	inf := InferQueryBindings(prog, idb)
 	if len(inf.Bindings) == 0 {
@@ -247,8 +290,13 @@ func WithMagicSetAuto(prog *datalog.Program, sizeHints map[string]int) (*Executi
 			continue
 		}
 		if len(sr.Head.Args) != len(want) {
+			arityErr := fmt.Errorf("magic-set arity mismatch: seed-rule head %s/%d but binding declares %d positions",
+				sr.Head.Predicate, len(sr.Head.Args), len(want))
+			if opts.Strict {
+				return nil, QueryBindingInference{}, []error{arityErr}
+			}
 			ep, errs := Plan(prog, sizeHints)
-			return ep, QueryBindingInference{}, errs
+			return ep, QueryBindingInference{Fallback: true, FallbackReason: arityErr}, errs
 		}
 	}
 
@@ -272,9 +320,15 @@ func WithMagicSetAuto(prog *datalog.Program, sizeHints map[string]int) (*Executi
 	// than surfacing the regression to the caller. The transform is opt-in
 	// (--magic-sets); silent fallback to a known-good plan is the right
 	// default until transform soundness is fully proven on real workloads.
+	//
+	// Strict mode (issue #112) surfaces these errors instead, so CI / tests
+	// can detect transform regressions that would otherwise be invisible.
 	if len(errs) > 0 {
+		if opts.Strict {
+			return nil, QueryBindingInference{}, errs
+		}
 		ep2, errs2 := Plan(prog, sizeHints)
-		return ep2, QueryBindingInference{}, errs2
+		return ep2, QueryBindingInference{Fallback: true, FallbackReason: errs[0]}, errs2
 	}
 	return ep, inf, errs
 }

--- a/ql/plan/magicset_infer_test.go
+++ b/ql/plan/magicset_infer_test.go
@@ -366,4 +366,164 @@ func TestWithMagicSetAuto_AppliesTransformWhenInferable(t *testing.T) {
 	if !hasMagic {
 		t.Fatalf("expected magic_* rule in plan after WithMagicSetAuto with inferable bindings")
 	}
+	// Issue #112: happy path must report Fallback=false / FallbackReason=nil.
+	if inf.Fallback {
+		t.Fatalf("expected Fallback=false on happy path, got true (reason=%v)", inf.FallbackReason)
+	}
+	if inf.FallbackReason != nil {
+		t.Fatalf("expected nil FallbackReason on happy path, got %v", inf.FallbackReason)
+	}
+}
+
+// TestWithMagicSetAuto_FallbackSignalsObservably (issue #112) asserts that
+// the silent-fallback path on an unsafe-head augmented program populates
+// Fallback / FallbackReason so callers can distinguish "no bindings to
+// infer" (Fallback=false, Bindings=nil) from "transform fired and broke"
+// (Fallback=true, Bindings=nil).
+func TestWithMagicSetAuto_FallbackSignalsObservably(t *testing.T) {
+	// Reuse the unsafe-head construction from
+	// TestWithMagicSetAuto_UnsafeHeadFallback.
+	rules := []datalog.Rule{
+		{
+			Head: datalog.Atom{Predicate: "P", Args: []datalog.Term{datalog.Var{Name: "x"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "Q", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "y"}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "R", Args: []datalog.Term{datalog.Var{Name: "y"}}}},
+			},
+		},
+		{
+			Head: datalog.Atom{Predicate: "R", Args: []datalog.Term{datalog.Var{Name: "z"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "Q", Args: []datalog.Term{datalog.Var{Name: "_"}, datalog.Var{Name: "z"}}}},
+			},
+		},
+		{
+			Head: datalog.Atom{Predicate: "Q", Args: []datalog.Term{datalog.Var{Name: "a"}, datalog.Var{Name: "b"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "Base", Args: []datalog.Term{datalog.Var{Name: "a"}, datalog.Var{Name: "b"}}}},
+			},
+		},
+	}
+	prog := &datalog.Program{
+		Rules: rules,
+		Query: &datalog.Query{
+			Select: []datalog.Term{datalog.Var{Name: "x"}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "P", Args: []datalog.Term{datalog.IntConst{Value: 1}}}},
+			},
+		},
+	}
+
+	ep, inf, errs := WithMagicSetAuto(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("expected silent fallback (no errors), got %v", errs)
+	}
+	if ep == nil {
+		t.Fatalf("expected non-nil ExecutionPlan from fallback path")
+	}
+	if !inf.Fallback {
+		t.Fatalf("expected Fallback=true on unsafe-head fallback (caller can't otherwise distinguish from no-bindings-inferred)")
+	}
+	if inf.FallbackReason == nil {
+		t.Fatalf("expected non-nil FallbackReason on fallback")
+	}
+	if !strings.Contains(inf.FallbackReason.Error(), "unsafe rule") {
+		t.Fatalf("expected FallbackReason to mention the unsafe-rule cause, got %q", inf.FallbackReason.Error())
+	}
+}
+
+// TestWithMagicSetAuto_NoBindingsIsNotFallback (issue #112) asserts that
+// the "no inferable bindings" path leaves Fallback=false. Only an actual
+// transform-then-fail is a fallback.
+func TestWithMagicSetAuto_NoBindingsIsNotFallback(t *testing.T) {
+	// Body has no constants, equalities-to-constants, or constant-bearing
+	// base literals — no bindings inferable.
+	prog := progPathClosure([]datalog.Literal{
+		{Positive: true, Atom: datalog.Atom{Predicate: "Path", Args: []datalog.Term{datalog.Var{Name: "a"}, datalog.Var{Name: "b"}}}},
+	}, "a", "b")
+	_, inf, errs := WithMagicSetAuto(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+	if inf.Fallback {
+		t.Fatalf("expected Fallback=false when no bindings are inferable, got true")
+	}
+	if inf.FallbackReason != nil {
+		t.Fatalf("expected nil FallbackReason on no-bindings path, got %v", inf.FallbackReason)
+	}
+}
+
+// TestWithMagicSetAutoOpts_StrictSurfacesPlanError (issue #112) asserts
+// that strict mode returns the underlying planning error rather than
+// silently falling back to plain Plan.
+func TestWithMagicSetAutoOpts_StrictSurfacesPlanError(t *testing.T) {
+	rules := []datalog.Rule{
+		{
+			Head: datalog.Atom{Predicate: "P", Args: []datalog.Term{datalog.Var{Name: "x"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "Q", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "y"}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "R", Args: []datalog.Term{datalog.Var{Name: "y"}}}},
+			},
+		},
+		{
+			Head: datalog.Atom{Predicate: "R", Args: []datalog.Term{datalog.Var{Name: "z"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "Q", Args: []datalog.Term{datalog.Var{Name: "_"}, datalog.Var{Name: "z"}}}},
+			},
+		},
+		{
+			Head: datalog.Atom{Predicate: "Q", Args: []datalog.Term{datalog.Var{Name: "a"}, datalog.Var{Name: "b"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "Base", Args: []datalog.Term{datalog.Var{Name: "a"}, datalog.Var{Name: "b"}}}},
+			},
+		},
+	}
+	prog := &datalog.Program{
+		Rules: rules,
+		Query: &datalog.Query{
+			Select: []datalog.Term{datalog.Var{Name: "x"}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "P", Args: []datalog.Term{datalog.IntConst{Value: 1}}}},
+			},
+		},
+	}
+
+	ep, _, errs := WithMagicSetAutoOpts(prog, nil, MagicSetOptions{Strict: true})
+	if len(errs) == 0 {
+		t.Fatalf("expected strict mode to surface planning errors from the augmented program, got none")
+	}
+	if ep != nil {
+		t.Fatalf("expected nil ExecutionPlan in strict failure; got non-nil")
+	}
+	sawUnsafeHead := false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "unsafe rule") {
+			sawUnsafeHead = true
+			break
+		}
+	}
+	if !sawUnsafeHead {
+		t.Fatalf("expected strict-mode error to surface unsafe-rule cause, got: %v", errs)
+	}
+}
+
+// TestWithMagicSetAutoOpts_StrictHappyPathUnchanged ensures strict mode is
+// transparent on programs whose augmented form plans cleanly.
+func TestWithMagicSetAutoOpts_StrictHappyPathUnchanged(t *testing.T) {
+	prog := progPathClosure([]datalog.Literal{
+		{Positive: true, Atom: datalog.Atom{Predicate: "Path", Args: []datalog.Term{datalog.IntConst{Value: 1}, datalog.Var{Name: "b"}}}},
+	}, "b")
+	ep, inf, errs := WithMagicSetAutoOpts(prog, nil, MagicSetOptions{Strict: true})
+	if len(errs) != 0 {
+		t.Fatalf("strict mode must be transparent on plannable inputs; got errors: %v", errs)
+	}
+	if ep == nil {
+		t.Fatalf("expected non-nil ExecutionPlan")
+	}
+	if inf.Fallback {
+		t.Fatalf("expected Fallback=false on happy path under strict mode")
+	}
+	if len(inf.Bindings) == 0 {
+		t.Fatalf("expected bindings to be inferred under strict mode happy path")
+	}
 }


### PR DESCRIPTION
Closes #112.

## Problem

`WithMagicSetAuto` (`ql/plan/magicset_infer.go:267-279`) silently swallowed any planning error from the magic-set-augmented program and fell back to plain `Plan(prog)`, returning `QueryBindingInference{}`. That was indistinguishable from the "no bindings inferable" path, so:

- transform regressions were invisible (no log, no error, no signal in the return type),
- callers and tests had no way to assert the transform actually fired,
- the bug was coupled to the `baseBoundVars` over-binding issue (lines 106-112) which lets aggressive bindings get accepted then quietly fall back. Zero observability.

## Fix

- `QueryBindingInference` gains `Fallback bool` + `FallbackReason error`. Distinguishes silent-fallback (`Fallback=true`, `Bindings=nil`) from no-bindings (`Fallback=false`, `Bindings=nil`).
- New `MagicSetOptions{Strict bool}` + `WithMagicSetAutoOpts(prog, hints, opts)`. Strict mode surfaces the augmented program's planning errors instead of falling back. `WithMagicSetAuto` is preserved as a thin wrapper over `WithMagicSetAutoOpts(MagicSetOptions{})` for backwards compat — every existing call site keeps non-strict semantics.
- CLI: new `--magic-sets-strict` flag (`cmd/tsq query`). Only meaningful with `--magic-sets`. Always emits an unconditional warning to stderr on fallback (the observability fix shouldn't be gated on `--verbose`).
- Tests:
  - happy path asserts `Fallback=false` / `FallbackReason=nil`,
  - no-bindings path asserts `Fallback=false` (only an actual transform-then-fail counts as fallback),
  - silent-fallback path asserts `Fallback=true` + `FallbackReason` mentions the underlying cause,
  - strict-mode path asserts the underlying planning error is returned (no swallowing).

Reuses the existing unsafe-head construction from `TestWithMagicSetAuto_UnsafeHeadFallback` as the synthetic invalid augmented program.

## Out of scope

- The coupled `baseBoundVars` over-binding bug (lines 106-112) — explicitly out of scope per the audit; should be a separate ticket.
- Wiring strict-mode into CI as a separate test target — non-trivial without large blast radius (would need an env-var-gated integration pass over real queries). Deferred to a follow-up issue.

## Test plan

- [x] `go test ./... -count=1` (all 17 packages green; `-race` skipped, host is 3 GB)
- [x] `go build ./...`
- [x] Pre-commit hooks (gofmt, golangci-lint --fix) clean
- [ ] CI green on PR