### PR TITLE
fix: race in vendored tsgo RPC response handling

### DIFF
--- a/extract/backend_vendored.go
+++ b/extract/backend_vendored.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -17,6 +18,49 @@ import (
 
 // DefaultRPCTimeout is the default timeout for individual RPC calls to the tsgo subprocess.
 const DefaultRPCTimeout = 30 * time.Second
+
+// ErrBackendPoisoned is returned by rpc() once a previous call timed out or was
+// cancelled mid-flight. The vendored backend shares a single json.Decoder over
+// the tsgo subprocess's stdout; when an RPC abandons its read goroutine on
+// timeout, that orphan goroutine is still blocked on Decode and would race the
+// next caller's decoder goroutine on the same byte stream — producing
+// ID-mismatch errors at best and a torn JSON stream at worst (see issue #134).
+//
+// Rather than try to recover, we mark the backend poisoned, close stdin to
+// unblock the orphan Decode, and refuse all subsequent RPCs. Callers that need
+// a fresh tsgo session must construct a new VendoredBackend. Mirrors the
+// poisoning discipline in extract/typecheck/client.go (issue #115 / PR #117).
+var ErrBackendPoisoned = errors.New("vendored backend: poisoned by prior RPC timeout or cancellation")
+
+// rpcKillAfterCancel is the grace period between closing tsgo's stdin on RPC
+// cancellation and force-killing the subprocess. Matches the rationale in
+// extract/typecheck/client.go: most healthy tsgo builds exit on stdin close
+// within a few hundred ms; the kill fallback exists for hung processes that
+// would otherwise leak the orphan Decode goroutine forever.
+//
+// Stored as an atomic.Pointer so tests can override the grace window without
+// racing the cancellation goroutine.
+var rpcKillAfterCancel atomic.Pointer[time.Duration]
+
+func init() {
+	d := 2 * time.Second
+	rpcKillAfterCancel.Store(&d)
+}
+
+func getRPCKillAfterCancel() time.Duration {
+	if p := rpcKillAfterCancel.Load(); p != nil {
+		return *p
+	}
+	return 2 * time.Second
+}
+
+// setRPCKillAfterCancel replaces the grace window and returns the previous
+// value, allowing tests to restore it via t.Cleanup.
+func setRPCKillAfterCancel(d time.Duration) time.Duration {
+	prev := getRPCKillAfterCancel()
+	rpcKillAfterCancel.Store(&d)
+	return prev
+}
 
 // VendoredBackend implements ExtractorBackend using a combination of tree-sitter
 // for AST walking and the tsgo CLI (typescript-go) for type checking and symbol
@@ -51,6 +95,20 @@ type VendoredBackend struct {
 
 	// tsgoAvailable is true if tsgo was found and started successfully.
 	tsgoAvailable bool
+
+	// poisoned is set (atomically, no lock required) when an RPC abandons its
+	// Decode goroutine via timeout or ctx cancellation. Once set it stays set
+	// for the lifetime of the backend; every subsequent rpc() returns
+	// ErrBackendPoisoned immediately rather than racing a fresh Decode
+	// goroutine against the stuck orphan on the shared json.Decoder. See
+	// ErrBackendPoisoned and issue #134.
+	poisoned atomic.Bool
+
+	// killOnce guards the cmd.Process.Kill() fallback path so concurrent
+	// timeouts cannot race into double-kill or double-timer-start. (RPCs are
+	// already serialised by tsgoMu, but the kill goroutine outlives the
+	// caller's mutex hold, so we still need this guard.)
+	killOnce sync.Once
 }
 
 // jsonRPCRequest is a JSON-RPC 2.0 request envelope.
@@ -287,11 +345,26 @@ func (b *VendoredBackend) startTsgo(_ context.Context) error {
 }
 
 // rpc sends a JSON-RPC request and waits for the response.
-// Caller must hold tsgoMu. The call is bounded by DefaultRPCTimeout and
-// respects the caller's context cancellation.
+//
+// Caller must hold tsgoMu (all current callers do). The call is bounded by
+// DefaultRPCTimeout and respects the caller's context cancellation.
+//
+// Poisoning discipline (issue #134): the vendored backend shares a single
+// json.Decoder across all RPCs. If we abandoned the Decode goroutine on
+// timeout, the next RPC would spawn a second Decode goroutine on the same
+// stream — two goroutines racing on one decoder, with predictable corruption.
+// Instead, on timeout/cancel we mark the backend poisoned, close stdin to
+// unblock the orphan Decode (so the goroutine exits cleanly rather than
+// leaking forever), and force-kill the subprocess after a grace window if
+// stdin-close didn't unstick it. After poisoning, every subsequent rpc()
+// returns ErrBackendPoisoned. Mirrors extract/typecheck/client.go's
+// poisoned/killOnce pattern (issue #115 / PR #117).
 func (b *VendoredBackend) rpc(ctx context.Context, method string, params interface{}) (*jsonRPCResponse, error) {
 	if !b.tsgoAvailable {
 		return nil, ErrUnsupported
+	}
+	if b.poisoned.Load() {
+		return nil, ErrBackendPoisoned
 	}
 
 	id := b.reqID.Add(1)
@@ -334,15 +407,51 @@ func (b *VendoredBackend) rpc(ctx context.Context, method string, params interfa
 
 	select {
 	case <-rpcCtx.Done():
+		// Poison the backend BEFORE closing stdin. Order matters: any caller
+		// that races us to the next rpc() must observe poisoned=true and bail
+		// out at the top rather than spawn a competing Decode goroutine on
+		// the shared b.tsgoOut.
+		b.poisoned.Store(true)
+		// Close stdin so tsgo sees EOF, exits, closes its stdout, and the
+		// orphan Decode goroutine in `go func()` above unblocks (returning an
+		// error into ch, which is buffered so the send is non-blocking and
+		// the goroutine exits cleanly without leaking).
+		if b.tsgoIn != nil {
+			_ = b.tsgoIn.Close()
+		}
+		// Best-effort kill if stdin-close didn't unstick the subprocess. Use
+		// sync.Once so this only fires for the first poisoning event.
+		b.killOnce.Do(func() {
+			cmd := b.tsgoCmd
+			go func() {
+				select {
+				case <-ch:
+					// Decode unblocked within grace window — no kill needed.
+					return
+				case <-time.After(getRPCKillAfterCancel()):
+					if cmd != nil && cmd.Process != nil {
+						_ = cmd.Process.Kill()
+					}
+				}
+			}()
+		})
 		return nil, fmt.Errorf("rpc %s (id=%d): %w", method, id, rpcCtx.Err())
 	case result := <-ch:
 		if result.err != nil {
+			// Decode failures indicate the stream is no longer in a known
+			// state — poison so the next caller doesn't try to reuse the
+			// torn decoder.
+			b.poisoned.Store(true)
 			return nil, fmt.Errorf("decode response: %w", result.err)
 		}
 		resp := &result.resp
 
-		// Validate response ID matches the request.
+		// Validate response ID matches the request. A mismatch means the
+		// stream framing has drifted (an earlier orphan Decode lost a
+		// response, or tsgo emitted out-of-order). Either way the decoder is
+		// no longer trustworthy — poison and refuse subsequent calls.
 		if resp.ID != id {
+			b.poisoned.Store(true)
 			return nil, fmt.Errorf("rpc response id mismatch: got %d, want %d", resp.ID, id)
 		}
 

--- a/extract/backend_vendored.go
+++ b/extract/backend_vendored.go
@@ -380,12 +380,18 @@ func (b *VendoredBackend) rpc(ctx context.Context, method string, params interfa
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	// Write request with Content-Length header (LSP-style framing).
+	// Write request with Content-Length header (LSP-style framing). A write
+	// failure here means stdin is broken (subprocess exited, pipe closed) —
+	// poison so subsequent callers don't retry against a dead pipe and so we
+	// don't leave a half-written framed message that would desync the next
+	// reader.
 	header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(data))
 	if _, err := io.WriteString(b.tsgoIn, header); err != nil {
+		b.poisoned.Store(true)
 		return nil, fmt.Errorf("write header: %w", err)
 	}
 	if _, err := b.tsgoIn.Write(data); err != nil {
+		b.poisoned.Store(true)
 		return nil, fmt.Errorf("write body: %w", err)
 	}
 

--- a/extract/backend_vendored_test.go
+++ b/extract/backend_vendored_test.go
@@ -463,3 +463,170 @@ func TestVendoredBackend_StderrCaptured(t *testing.T) {
 	// that the field is bytes.Buffer, not *os.File).
 	var _ bytes.Buffer = b.tsgoStderr
 }
+
+// TestVendoredBackend_RPC_TimeoutPoisonsBackend is the regression test for
+// issue #134. Before the fix, a timed-out RPC abandoned its Decode goroutine,
+// leaving the orphan blocked on the shared json.Decoder. The next rpc() call
+// would spawn a second Decode goroutine on the same byte stream — two
+// goroutines racing one decoder, producing ID-mismatch errors at best and
+// stream corruption at worst.
+//
+// The fix is to mark the backend poisoned on timeout and refuse subsequent
+// calls. This test asserts that exact behaviour:
+//  1. First rpc() with a ~immediately-cancelled context returns a context error.
+//  2. The backend is now poisoned.
+//  3. A second rpc() — even with a fresh, healthy context and a tsgo stdout
+//     pipe that is now serving valid responses — fails fast with
+//     ErrBackendPoisoned, NOT with an ID mismatch error caused by consuming
+//     request 1's late response.
+//
+// This test would FAIL on the pre-fix code: the second rpc() would consume
+// request 1's late response (id=1, wrong) and surface "id mismatch" — not
+// ErrBackendPoisoned — proving the orphan goroutine racing the new one.
+func TestVendoredBackend_RPC_TimeoutPoisonsBackend(t *testing.T) {
+	// Tighten the kill grace window so the test doesn't have to wait 2s for
+	// the (unused, in this test) kill goroutine to settle.
+	prev := setRPCKillAfterCancel(50 * time.Millisecond)
+	t.Cleanup(func() { setRPCKillAfterCancel(prev) })
+
+	b := &VendoredBackend{tsgoAvailable: true}
+
+	stdinR, stdinW := io.Pipe()
+	stdoutR, stdoutW := io.Pipe()
+	t.Cleanup(func() {
+		stdinR.Close()
+		stdoutW.Close()
+	})
+
+	b.tsgoIn = stdinW
+	b.tsgoOut = json.NewDecoder(stdoutR)
+
+	// Drain stdin so writes don't block the test.
+	go func() { _, _ = io.Copy(io.Discard, stdinR) }()
+
+	// First call: cancel ctx immediately. The Decode goroutine inside rpc()
+	// will block on stdoutR (we never write to stdoutW here) until poisoning
+	// closes stdin — which doesn't help unblock the Decode either. So the
+	// orphan goroutine is genuinely stuck on Decode at the moment we return
+	// from the first rpc(). That is the precondition for the bug.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := b.rpc(ctx, "first", nil)
+	if err == nil {
+		t.Fatal("first rpc with cancelled ctx: expected error, got nil")
+	}
+	if !b.poisoned.Load() {
+		t.Fatal("expected backend to be poisoned after timed-out rpc")
+	}
+
+	// Second call. On the pre-fix code, this would proceed past the check,
+	// spawn a fresh Decode goroutine racing the orphan, and we'd see an
+	// id-mismatch or decode error if anything ever arrived on the wire.
+	// Post-fix, it must fail fast with ErrBackendPoisoned and NOT spawn a
+	// new Decode goroutine at all.
+	_, err = b.rpc(context.Background(), "second", nil)
+	if !errors.Is(err, ErrBackendPoisoned) {
+		t.Fatalf("second rpc after timeout: want ErrBackendPoisoned, got %v", err)
+	}
+
+	// Even if we now feed a "valid" response onto the wire (simulating the
+	// late tsgo reply that caused the original bug), the backend must still
+	// refuse — because there is no way to know which request that response
+	// belongs to.
+	go func() {
+		resp := jsonRPCResponse{
+			JSONRPC: "2.0",
+			ID:      1, // The id of the (now abandoned) first request.
+			Result:  json.RawMessage(`{}`),
+		}
+		_ = json.NewEncoder(stdoutW).Encode(resp)
+	}()
+	// Brief delay so the encode goroutine actually writes — without this
+	// the test passes for the wrong reason (nothing on the wire yet).
+	time.Sleep(20 * time.Millisecond)
+
+	_, err = b.rpc(context.Background(), "third", nil)
+	if !errors.Is(err, ErrBackendPoisoned) {
+		t.Fatalf("third rpc with late response on wire: want ErrBackendPoisoned, got %v", err)
+	}
+}
+
+// TestVendoredBackend_RPC_DecodeErrorPoisonsBackend asserts that a decode
+// failure (torn JSON, IO error) also poisons the backend rather than leaving
+// it half-broken with a corrupt decoder state.
+func TestVendoredBackend_RPC_DecodeErrorPoisonsBackend(t *testing.T) {
+	b := &VendoredBackend{tsgoAvailable: true}
+
+	stdinR, stdinW := io.Pipe()
+	stdoutR, stdoutW := io.Pipe()
+	t.Cleanup(func() {
+		stdinR.Close()
+		stdoutR.Close()
+	})
+
+	b.tsgoIn = stdinW
+	b.tsgoOut = json.NewDecoder(stdoutR)
+
+	go func() { _, _ = io.Copy(io.Discard, stdinR) }()
+
+	// Write malformed JSON onto the stream.
+	go func() {
+		_, _ = stdoutW.Write([]byte("not valid json at all\n"))
+		stdoutW.Close()
+	}()
+
+	_, err := b.rpc(context.Background(), "test", nil)
+	if err == nil {
+		t.Fatal("expected decode error, got nil")
+	}
+	if !b.poisoned.Load() {
+		t.Fatal("expected backend to be poisoned after decode error")
+	}
+
+	_, err = b.rpc(context.Background(), "next", nil)
+	if !errors.Is(err, ErrBackendPoisoned) {
+		t.Fatalf("subsequent rpc after decode error: want ErrBackendPoisoned, got %v", err)
+	}
+}
+
+// TestVendoredBackend_RPC_IDMismatchPoisonsBackend asserts that an id-mismatch
+// response (which means the stream framing drifted) also poisons the backend.
+// The pre-existing TestVendoredBackend_RPC_MismatchedID test only checks that
+// the first call returns an error — this test additionally checks that the
+// backend refuses subsequent RPCs.
+func TestVendoredBackend_RPC_IDMismatchPoisonsBackend(t *testing.T) {
+	b := &VendoredBackend{tsgoAvailable: true}
+
+	stdinR, stdinW := io.Pipe()
+	stdoutR, stdoutW := io.Pipe()
+	t.Cleanup(func() {
+		stdinR.Close()
+		stdoutW.Close()
+	})
+
+	b.tsgoIn = stdinW
+	b.tsgoOut = json.NewDecoder(stdoutR)
+
+	go func() { _, _ = io.Copy(io.Discard, stdinR) }()
+	go func() {
+		resp := jsonRPCResponse{
+			JSONRPC: "2.0",
+			ID:      99999,
+			Result:  json.RawMessage(`{}`),
+		}
+		_ = json.NewEncoder(stdoutW).Encode(resp)
+	}()
+
+	_, err := b.rpc(context.Background(), "first", nil)
+	if err == nil {
+		t.Fatal("expected mismatch error, got nil")
+	}
+	if !b.poisoned.Load() {
+		t.Fatal("expected backend to be poisoned after id mismatch")
+	}
+
+	_, err = b.rpc(context.Background(), "second", nil)
+	if !errors.Is(err, ErrBackendPoisoned) {
+		t.Fatalf("subsequent rpc after id mismatch: want ErrBackendPoisoned, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #134.

## Problem

`extract/backend_vendored.go` shares a single `json.Decoder` across all RPC calls to the tsgo subprocess. The `rpc()` function spawned a goroutine to call `Decode`, racing it against `rpcCtx.Done()` for the timeout. On timeout/cancel, `rpc()` returned immediately, but the spawned goroutine remained blocked on `Decode` holding the shared decoder.

The next caller acquired `tsgoMu`, wrote a fresh request, and spawned a *second* `Decode` goroutine on the same decoder — two goroutines racing on one byte stream. Outcomes:

- Whichever goroutine wins gets request 1's late response. The other gets request 2's.
- Caller 2 sees an ID mismatch (expected id=2, got id=1) → permanent visible error.
- Worse: the late response can be partially consumed by goroutine A and partially by goroutine B, tearing the JSON stream itself. From that point on every subsequent `Decode` returns garbage, silently dropping `Symbol`/`SymbolType`/cross-file-ref facts and degrading downstream taint queries to false negatives.

## Fix

Mirror the proven `extract/typecheck/client.go` pattern (introduced for issue #115 / PR #117):

1. New `poisoned atomic.Bool` and `killOnce sync.Once` fields on `VendoredBackend`.
2. New `ErrBackendPoisoned` sentinel error.
3. `rpc()` fast-fails with `ErrBackendPoisoned` if `poisoned` is set.
4. On timeout / ctx cancel: set `poisoned`, close `b.tsgoIn` to unblock the orphan `Decode` goroutine, force-kill the subprocess after a grace window (`rpcKillAfterCancel`, default 2s).
5. On decode error or id-mismatch: also set `poisoned` (the stream is no longer trustworthy).

The backend cleanly degrades to "tsgo unavailable" mode rather than silently returning corrupted facts. Callers that need a fresh tsgo session must construct a new `VendoredBackend`.

### Why not a full id-keyed response router

Callers already hold `tsgoMu` (verified at the three call sites: `ResolveSymbol`, `ResolveType`, `CrossFileRefs`), so concurrency isn't the underlying issue — the unrecoverable problem is that once a `Decode` is abandoned mid-stream, there is no way to know where the next `Decode` should resume. Any router would still need the same poisoning behaviour, with more surface area for the same outcome. This change is the minimum that closes the race.

## Tests

Three new regression tests in `extract/backend_vendored_test.go`:

- `TestVendoredBackend_RPC_TimeoutPoisonsBackend` — proves the bug is closed: after a timed-out rpc, a subsequent rpc fails fast with `ErrBackendPoisoned` even when a late response (with the abandoned id=1) is sitting on the wire. Pre-fix this would have returned an id-mismatch error from the abandoned response leaking into request 2.
- `TestVendoredBackend_RPC_DecodeErrorPoisonsBackend` — feeds malformed JSON, asserts decode failure poisons the backend and refuses subsequent calls.
- `TestVendoredBackend_RPC_IDMismatchPoisonsBackend` — strengthens the existing `TestVendoredBackend_RPC_MismatchedID` to also assert post-mismatch poisoning.

All three were verified to FAIL on pre-fix code (with the `b.poisoned.Store(true)` calls stubbed out) and PASS post-fix under `go test -race`. Full suite green: `go test -race ./...`.

## Audit reference

`tsq-fragility-audit-2026-04-18.md` finding #2 (HIGH severity).