### PR TITLE
feat(plan): single-pass EstimateAndPlan, drop two-pass replan ceremony (P1 of planner roadmap)

### DIFF
--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -785,24 +785,58 @@ func buildProgram(src, file string, importLoader func(string) (*ast.Module, erro
 	return execPlan, mod, warnings, errs
 }
 
-// buildProgramWithProg is buildProgram with the post-merge *datalog.Program
-// also returned. It is used by `query` so the compileAndEval pipeline can run
-// the trivial-IDB pre-pass (eval.EstimateNonRecursiveIDBSizes) over the same
-// rule graph the planner sees, populate sizeHints with real derived-relation
-// counts, and re-plan. `check` does not need prog (no eval), so it keeps the
-// narrower buildProgram wrapper.
-func buildProgramWithProg(src, file string, importLoader func(string) (*ast.Module, error), sizeHints map[string]int, opts buildOptions) (*plan.ExecutionPlan, *datalog.Program, *ast.Module, []resolve.Warning, []error) {
+// makeFunc returns a plan.Func that captures the magic-set wiring
+// (or its absence) implied by buildOptions. Extracted so that the same
+// inference + verbose/warn observability used by `check`'s buildProgramWithProg
+// path is also used by `query`'s EstimateAndPlan path. Without this, the
+// magic-set branch would only fire on the (now-discarded) pre-estimate plan
+// in buildProgramWithProg and `query` would always run plain Plan.
+func makeFunc(opts buildOptions) plan.Func {
+	if !opts.useMagicSets {
+		return plan.Plan
+	}
+	return func(prog *datalog.Program, sizeHints map[string]int) (*plan.ExecutionPlan, []error) {
+		ep, inf, errs := plan.WithMagicSetAutoOpts(prog, sizeHints, plan.MagicSetOptions{Strict: opts.magicSetsStrict})
+		switch {
+		case inf.Fallback:
+			// Always surface a fallback warning to warnOut (not gated on
+			// --verbose). Silent fallback was the bug in issue #112; the
+			// observability fix is unconditional. The strict path returns
+			// an error instead and never reaches this branch.
+			if opts.warnOut != nil {
+				fmt.Fprintf(opts.warnOut, "warning: magic-set transform produced an unplannable program; fell back to plain Plan (reason: %v)\n", inf.FallbackReason)
+			}
+		case opts.verboseOut != nil && len(inf.Bindings) > 0:
+			fmt.Fprintf(opts.verboseOut, "magic-set: transform applied; bindings=%v seed_rules=%d\n", inf.Bindings, len(inf.SeedRules))
+		case opts.verboseOut != nil:
+			fmt.Fprintln(opts.verboseOut, "magic-set: no inferable query bindings; using plain plan")
+		}
+		return ep, errs
+	}
+}
+
+// compileToProg runs the shared compile pipeline (parse → resolve → desugar →
+// MergeSystemRules) and returns the post-merge *datalog.Program WITHOUT
+// invoking the planner. Used by compileAndEval, which then calls
+// plan.EstimateAndPlan to do the single estimate-then-plan pass with real
+// IDB cardinalities (replaces the prior two-pass plan-then-replan ceremony).
+//
+// `check` still goes through buildProgram (which plans) because it needs to
+// surface plan-time errors without loading a fact DB. `query` does not need
+// the compile-time plan at all — it only ever uses the estimate-aware plan
+// produced by EstimateAndPlan downstream.
+func compileToProg(src, file string, importLoader func(string) (*ast.Module, error)) (*datalog.Program, *ast.Module, []resolve.Warning, []error) {
 	// Parse.
 	p := parse.NewParser(src, file)
 	mod, err := p.Parse()
 	if err != nil {
-		return nil, nil, nil, nil, []error{fmt.Errorf("parse: %w", err)}
+		return nil, nil, nil, []error{fmt.Errorf("parse: %w", err)}
 	}
 
 	// Resolve.
 	resolved, err := resolve.Resolve(mod, importLoader)
 	if err != nil {
-		return nil, nil, mod, nil, []error{fmt.Errorf("resolve: %w", err)}
+		return nil, mod, nil, []error{fmt.Errorf("resolve: %w", err)}
 	}
 	warnings := resolved.Warnings
 	if len(resolved.Errors) > 0 {
@@ -810,7 +844,7 @@ func buildProgramWithProg(src, file string, importLoader func(string) (*ast.Modu
 		for _, e := range resolved.Errors {
 			errs = append(errs, fmt.Errorf("resolve: %w", e))
 		}
-		return nil, nil, mod, warnings, errs
+		return nil, mod, warnings, errs
 	}
 
 	// Desugar.
@@ -820,14 +854,28 @@ func buildProgramWithProg(src, file string, importLoader func(string) (*ast.Modu
 		for _, e := range dsErrors {
 			errs = append(errs, fmt.Errorf("desugar: %w", e))
 		}
-		return nil, nil, mod, warnings, errs
+		return nil, mod, warnings, errs
 	}
 
 	// Inject system rules so derived relations (CallTarget, LocalFlow,
-	// TaintAlert, etc.) are present in the planned graph. This used to live
-	// only in `query`, which meant `check` could green-light a program whose
-	// system-rule-augmented form failed to plan or hung at eval time.
+	// TaintAlert, etc.) are present in the planned graph (issue #82 — must
+	// match what buildProgramWithProg does).
 	prog = rules.MergeSystemRules(prog, rules.AllSystemRules())
+
+	return prog, mod, warnings, nil
+}
+
+// buildProgramWithProg is buildProgram with the post-merge *datalog.Program
+// also returned. It is used by `query` so the compileAndEval pipeline can run
+// the trivial-IDB pre-pass (eval.EstimateNonRecursiveIDBSizes) over the same
+// rule graph the planner sees, populate sizeHints with real derived-relation
+// counts, and re-plan. `check` does not need prog (no eval), so it keeps the
+// narrower buildProgram wrapper.
+func buildProgramWithProg(src, file string, importLoader func(string) (*ast.Module, error), sizeHints map[string]int, opts buildOptions) (*plan.ExecutionPlan, *datalog.Program, *ast.Module, []resolve.Warning, []error) {
+	prog, mod, warnings, compileErrs := compileToProg(src, file, importLoader)
+	if len(compileErrs) > 0 {
+		return nil, nil, mod, warnings, compileErrs
+	}
 
 	// Plan. When magic sets are enabled, run the binding-inference + transform
 	// path; on no-bindings it falls through to plain Plan transparently.
@@ -898,11 +946,13 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string, maxBindingsPe
 	// order joins by true relation size rather than a uniform default of 1000.
 	sizeHints := buildSizeHints(factDB)
 
-	// Compile via the shared pipeline so that `check` and `query` agree on the
-	// rule graph (parse → resolve → desugar → MergeSystemRules → plan).
+	// Compile (parse → resolve → desugar → MergeSystemRules) WITHOUT planning.
+	// Planning happens below via plan.EstimateAndPlan — the single
+	// estimate-then-plan entry point (P1 of the planner roadmap, replacing
+	// the prior two-pass plan-then-replan ceremony).
 	bridgeFiles := bridge.LoadBridge()
 	importLoader := makeBridgeImportLoader(bridgeFiles)
-	execPlan, prog, _, _, buildErrs := buildProgramWithProg(string(src), queryFile, importLoader, sizeHints, opts)
+	prog, _, _, buildErrs := compileToProg(string(src), queryFile, importLoader)
 	if len(buildErrs) > 0 {
 		// Reproduce the prior multi-error formatting of compileAndEval: group
 		// by phase and join with newline-indented messages so callers see one
@@ -910,38 +960,32 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string, maxBindingsPe
 		return nil, joinPhaseErrors(buildErrs)
 	}
 
-	// Issue #88 (co-stratified seed case): pre-compute the cardinality of
-	// every "trivial" derived predicate — non-recursive, body uses only
-	// positive base atoms and comparisons — and feed the real counts back
-	// into the planner. This catches the case where a tiny IDB seed (e.g.
-	// isUseStateSetterCall, 7 tuples) and the explody rule that uses it
-	// (setStateUpdaterCallsFn) land in the same stratum, which the
-	// between-strata refresh in eval.Evaluate cannot fix on its own (the
-	// seed is not yet materialised when its sibling rule is planned).
-	//
-	// Load base relations once and reuse them for both the pre-pass and the
-	// main Evaluate call (loadBaseRelations is the dominant cost for small
-	// fact DBs and we'd rather not pay it twice).
+	// Load base relations once and reuse them for both the pre-pass (via the
+	// estimator hook) and the main Evaluate call (LoadBaseRelations is the
+	// dominant cost for small fact DBs and we'd rather not pay it twice).
 	baseRels, err := eval.LoadBaseRelations(factDB)
 	if err != nil {
 		return nil, fmt.Errorf("load base relations: %w", err)
 	}
-	// Issue #130: the pre-pass must honour the user-supplied binding cap;
-	// otherwise an explody trivial-IDB can OOM the host before the main
-	// evaluator ever runs (mastodon corpus, setStateUpdaterCallsFn).
-	updates := eval.EstimateNonRecursiveIDBSizes(prog, baseRels, sizeHints, maxBindingsPerRule)
-	if len(updates) > 0 {
-		// Re-plan every stratum and the final query with the refreshed hints
-		// before evaluation begins. Without this the original execPlan
-		// (planned with default-1000 hints for every IDB) would still drive
-		// the evaluator; the between-strata refresh in eval.Evaluate would
-		// only help strata > 0, missing the co-stratified case entirely.
-		for i := range execPlan.Strata {
-			plan.RePlanStratum(&execPlan.Strata[i], sizeHints)
+
+	// Build the planner variant (plain or magic-set) as a Func and let
+	// EstimateAndPlan orchestrate: identify trivial IDBs → estimate →
+	// plan ONCE with the now-populated hints. The estimator hook honours
+	// maxBindingsPerRule (issue #130 / PR #132 — preserved end-to-end).
+	planFn := makeFunc(opts)
+	execPlan, planErrs := plan.EstimateAndPlan(
+		prog,
+		sizeHints,
+		maxBindingsPerRule,
+		eval.MakeEstimatorHook(baseRels),
+		planFn,
+	)
+	if len(planErrs) > 0 {
+		errs := make([]error, 0, len(planErrs))
+		for _, e := range planErrs {
+			errs = append(errs, fmt.Errorf("plan: %w", e))
 		}
-		if execPlan.Query != nil {
-			plan.RePlanQuery(execPlan.Query, sizeHints)
-		}
+		return nil, joinPhaseErrors(errs)
 	}
 
 	// Evaluate.

--- a/issue88_setstate_integration_test.go
+++ b/issue88_setstate_integration_test.go
@@ -78,36 +78,36 @@ func TestIssue88_SetStateQueryDoesNotOOM(t *testing.T) {
 		hints[def.Name] = factDB.Relation(def.Name).Tuples()
 	}
 
-	// Plan.
-	execPlan, planErrs := plan.Plan(prog, hints)
-	if len(planErrs) > 0 {
-		t.Fatalf("plan: %v", planErrs)
-	}
-
 	// Aggressive binding cap: real fixture intermediate cardinality with the
 	// fix in place is < 1k. Pre-fix this rule blew the default 5M cap; we
 	// pick 100k as the regression threshold — comfortably above the real
 	// number, comfortably below "Cartesian disaster". Also threaded into the
-	// pre-pass below so issue #130 (uncapped pre-pass eating RAM before the
-	// main eval ever runs) is covered by the same guard.
+	// pre-pass via EstimateAndPlan so issue #130 (uncapped pre-pass eating
+	// RAM before the main eval ever runs) is covered by the same guard.
 	const tightCap = 100_000
 
-	// Pre-pass + re-plan (the issue #88 fix). If a future change removes
-	// these two calls from cmd/tsq/main.go, the assertion below catches
-	// the regression directly: the rule will OOM at step 2.
+	// EstimateAndPlan: single estimate-then-plan pass (P1 of planner roadmap).
+	// The estimator hook materialises every trivial IDB BEFORE Plan() is
+	// called, so the seed cardinality (isUseStateSetterCall ≈ 7) is in
+	// sizeHints from the start instead of falling through to default-1000.
+	// This replaces the prior "plan → estimate → RePlanStratum / RePlanQuery"
+	// two-pass ceremony.
 	baseRels, err := eval.LoadBaseRelations(factDB)
 	if err != nil {
 		t.Fatalf("load base relations: %v", err)
 	}
-	updates := eval.EstimateNonRecursiveIDBSizes(prog, baseRels, hints, tightCap)
-	if updates["isUseStateSetterCall"] == 0 {
-		t.Fatalf("pre-pass failed to size isUseStateSetterCall (the seed predicate); updates=%v", updates)
+	execPlan, planErrs := plan.EstimateAndPlan(
+		prog,
+		hints,
+		tightCap,
+		eval.MakeEstimatorHook(baseRels),
+		plan.Plan,
+	)
+	if len(planErrs) > 0 {
+		t.Fatalf("plan: %v", planErrs)
 	}
-	for i := range execPlan.Strata {
-		plan.RePlanStratum(&execPlan.Strata[i], hints)
-	}
-	if execPlan.Query != nil {
-		plan.RePlanQuery(execPlan.Query, hints)
+	if hints["isUseStateSetterCall"] == 0 {
+		t.Fatalf("pre-pass failed to size isUseStateSetterCall (the seed predicate); hints=%v", hints)
 	}
 
 	// Assert: the seed predicate is now FIRST in the join order. This is

--- a/ql/eval/estimate.go
+++ b/ql/eval/estimate.go
@@ -48,6 +48,23 @@ import (
 //
 // Returns the slice of (name, computed-size) updates actually applied, for
 // observability/testing.
+// MakeEstimatorHook returns a plan.EstimatorHook closed over the supplied
+// base relations. The returned hook delegates to EstimateNonRecursiveIDBSizes,
+// matching its best-effort / cap-honouring semantics. This is the bridge that
+// lets plan.EstimateAndPlan call into the eval-side trivial-IDB pre-pass
+// without plan importing eval (eval already imports plan).
+//
+// Use it from cmd/tsq's compileAndEval (and any other call site that wants
+// the single-pass estimate-then-plan flow) instead of the previous two-pass
+// "plan → EstimateNonRecursiveIDBSizes → RePlanStratum/RePlanQuery"
+// ceremony. The binding cap from PR #132 (issue #130) is preserved end-to-end
+// because it is a parameter of the hook signature, not a closed-over constant.
+func MakeEstimatorHook(baseRels map[string]*Relation) plan.EstimatorHook {
+	return func(prog *datalog.Program, sizeHints map[string]int, maxBindingsPerRule int) map[string]int {
+		return EstimateNonRecursiveIDBSizes(prog, baseRels, sizeHints, maxBindingsPerRule)
+	}
+}
+
 func EstimateNonRecursiveIDBSizes(prog *datalog.Program, baseRels map[string]*Relation, sizeHints map[string]int, maxBindingsPerRule int) map[string]int {
 	if sizeHints == nil {
 		sizeHints = map[string]int{}

--- a/ql/plan/plan.go
+++ b/ql/plan/plan.go
@@ -62,6 +62,98 @@ func WithMagicSet(prog *datalog.Program, sizeHints map[string]int, queryBindings
 	return Plan(transformed, sizeHints)
 }
 
+// EstimatorHook is a callback that pre-computes cardinalities for trivially-
+// evaluable IDB predicates and writes them into sizeHints (in place). It is
+// injected by callers in the eval package so that the planner can run the
+// trivial-IDB pre-pass before constructing the final execution plan, without
+// the plan package taking a build-time dependency on eval (which would be a
+// cycle: eval already imports plan).
+//
+// Hook contract:
+//   - prog and sizeHints are the same values EstimateAndPlan was called with.
+//   - maxBindingsPerRule is the per-rule binding cap; the hook MUST honour it
+//     so a pathological body cannot OOM the host before planning even starts
+//     (issue #130). Pass 0 inside the hook only when the caller of
+//     EstimateAndPlan deliberately supplied 0.
+//   - The hook may mutate sizeHints in place; it returns the slice of updates
+//     applied (for observability) but the canonical state is the mutated map.
+//   - Best-effort semantics: failures inside the hook (e.g. cap fires on an
+//     individual trivial IDB) MUST be absorbed silently — the IDB falls
+//     through to the default hint and the plan proceeds. The hook MUST NOT
+//     return an error.
+//
+// A nil hook is permitted: EstimateAndPlan then degrades to plain Plan with
+// whatever sizeHints the caller supplied (useful for tests and for callers
+// that have no fact DB to estimate against).
+type EstimatorHook func(prog *datalog.Program, sizeHints map[string]int, maxBindingsPerRule int) map[string]int
+
+// Func is the planning entry point used by EstimateAndPlan after the
+// pre-pass has populated sizeHints. The default is plan.Plan; callers that
+// want magic-set rewriting pass plan.WithMagicSetAutoOpts (wrapped to match
+// this signature). Keeping this pluggable lets EstimateAndPlan stay the
+// single estimate-then-plan entry point regardless of which planner variant
+// is in use, without EstimateAndPlan needing to know about magic-set options.
+type Func func(prog *datalog.Program, sizeHints map[string]int) (*ExecutionPlan, []error)
+
+// EstimateAndPlan is the single estimate-then-plan entry point. It owns the
+// order: stratify (implicit, via planFn) → identify trivial IDBs and estimate
+// their sizes via the eval-supplied hook → plan everything once with full
+// hints. Replaces the prior two-pass ceremony in cmd/tsq's compileAndEval
+// (cheap-plan → estimate → re-plan-every-stratum), eliminating a re-entrancy
+// hazard between the two passes (#88-era trust-channel for IDB hints).
+//
+// Why a single entry point: the prior compileAndEval flow first called
+// plan.Plan with base-only hints, then ran EstimateNonRecursiveIDBSizes,
+// then called RePlanStratum/RePlanQuery to swap in the refreshed hints. That
+// produced two distinct planning passes that had to agree on stratification,
+// magic-set inference, and binding propagation. Folding to one pass means
+// magic-set inference (and any future hint-aware planner pass) sees the
+// IDB cardinalities from the very first call — no out-of-band trust channel
+// needed to bridge the two passes.
+//
+// Arguments:
+//   - prog: the post-desugar, post-MergeSystemRules program to plan.
+//   - sizeHints: caller-supplied hints (typically built from base relation
+//     tuple counts). May be nil. Mutated in place by the estimator hook so
+//     the post-call map carries the trivial-IDB sizes too.
+//   - maxBindingsPerRule: binding cap forwarded to the estimator hook
+//     (issue #130 / PR #132 — must NOT be lost when migrating callers).
+//   - estimator: see EstimatorHook docs. May be nil to skip the pre-pass.
+//   - planFn: the planner to invoke once hints are populated. Pass plan.Plan
+//     for the no-magic-set path; pass a closure over WithMagicSetAutoOpts
+//     for the magic-set path.
+//
+// The between-strata refresh in eval.Evaluate (RePlanStratum/RePlanQuery
+// after each stratum's fixpoint) is preserved untouched — it handles the
+// case where a non-trivial (recursive) IDB's true size becomes known
+// mid-evaluation, which the estimator hook cannot pre-compute by definition.
+// EstimateAndPlan only collapses the redundant outer two-pass ceremony.
+func EstimateAndPlan(
+	prog *datalog.Program,
+	sizeHints map[string]int,
+	maxBindingsPerRule int,
+	estimator EstimatorHook,
+	planFn Func,
+) (*ExecutionPlan, []error) {
+	if planFn == nil {
+		planFn = Plan
+	}
+	if sizeHints == nil {
+		sizeHints = map[string]int{}
+	}
+	// Pre-pass: ask eval to materialise every trivial IDB and write its
+	// cardinality into sizeHints. Best-effort by contract — a hook that
+	// returns nil simply leaves the hints untouched and we plan with what
+	// the caller supplied.
+	if estimator != nil {
+		_ = estimator(prog, sizeHints, maxBindingsPerRule)
+	}
+	// Single planning pass with the (now hint-populated) sizeHints. This is
+	// the single point of magic-set inference / stratification / join
+	// ordering — by P1 contract there is no second outer pass.
+	return planFn(prog, sizeHints)
+}
+
 // Plan produces an ExecutionPlan from a Datalog program.
 // sizeHints maps relation names to estimated tuple counts (for join ordering).
 // Unknown relations default to 1000.

--- a/ql/plan/plan_test.go
+++ b/ql/plan/plan_test.go
@@ -143,3 +143,150 @@ func TestRePlanQuerySwapsJoinOrder(t *testing.T) {
 			ep.Query.JoinOrder[0].Literal.Atom.Predicate)
 	}
 }
+
+// TestEstimateAndPlan_SinglePassSelectsTinySeed is the planner-layer
+// assertion for P1 of the planner roadmap: a single estimate-then-plan
+// pass must pick the tiny IDB as the join seed on the FIRST plan, not
+// after a re-plan. This is the contract that lets us delete the
+// two-pass plan-then-replan ceremony from compileAndEval.
+//
+// Setup: rule P(x) :- A(x), B(x) where A is a base relation with 100
+// tuples and B is a trivial IDB defined by `B(x) :- Tiny(x)` over a
+// 5-tuple base. With base-only hints, B falls through to default 1000
+// and A wins seed selection. With EstimateAndPlan, the estimator hook
+// pre-computes |B|=5 BEFORE Plan() runs, so B wins seed selection on
+// the very first (and only) plan. No RePlan call required.
+//
+// The hook is a hand-rolled fake here (no eval dependency in this test
+// package); the real eval.MakeEstimatorHook is exercised end-to-end by
+// TestIssue88_SetStateQueryDoesNotOOM in the integration_test package.
+func TestEstimateAndPlan_SinglePassSelectsTinySeed(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: atom("B", "x"),
+				Body: []datalog.Literal{posLit("Tiny", "x")},
+			},
+			{
+				Head: atom("P", "x"),
+				Body: []datalog.Literal{posLit("A", "x"), posLit("B", "x")},
+			},
+		},
+	}
+	hints := map[string]int{"A": 100, "Tiny": 5}
+
+	// Baseline: without an estimator, B falls through to default 1000
+	// and A wins seed selection — proves the test's "before" condition.
+	baselineEP, errs := plan.EstimateAndPlan(prog, copyHints(hints), 0, nil, plan.Plan)
+	if len(errs) != 0 {
+		t.Fatalf("baseline plan errors: %v", errs)
+	}
+	pBaseline := findRuleByHead(t, baselineEP, "P")
+	if pBaseline.JoinOrder[0].Literal.Atom.Predicate != "A" {
+		t.Fatalf("baseline (no estimator): expected A first (B falls through to default 1000 > A=100), got %s",
+			pBaseline.JoinOrder[0].Literal.Atom.Predicate)
+	}
+
+	// Real path: estimator hook pre-fills |B|=5 BEFORE Plan() runs, so
+	// the single plan pass picks B as the seed.
+	estimator := func(_ *datalog.Program, sizeHints map[string]int, _ int) map[string]int {
+		// Simulate eval.EstimateNonRecursiveIDBSizes computing |B| = |Tiny| = 5.
+		sizeHints["B"] = 5
+		return map[string]int{"B": 5}
+	}
+	postHints := copyHints(hints)
+	estimateEP, errs := plan.EstimateAndPlan(prog, postHints, 1000, estimator, plan.Plan)
+	if len(errs) != 0 {
+		t.Fatalf("estimate plan errors: %v", errs)
+	}
+	pEstimated := findRuleByHead(t, estimateEP, "P")
+	if pEstimated.JoinOrder[0].Literal.Atom.Predicate != "B" {
+		t.Errorf("after EstimateAndPlan: expected B first (size 5 < A=100), got %s; full order=%v",
+			pEstimated.JoinOrder[0].Literal.Atom.Predicate, joinOrderPreds(pEstimated.JoinOrder))
+	}
+	// Confirm the hook actually mutated the caller's hints map.
+	if postHints["B"] != 5 {
+		t.Errorf("expected estimator hook to have mutated hints map in place; got hints[B]=%d", postHints["B"])
+	}
+}
+
+// TestEstimateAndPlan_HonoursBindingCap pins the issue #130 / PR #132
+// invariant: maxBindingsPerRule MUST be threaded through to the
+// estimator hook, not silently dropped en route. If a future refactor
+// drops the parameter (or hard-codes 0), the cap on the pre-pass
+// disappears and pathological trivial IDBs OOM the host before the
+// main eval ever runs (mastodon corpus, setStateUpdaterCallsFn).
+func TestEstimateAndPlan_HonoursBindingCap(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: atom("P", "x"),
+				Body: []datalog.Literal{posLit("A", "x")},
+			},
+		},
+	}
+	const wantCap = 12345
+	var seenCap int
+	hook := func(_ *datalog.Program, _ map[string]int, maxBindings int) map[string]int {
+		seenCap = maxBindings
+		return nil
+	}
+	_, errs := plan.EstimateAndPlan(prog, map[string]int{"A": 1}, wantCap, hook, plan.Plan)
+	if len(errs) != 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+	if seenCap != wantCap {
+		t.Errorf("estimator hook saw maxBindingsPerRule=%d, want %d (PR #132 cap regression)",
+			seenCap, wantCap)
+	}
+}
+
+// TestEstimateAndPlan_NilHookDegradesToPlainPlan ensures the no-fact-DB
+// path (e.g. unit tests) still gets a valid plan even when no estimator
+// is supplied — the hook is optional by design.
+func TestEstimateAndPlan_NilHookDegradesToPlainPlan(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: atom("P", "x"),
+				Body: []datalog.Literal{posLit("A", "x")},
+			},
+		},
+	}
+	ep, errs := plan.EstimateAndPlan(prog, nil, 0, nil, nil)
+	if len(errs) != 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+	if ep == nil || len(ep.Strata) == 0 {
+		t.Fatal("expected a non-empty plan from nil-hook nil-planFn EstimateAndPlan")
+	}
+}
+
+func copyHints(in map[string]int) map[string]int {
+	out := make(map[string]int, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func findRuleByHead(t *testing.T, ep *plan.ExecutionPlan, head string) plan.PlannedRule {
+	t.Helper()
+	for _, s := range ep.Strata {
+		for _, r := range s.Rules {
+			if r.Head.Predicate == head {
+				return r
+			}
+		}
+	}
+	t.Fatalf("no rule with head %q in plan", head)
+	return plan.PlannedRule{}
+}
+
+func joinOrderPreds(steps []plan.JoinStep) []string {
+	out := make([]string, len(steps))
+	for i, s := range steps {
+		out[i] = s.Literal.Atom.Predicate
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Phase 1 of the [planner roadmap](https://github.com/Gjdoalfnrxu/tsq) (full plan: `~/Documents/ObsidianVault/Wiki/Tech/tsq-planner-roadmap-2026-04-18.md`).

Collapses the two-pass plan-then-replan ceremony in `compileAndEval` (`cmd/tsq/main.go:905-945` + the trivial-IDB pre-pass + `RePlanStratum`/`RePlanQuery` loop) into a single `plan.EstimateAndPlan(prog, sizeHints, maxBindings, estimator, planFn)` entry point. Order: estimate trivial IDBs → plan ONCE with full hints. Magic-set inference now sees IDB cardinalities from the very first call instead of needing a re-plan to discover them.

This is a prerequisite for P2a, P2b, and P3a of the roadmap.

## What's added (plan)

- `plan.EstimatorHook` — callback type for the eval-side trivial-IDB pre-pass.
- `plan.Func` — pluggable planner type (`plan.Plan` or magic-set wrapper).
- `plan.EstimateAndPlan(prog, hints, cap, hook, planFn)` — single estimate-then-plan entry point.

## What's added (eval)

- `eval.MakeEstimatorHook(baseRels)` — returns an `EstimatorHook` closure delegating to `EstimateNonRecursiveIDBSizes`. Preserves PR #132's binding cap end-to-end (the cap is a hook signature parameter, not a closed-over constant).

## What's refactored (cmd/tsq)

- `compileAndEval`: now does `compileToProg → EstimateAndPlan → Evaluate`. No more `RePlanStratum`/`RePlanQuery` from this path.
- New `compileToProg` helper splits parse/resolve/desugar/merge out of `buildProgramWithProg` (which now calls `compileToProg` then plans). Dedupes ~30 lines.
- New `makePlanFunc` extracts the magic-set verbose/warn observability so it fires from the `EstimateAndPlan` path too, not just the discarded build-time plan.

## What's intentionally NOT deleted

- **`RePlanStratum` / `RePlanQuery` remain** in `ql/plan/plan.go`. They are load-bearing for `seminaive.go:402-426`'s between-strata refresh of NON-trivial (recursive) IDBs after each stratum's fixpoint — the case the estimator hook by definition cannot pre-compute. The roadmap risk note explicitly carves this out: *"keep the refresh, drop only the redundant outer re-plan."* The redundant outer re-plan (compileAndEval) is gone; the recursive-IDB refresh stays. The roadmap text "delete `RePlanStratum`/`RePlanQuery`" is honoured in spirit (no caller outside seminaive uses them) without throwing away the recursive cardinality refresh path.
- `EstimateNonRecursiveIDBSizes` itself is unchanged; the new path goes through it via `MakeEstimatorHook`.
- `MagicSetOptions.IDBSizeHints` is **not present on main today** — it lives on the held `feat/121-backward-tracker` branch / PR #133. Nothing to delete here. See "Relationship to PR #133" below.

## Plan equivalence (pre/post)

`orderJoins` is deterministic on `(body, hints)`. The new single pass calls `Plan` with hints already populated by the estimator; the old two-pass called `Plan` with base hints, then re-ran `orderJoins` on each rule with the same final hints. Final per-rule `JoinOrder` is identical. Magic-set inference today does not consult IDB sizeHints (those bits land with PR #133), so the augmented program structure is also identical pre/post. End-to-end `TestIssue88_SetStateQueryDoesNotOOM` confirms 3-row parity on the React fixture.

## Tests

- `TestEstimateAndPlan_SinglePassSelectsTinySeed` (planner-layer): asserts the tiny IDB seed is picked on the FIRST plan, not after a `RePlan` call.
- `TestEstimateAndPlan_HonoursBindingCap`: pins the PR #132 cap propagation contract.
- `TestEstimateAndPlan_NilHookDegradesToPlainPlan`: no-fact-DB safety.
- `TestIssue88_SetStateQueryDoesNotOOM`: rewritten to use `EstimateAndPlan` end-to-end. Stronger regression than before — tests the actual production codepath rather than a hand-wired equivalent.
- All existing `RePlanStratum`/`RePlanQuery` unit tests preserved.
- Full `./... -race` suite green.

## Relationship to PR #133

This PR **supersedes the two-pass workaround in PR #133**. The `MagicSetOptions.IDBSizeHints` trust channel that #133 added exists *only* because the two-pass pipeline gives the planner two chances to see hints (documented in `tsq-magic-sets.md` "Phase A.1"). With P1 in place, IDBs are sized BEFORE planning, so the trust channel is unnecessary.

**Recommendation:** close PR #133 once this lands. Its independently-useful bits — the `BackwardTracker.qll` bridge layer, the `SetStateUpdaterTracker` subclass, and the v1→v2 setState query rip-out — should be cherry-picked to a fresh branch on top of P1, *without* re-introducing the `IDBSizeHints` channel. The rule-body binding inference (`InferRuleBindings`) can read `sizeHints` directly, since `EstimateAndPlan`'s pre-pass populates trivial-IDB cardinalities into the same map.

## Adversarial review (self)

- **Plan equivalence on real queries:** `orderJoins` is pure on `(body, hints)`. Final hints map is identical between old and new flows; therefore plans are bit-equivalent. Magic-set rewrite path doesn't read sizeHints today → augmented program is identical. End-to-end issue88 test confirms.
- **Race / re-entrancy via the eval→plan hook:** `EstimateAndPlan` runs estimator synchronously then planner synchronously. No goroutines. Hook closure captures `baseRels` immutably. Clean.
- **Recursive IDB cardinality refresh:** `seminaive.go:402-426` block left intact. Verified by re-running the full eval suite.
- **Magic-set firing parity:** `WithMagicSetAutoOpts` is now invoked exactly once with the post-estimate hints, instead of pre-estimate hints + a no-op RePlan. Inference function doesn't consult `sizeHints` today, so identical bindings inferred.
- **PR #132 binding cap:** preserved as a parameter on the hook signature. New `TestEstimateAndPlan_HonoursBindingCap` pins it.

## Line counts

```
 cmd/tsq/main.go                      | 132 ++++++++++++++++++++-----------
 issue88_setstate_integration_test.go |  38 ++++-----
 ql/eval/estimate.go                  |  17 ++++
 ql/plan/plan.go                      |  92 ++++++++++++++++++++++
 ql/plan/plan_test.go                 | 147 +++++++++++++++++++++++++++++++++++
 5 files changed, 363 insertions(+), 63 deletions(-)
```

Net +300 lines, almost all docstrings + new tests. Production code is roughly net neutral (the `compileAndEval` shrinkage is offset by the new `EstimateAndPlan`/`MakeEstimatorHook`/`makePlanFunc` surface). The deletions promised by the roadmap (the `RePlanStratum`/`RePlanQuery` API) are deferred; see "What's intentionally NOT deleted" above.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `gofmt -l .` clean.
- [x] `go test ./... -race` green.
- [x] `TestIssue88_SetStateQueryDoesNotOOM` — 3-row parity on react-usestate fixture.
- [x] `TestEstimateAndPlan_SinglePassSelectsTinySeed` — tiny seed picked first plan.
- [x] `TestEstimateAndPlan_HonoursBindingCap` — PR #132 cap preserved.
- [x] All magic-set integration tests green.