### PR TITLE
fix(eval): thread binding cap into trivial-IDB pre-pass (#130)

### DIFF
--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -714,7 +714,10 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string, maxBindingsPe
 	if err != nil {
 		return nil, fmt.Errorf("load base relations: %w", err)
 	}
-	updates := eval.EstimateNonRecursiveIDBSizes(prog, baseRels, sizeHints)
+	// Issue #130: the pre-pass must honour the user-supplied binding cap;
+	// otherwise an explody trivial-IDB can OOM the host before the main
+	// evaluator ever runs (mastodon corpus, setStateUpdaterCallsFn).
+	updates := eval.EstimateNonRecursiveIDBSizes(prog, baseRels, sizeHints, maxBindingsPerRule)
 	if len(updates) > 0 {
 		// Re-plan every stratum and the final query with the refreshed hints
 		// before evaluation begins. Without this the original execPlan

--- a/issue88_setstate_integration_test.go
+++ b/issue88_setstate_integration_test.go
@@ -84,6 +84,14 @@ func TestIssue88_SetStateQueryDoesNotOOM(t *testing.T) {
 		t.Fatalf("plan: %v", planErrs)
 	}
 
+	// Aggressive binding cap: real fixture intermediate cardinality with the
+	// fix in place is < 1k. Pre-fix this rule blew the default 5M cap; we
+	// pick 100k as the regression threshold — comfortably above the real
+	// number, comfortably below "Cartesian disaster". Also threaded into the
+	// pre-pass below so issue #130 (uncapped pre-pass eating RAM before the
+	// main eval ever runs) is covered by the same guard.
+	const tightCap = 100_000
+
 	// Pre-pass + re-plan (the issue #88 fix). If a future change removes
 	// these two calls from cmd/tsq/main.go, the assertion below catches
 	// the regression directly: the rule will OOM at step 2.
@@ -91,7 +99,7 @@ func TestIssue88_SetStateQueryDoesNotOOM(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load base relations: %v", err)
 	}
-	updates := eval.EstimateNonRecursiveIDBSizes(prog, baseRels, hints)
+	updates := eval.EstimateNonRecursiveIDBSizes(prog, baseRels, hints, tightCap)
 	if updates["isUseStateSetterCall"] == 0 {
 		t.Fatalf("pre-pass failed to size isUseStateSetterCall (the seed predicate); updates=%v", updates)
 	}
@@ -107,12 +115,6 @@ func TestIssue88_SetStateQueryDoesNotOOM(t *testing.T) {
 	// will Cartesian-blow regardless of whether the test happens to fit
 	// under the binding cap on this small fixture.
 	assertSeedFirst(t, execPlan, "setStateUpdaterCallsFn", "isUseStateSetterCall")
-
-	// Aggressive binding cap: real fixture intermediate cardinality with the
-	// fix in place is < 1k. Pre-fix this rule blew the default 5M cap; we
-	// pick 100k as the regression threshold — comfortably above the real
-	// number, comfortably below "Cartesian disaster".
-	const tightCap = 100_000
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/ql/eval/estimate.go
+++ b/ql/eval/estimate.go
@@ -38,9 +38,17 @@ import (
 // are silently absorbed — the pre-pass is best-effort. If a "trivial" rule
 // itself OOMs we'd rather degrade to the default hint than fail compilation.
 //
+// maxBindingsPerRule is the per-rule binding cap applied to each trivial IDB
+// evaluation. Without it the pre-pass can fully materialise an N×M join just
+// to count head facts and OOM (issue #130 — mastodon corpus blew 30 GB RSS
+// inside this function on setStateUpdaterCallsFn). Pass 0 to disable the cap
+// (legacy behaviour, not recommended on real corpora). When the cap fires the
+// failed/break branch below treats the IDB as "could not estimate" and the
+// default hint applies — exactly the right semantics for a best-effort pass.
+//
 // Returns the slice of (name, computed-size) updates actually applied, for
 // observability/testing.
-func EstimateNonRecursiveIDBSizes(prog *datalog.Program, baseRels map[string]*Relation, sizeHints map[string]int) map[string]int {
+func EstimateNonRecursiveIDBSizes(prog *datalog.Program, baseRels map[string]*Relation, sizeHints map[string]int, maxBindingsPerRule int) map[string]int {
 	if sizeHints == nil {
 		sizeHints = map[string]int{}
 	}
@@ -69,7 +77,14 @@ func EstimateNonRecursiveIDBSizes(prog *datalog.Program, baseRels map[string]*Re
 		failed := false
 		for _, rule := range t.Rules {
 			planned := plan.SingleRule(rule, sizeHints)
-			tuples, err := Rule(context.Background(), planned, keyed, 0) // no binding cap during pre-pass
+			// Apply the user-supplied binding cap so a pathological body
+			// (cross-product before a selective join) cannot eat all RAM
+			// here. On cap-exceeded the err branch below treats the IDB as
+			// unestimatable and falls through to the default hint. Issue
+			// #130: passing 0 here meant pre-pass evaluation was unbounded
+			// and OOMed on real corpora before the cap could ever fire on
+			// the main eval pass.
+			tuples, err := Rule(context.Background(), planned, keyed, maxBindingsPerRule)
 			if err != nil {
 				// Best-effort: skip this IDB entirely on any error so we
 				// don't half-populate hints. The default hint will apply

--- a/ql/eval/estimate_test.go
+++ b/ql/eval/estimate_test.go
@@ -43,7 +43,7 @@ func TestEstimateNonRecursiveIDBSizesBaseOnly(t *testing.T) {
 		"A": makeIntRel(t, "A", 1, 2, 3, 4, 5),
 	}
 	hints := map[string]int{"A": 5}
-	updates := eval.EstimateNonRecursiveIDBSizes(prog, base, hints)
+	updates := eval.EstimateNonRecursiveIDBSizes(prog, base, hints, 0)
 	if updates["Q"] != 5 {
 		t.Errorf("Q size: want 5, got %d (updates=%v, hints=%v)", updates["Q"], updates, hints)
 	}
@@ -77,7 +77,7 @@ func TestEstimateNonRecursiveIDBSizesJoinSelectivity(t *testing.T) {
 		"B": makeIntRel2(t, "B", [2]int64{1, 10}, [2]int64{2, 20}, [2]int64{7, 70}),
 	}
 	hints := map[string]int{"A": 5, "B": 3}
-	updates := eval.EstimateNonRecursiveIDBSizes(prog, base, hints)
+	updates := eval.EstimateNonRecursiveIDBSizes(prog, base, hints, 0)
 	if updates["Q"] != 2 {
 		t.Errorf("Q join size: want 2 (real intersection), got %d", updates["Q"])
 	}
@@ -110,7 +110,7 @@ func TestEstimateNonRecursiveIDBSizesTransitive(t *testing.T) {
 		"B": makeIntRel(t, "B", 1, 2),
 	}
 	hints := map[string]int{"A": 8, "B": 2}
-	updates := eval.EstimateNonRecursiveIDBSizes(prog, base, hints)
+	updates := eval.EstimateNonRecursiveIDBSizes(prog, base, hints, 0)
 	if updates["L"] != 2 {
 		t.Errorf("L: want 2, got %d", updates["L"])
 	}
@@ -139,9 +139,90 @@ func TestEstimateNonRecursiveIDBSizesNeverShrinks(t *testing.T) {
 		"A": makeIntRel(t, "A", 1),
 	}
 	hints := map[string]int{"A": 1, "Q": 9999}
-	eval.EstimateNonRecursiveIDBSizes(prog, base, hints)
+	eval.EstimateNonRecursiveIDBSizes(prog, base, hints, 0)
 	if hints["Q"] != 9999 {
 		t.Errorf("Q hint shrunk from 9999 to %d", hints["Q"])
+	}
+}
+
+// TestEstimateNonRecursiveIDBSizesHonoursBindingCap is the issue #130
+// regression guard. A trivial IDB whose body forms an unbound cross-product
+// (no shared variables across the first two literals) would, with the
+// pre-pass uncapped, materialise the full N×M intermediate just to count head
+// facts — on real corpora this OOMs the host before the main eval ever runs.
+//
+// Construction: A(x) and B(y) share no variables in `Q(x,y) :- A(x), B(y).`
+// Cross-product cardinality with |A|=|B|=200 is 40,000 — well above the
+// cap=1000 we set, but small enough not to actually OOM the test host.
+//
+// With the cap correctly threaded, the pre-pass should hit the binding cap
+// inside Rule(), `failed` should fire, the IDB drops out of `updates` and
+// `hints` falls back to default. With the cap NOT threaded (the buggy
+// behaviour pre-#130), Rule() would run unbounded and produce updates["Q"]
+// = 40000.
+//
+// Mutation-killable: if the cap parameter were dropped or hard-coded back
+// to 0, this test would see updates["Q"] == 40000 and fail.
+func TestEstimateNonRecursiveIDBSizesHonoursBindingCap(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: datalog.Atom{Predicate: "Q", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "y"}}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{datalog.Var{Name: "x"}}}},
+					{Positive: true, Atom: datalog.Atom{Predicate: "B", Args: []datalog.Term{datalog.Var{Name: "y"}}}},
+				},
+			},
+		},
+	}
+	a := eval.NewRelation("A", 1)
+	b := eval.NewRelation("B", 1)
+	for i := int64(0); i < 200; i++ {
+		a.Add(eval.Tuple{eval.IntVal{V: i}})
+		b.Add(eval.Tuple{eval.IntVal{V: i + 10000}})
+	}
+	base := map[string]*eval.Relation{"A": a, "B": b}
+	hints := map[string]int{"A": 200, "B": 200}
+
+	updates := eval.EstimateNonRecursiveIDBSizes(prog, base, hints, 1000)
+
+	// Bug case: cap ignored, full 40k cross-product computed.
+	if updates["Q"] == 40000 {
+		t.Fatalf("issue #130 regression: pre-pass ignored binding cap and materialised full %d-tuple cross-product", updates["Q"])
+	}
+	// Expected: cap fired, IDB skipped, no entry written.
+	if _, ok := updates["Q"]; ok {
+		t.Errorf("Q exceeded cap; expected best-effort skip, got updates[Q]=%d", updates["Q"])
+	}
+	if _, ok := hints["Q"]; ok {
+		t.Errorf("Q hint should be absent on cap-skip; got hints[Q]=%d", hints["Q"])
+	}
+}
+
+// TestEstimateNonRecursiveIDBSizesZeroCapIsUnbounded confirms the legacy
+// escape hatch: passing 0 disables the cap. Mutation-killable: if cap=0
+// were silently coerced to a non-zero default, this rule would be skipped
+// instead of producing the full count.
+func TestEstimateNonRecursiveIDBSizesZeroCapIsUnbounded(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: datalog.Atom{Predicate: "Q", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "y"}}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{datalog.Var{Name: "x"}}}},
+					{Positive: true, Atom: datalog.Atom{Predicate: "B", Args: []datalog.Term{datalog.Var{Name: "y"}}}},
+				},
+			},
+		},
+	}
+	base := map[string]*eval.Relation{
+		"A": makeIntRel(t, "A", 1, 2, 3, 4, 5),
+		"B": makeIntRel(t, "B", 10, 20, 30, 40),
+	}
+	hints := map[string]int{"A": 5, "B": 4}
+	updates := eval.EstimateNonRecursiveIDBSizes(prog, base, hints, 0)
+	if updates["Q"] != 20 {
+		t.Errorf("Q (cap=0, full cross-product): want 20, got %d", updates["Q"])
 	}
 }
 
@@ -170,7 +251,7 @@ func TestEstimateNonRecursiveIDBSizesSkipsRecursive(t *testing.T) {
 		"Edge": makeIntRel2(t, "Edge", [2]int64{1, 2}),
 	}
 	hints := map[string]int{"Edge": 1}
-	updates := eval.EstimateNonRecursiveIDBSizes(prog, base, hints)
+	updates := eval.EstimateNonRecursiveIDBSizes(prog, base, hints, 0)
 	if _, ok := updates["Path"]; ok {
 		t.Errorf("Path is recursive — should be skipped, got update %d", updates["Path"])
 	}


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

Closes #130.

## Summary

PR #101 (which closed #88, the synthetic OOM) introduced the trivial-IDB pre-pass that pre-evaluates non-recursive derived predicates to feed `sizeHints`. The pre-pass call site (`ql/eval/estimate.go:72`) hard-coded the binding cap to `0`, disabling the per-rule cap during pre-pass evaluation. The annotation said "best-effort, errors silently absorbed" — but with the cap disabled the pre-pass cannot error, only thrash. On real corpora that means OOM before the main eval ever runs.

## Root cause

Mastodon corpus profile (heap snapshots every 10 s + per-IDB instrumentation, `~/setstate-bench/profiles/run2/`):

- Rule killing the host: `setStateUpdaterCallsFn`, evaluated by the pre-pass for hint generation
- Cross-product: `functionContainsStar=438165 × isUseStateSetterCall=390`
- Top allocators: `eval.binding.clone` 89.45% inuse / 66% alloc, `eval.applyPositive` 95% cum, `eval.EstimateNonRecursiveIDBSizes` 97% cum
- OOM ceiling: 30 GB RSS (host has 30 GB), empty stderr / 0-byte CSV — the binding cap never fires because it's disabled

The pre-pass doesn't actually need the rule's full materialised body — it only wants the head cardinality for sizeHints. But the current implementation evaluates the rule end-to-end and counts the result. With cap=0 there's nothing stopping the intermediate from blowing up.

## Fix

Add `maxBindingsPerRule int` to `EstimateNonRecursiveIDBSizes`. Thread the user-supplied `--max-bindings-per-rule` value through `compileAndEval` to the pre-pass call site. Pass it to `Rule(ctx, planned, keyed, maxBindingsPerRule)` instead of `0`.

The existing `failed/break` branch already handles `BindingCapError` correctly: when the cap fires, the IDB drops out of `sizeHints`, the default hint (1000) applies for downstream planning. This is exactly the "could not estimate, fall back" behaviour the pre-pass annotation always claimed.

**Memory impact:** bounded by `cap × ~350 B` ≈ 1.7 GB at the default 5M cap.
**Semantic impact:** zero. The rule's hint just defaults if its pre-pass can't complete. Downstream IDBs may pick suboptimal joins on a default-1000 hint, but that's strictly better than OOM.

## Tests

- `TestEstimateNonRecursiveIDBSizesHonoursBindingCap` (`ql/eval/estimate_test.go`): synthetic cross-product IDB `Q(x,y) :- A(x), B(y)` with `|A|=|B|=200` (full=40k tuples) and cap=1000 — asserts the IDB is skipped, no `updates["Q"]`, no `hints["Q"]`. Mutation-killable: dropping or zeroing the cap parameter produces `updates["Q"]==40000` and the test fails.
- `TestEstimateNonRecursiveIDBSizesZeroCapIsUnbounded`: confirms `cap=0` preserves the legacy unbounded semantics.
- `issue88_setstate_integration_test.go`: existing #88 regression test now also threads `tightCap` (100k) into the pre-pass — same guard covers both #88 (planner outcome) and #130 (pre-pass cap honoured).
- All existing estimate tests updated to pass cap=0 (preserves their original semantics).
- Full suite: `go test ./... -count=1` green.

## Verification on mastodon

Built `cmd/tsq` from this branch on `cain-nas` (placed under `~/setstate-bench/tsq-fix-test/`, cleaned up after). Ran against `dbs/mastodon.db` with `find_setstate_updater_calls_fn.ql`:

| Cap | Result | Wall | Peak RSS |
|---|---|---|---|
| 5M (default) | clean `BindingCapError` from `_disj_2` step 1 | seconds | bounded |
| 50M | clean `BindingCapError` from `setStateUpdaterCallsFn` step 4 | 73s | 27.1 GB |

Pre-fix this query OOMed at 30 GB RSS with empty stderr (host kill). Post-fix the planner produces a clean diagnostic the user can act on. The query body itself remains fundamentally cartesian on this corpus — the cap turns the host-OOM into a planner error, but does not make this query evaluable on mastodon-scale data. That's a separate problem (sampling estimator / per-IDB watchdog, see wiki notes); this PR is the immediate blast shield.

## Files

- `ql/eval/estimate.go` — signature + cap pass-through + comment update
- `ql/eval/estimate_test.go` — new `HonoursBindingCap` and `ZeroCapIsUnbounded` tests; existing tests updated for new signature
- `cmd/tsq/main.go` — pass `maxBindingsPerRule` into `EstimateNonRecursiveIDBSizes`
- `issue88_setstate_integration_test.go` — pass `tightCap` into the pre-pass call

## Test plan

- [x] `go test ./... -count=1` green locally
- [x] Mastodon corpus completes with clean `BindingCapError` at default cap (no OOM)
- [x] Mastodon corpus with elevated cap stays bounded at expected RSS
- [ ] CI green