### PR TITLE
feat(plan,eval): projection pushdown (P3b)

### DIFF
--- a/ql/eval/join.go
+++ b/ql/eval/join.go
@@ -200,6 +200,15 @@ func evalJoinStepsWithDelta(steps []plan.JoinStep, rels map[string]*Relation, de
 	return current, nil
 }
 
+// projectBindingsObserver is a test hook. When non-nil, it is invoked once
+// per output binding produced by projectBindings with the actual key count
+// of that binding. Production code leaves this nil; tests in this package
+// set it via t.Cleanup to observe runtime per-row width and verify that
+// projection actually shrinks bindings (not just that the planner annotates
+// LiveVars correctly). Not safe for concurrent use; tests serialise by
+// virtue of running one Rule call at a time.
+var projectBindingsObserver func(width int)
+
 // projectBindings narrows every binding to only the variables in keep
 // (P3b — projection pushdown). When keep is nil, returns input unchanged
 // so legacy callers building plans by hand (without LiveVars) get the
@@ -237,6 +246,9 @@ func projectBindings(bindings []binding, keep []string) []binding {
 			}
 		}
 		out[i] = nb
+		if projectBindingsObserver != nil {
+			projectBindingsObserver(len(nb))
+		}
 	}
 	return out
 }

--- a/ql/eval/join.go
+++ b/ql/eval/join.go
@@ -141,7 +141,11 @@ func evalJoinSteps(steps []plan.JoinStep, rels map[string]*Relation, initial []b
 			}
 			return nil, err
 		}
-		current = next
+		// P3b: projection pushdown. Drop variables that no later step or
+		// the head/select still needs. Skipped when LiveVars is nil
+		// (legacy hand-built plans) so we don't change semantics for
+		// callers who haven't been through the planner's annotation pass.
+		current = projectBindings(next, step.LiveVars)
 		if err := limits.check(i, len(current)); err != nil {
 			return nil, err
 		}
@@ -187,12 +191,54 @@ func evalJoinStepsWithDelta(steps []plan.JoinStep, rels map[string]*Relation, de
 			}
 			return nil, err
 		}
-		current = next
+		// P3b: see evalJoinSteps.
+		current = projectBindings(next, step.LiveVars)
 		if err := limits.check(i, len(current)); err != nil {
 			return nil, err
 		}
 	}
 	return current, nil
+}
+
+// projectBindings narrows every binding to only the variables in keep
+// (P3b — projection pushdown). When keep is nil, returns input unchanged
+// so legacy callers building plans by hand (without LiveVars) get the
+// pre-P3b behaviour.
+//
+// When keep is non-nil but empty, every binding becomes empty — used at
+// the tail of plans whose head has no vars (e.g. a count-only aggregate
+// rule). This is correct: subsequent users of the binding list (e.g.
+// projectHead) are no-ops on empty bindings whose head also has no vars.
+//
+// The new map is allocated with len(keep) capacity, which is the whole
+// memory win on wide bodies: a 12-var binding probed by a 3-var head
+// shrinks every clone from 12 entries to 3.
+//
+// Special case: if every kept var is already present in the binding AND
+// the binding has exactly len(keep) entries, we still allocate a fresh
+// map — applyPositive's filter fast path shares one binding map across
+// many output rows, so freeing the unused-key slots without a copy
+// would corrupt sibling rows. The cost (one tiny allocation per output)
+// is the price of correctness; net memory still drops because all
+// downstream clones see the smaller map.
+func projectBindings(bindings []binding, keep []string) []binding {
+	if keep == nil {
+		return bindings
+	}
+	if len(bindings) == 0 {
+		return bindings
+	}
+	out := make([]binding, len(bindings))
+	for i, b := range bindings {
+		nb := make(binding, len(keep))
+		for _, k := range keep {
+			if v, ok := b[k]; ok {
+				nb[k] = v
+			}
+		}
+		out[i] = nb
+	}
+	return out
 }
 
 // applyStep applies a single JoinStep to the current set of bindings.

--- a/ql/eval/projection_observer_test.go
+++ b/ql/eval/projection_observer_test.go
@@ -1,0 +1,16 @@
+package eval
+
+// SetProjectBindingsObserver exposes the package-level projectBindings test
+// hook to external (eval_test) test packages. Pass nil to clear. The test
+// is responsible for restoring the previous value (use t.Cleanup with
+// GetProjectBindingsObserver).
+func SetProjectBindingsObserver(fn func(width int)) {
+	projectBindingsObserver = fn
+}
+
+// GetProjectBindingsObserver returns the current observer (may be nil).
+// Tests should snapshot this before SetProjectBindingsObserver and restore
+// it via t.Cleanup.
+func GetProjectBindingsObserver() func(width int) {
+	return projectBindingsObserver
+}

--- a/ql/eval/projection_test.go
+++ b/ql/eval/projection_test.go
@@ -235,6 +235,82 @@ func TestEval_ProjectionPushdown_PeakRowSizeReduction(t *testing.T) {
 		peakOff, observedPeak, plannedPeak, ratio)
 }
 
+// TestEval_ProjectionPushdown_FilterFastPathSiblingIsolation exercises the
+// zero-free-var positive-atom shared-binding-map fast path in applyPositive.
+// When an atom has no free variables (e.g. B(x) with x already bound), the
+// fast path appends the SAME map pointer to many output rows. projectBindings
+// must allocate a fresh map per output to prevent mutation in one row from
+// corrupting siblings.
+//
+// Body shape: R(x) :- A(x), B(x), C(x). A binds x; B and C are pure filters
+// (no free vars at their step). With projection ON, projectBindings runs
+// after each filter step on N rows that all share one source map. A
+// regression to in-place mutation would cause sibling-row corruption,
+// observable as wrong tuple counts vs the projection-off baseline.
+func TestEval_ProjectionPushdown_FilterFastPathSiblingIsolation(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: datalog.Atom{
+					Predicate: "R",
+					Args:      []datalog.Term{datalog.Var{Name: "x"}},
+				},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{datalog.Var{Name: "x"}}}},
+					{Positive: true, Atom: datalog.Atom{Predicate: "B", Args: []datalog.Term{datalog.Var{Name: "x"}}}},
+					{Positive: true, Atom: datalog.Atom{Predicate: "C", Args: []datalog.Term{datalog.Var{Name: "x"}}}},
+				},
+			},
+		},
+	}
+	a := eval.NewRelation("A", 1)
+	b := eval.NewRelation("B", 1)
+	c := eval.NewRelation("C", 1)
+	for i := 0; i < 10; i++ {
+		a.Add(eval.Tuple{eval.IntVal{V: int64(i)}})
+		b.Add(eval.Tuple{eval.IntVal{V: int64(i)}})
+		c.Add(eval.Tuple{eval.IntVal{V: int64(i)}})
+	}
+	rels := map[string]*eval.Relation{"A/1": a, "B/1": b, "C/1": c}
+
+	ep, errs := plan.Plan(prog, map[string]int{"A": 10, "B": 10, "C": 10})
+	if len(errs) != 0 {
+		t.Fatalf("plan: %v", errs)
+	}
+
+	// Projection ON.
+	tuplesOn, err := eval.Rule(context.Background(), ep.Strata[0].Rules[0], rels, 0)
+	if err != nil {
+		t.Fatalf("Rule (projection on): %v", err)
+	}
+
+	// Projection OFF (wipe LiveVars).
+	r2 := ep.Strata[0].Rules[0]
+	for i := range r2.JoinOrder {
+		r2.JoinOrder[i].LiveVars = nil
+	}
+	tuplesOff, err := eval.Rule(context.Background(), r2, rels, 0)
+	if err != nil {
+		t.Fatalf("Rule (projection off): %v", err)
+	}
+
+	if len(tuplesOn) == 0 {
+		t.Fatal("projection on returned no tuples")
+	}
+	if len(tuplesOn) != len(tuplesOff) {
+		t.Fatalf("filter-fast-path sibling corruption: on=%d off=%d", len(tuplesOn), len(tuplesOff))
+	}
+	seen := map[string]bool{}
+	for _, tup := range tuplesOff {
+		seen[fmt.Sprint(tup)] = true
+	}
+	for _, tup := range tuplesOn {
+		if !seen[fmt.Sprint(tup)] {
+			t.Errorf("tuple %v in projection-on but not projection-off — sibling-row corruption suspected", tup)
+		}
+	}
+}
+
 // BenchmarkEval_Chain8_ProjectionOn vs Off — the spec target: at least
 // 2x reduction in peak intermediate row size for a synthetic wide-chain
 // shape with a narrow head.

--- a/ql/eval/projection_test.go
+++ b/ql/eval/projection_test.go
@@ -1,0 +1,238 @@
+package eval_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// makeChainProgram builds a wide chain join `R(x0, xN) :- A0(x0,x1),
+// A1(x1,x2), ..., A{N-1}(x{N-1}, xN)`. Head only references the first
+// and last vars — every intermediate var is "dead" after one hop.
+func makeChainProgram(n int) *datalog.Program {
+	body := make([]datalog.Literal, n)
+	for i := 0; i < n; i++ {
+		body[i] = datalog.Literal{
+			Positive: true,
+			Atom: datalog.Atom{
+				Predicate: fmt.Sprintf("A%d", i),
+				Args: []datalog.Term{
+					datalog.Var{Name: fmt.Sprintf("x%d", i)},
+					datalog.Var{Name: fmt.Sprintf("x%d", i+1)},
+				},
+			},
+		}
+	}
+	return &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: datalog.Atom{
+					Predicate: "R",
+					Args: []datalog.Term{
+						datalog.Var{Name: "x0"},
+						datalog.Var{Name: fmt.Sprintf("x%d", n)},
+					},
+				},
+				Body: body,
+			},
+		},
+	}
+}
+
+// makeChainRelations builds N edge relations where each Ai connects k
+// fan-out values: tuple (i, j) for j in 0..k-1. The total chain output
+// has k^N tuples but the head projects only first/last so the materialised
+// rule output is bounded.
+func makeChainRelations(n, k int) map[string]*eval.Relation {
+	rels := map[string]*eval.Relation{}
+	for i := 0; i < n; i++ {
+		r := eval.NewRelation(fmt.Sprintf("A%d", i), 2)
+		for x := 0; x < k; x++ {
+			for y := 0; y < k; y++ {
+				r.Add(eval.Tuple{eval.IntVal{V: int64(x)}, eval.IntVal{V: int64(y)}})
+			}
+		}
+		rels[fmt.Sprintf("A%d/2", i)] = r
+	}
+	return rels
+}
+
+// TestEval_ProjectionPushdown_ChainProducesCorrectResults: end-to-end
+// equivalence — projection-on must produce the same results as
+// projection-off.
+func TestEval_ProjectionPushdown_ChainProducesCorrectResults(t *testing.T) {
+	const n, k = 3, 4
+	prog := makeChainProgram(n)
+	rels := makeChainRelations(n, k)
+
+	hints := map[string]int{}
+	for i := 0; i < n; i++ {
+		hints[fmt.Sprintf("A%d", i)] = k * k
+	}
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("plan: %v", errs)
+	}
+
+	// Verify LiveVars are populated.
+	steps := ep.Strata[0].Rules[0].JoinOrder
+	for i, s := range steps {
+		if s.LiveVars == nil {
+			t.Errorf("step %d LiveVars nil", i)
+		}
+	}
+
+	tuplesOn, err := eval.Rule(context.Background(), ep.Strata[0].Rules[0], rels, 0)
+	if err != nil {
+		t.Fatalf("Rule (projection on): %v", err)
+	}
+
+	// Now wipe LiveVars and re-evaluate to confirm equivalence.
+	r2 := ep.Strata[0].Rules[0]
+	for i := range r2.JoinOrder {
+		r2.JoinOrder[i].LiveVars = nil
+	}
+	tuplesOff, err := eval.Rule(context.Background(), r2, rels, 0)
+	if err != nil {
+		t.Fatalf("Rule (projection off): %v", err)
+	}
+
+	// Sets must be identical.
+	if len(tuplesOn) != len(tuplesOff) {
+		t.Fatalf("result count differs: on=%d off=%d", len(tuplesOn), len(tuplesOff))
+	}
+	seen := map[string]bool{}
+	for _, tup := range tuplesOff {
+		seen[fmt.Sprint(tup)] = true
+	}
+	for _, tup := range tuplesOn {
+		if !seen[fmt.Sprint(tup)] {
+			t.Errorf("tuple %v in projection-on but not projection-off", tup)
+		}
+	}
+}
+
+// TestEval_ProjectionPushdown_BindingMapShrinks asserts the load-bearing
+// observable contract of P3b: after a mid-chain step, the binding map
+// (per row) carries fewer keys than it would without projection.
+//
+// We instrument via a sentinel: build a chain such that at the join step
+// we want to inspect, the head needs only 2 of 5 bound vars. We can't
+// inspect mid-evaluation directly, but we can compare the LiveVars
+// length to the cumulative-bound length at that step.
+func TestEval_ProjectionPushdown_BindingMapShrinks(t *testing.T) {
+	const n = 5
+	prog := makeChainProgram(n)
+	hints := map[string]int{}
+	for i := 0; i < n; i++ {
+		hints[fmt.Sprintf("A%d", i)] = 100
+	}
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("plan: %v", errs)
+	}
+	steps := ep.Strata[0].Rules[0].JoinOrder
+	// Cumulative bound count after each step:
+	// after A0: {x0,x1} = 2
+	// after A1: {x0,x1,x2} = 3
+	// after A2: {x0,x1,x2,x3} = 4
+	// after A3: {x0..x4} = 5
+	// after A4: {x0..x5} = 6
+	// Head needs {x0, x5} only.
+	// LiveVars after A2 should be {x0} (only x0 bound and survives downstream:
+	// x1 dead; x2 needed by A3; x3 needed by A3; wait — x3 not yet bound at A2).
+	// After A2, bound={x0,x1,x2,x3}. Demand for steps[3..]+head = {x3,x4,x5,x0}.
+	// Intersect: {x0, x3}. So LiveVars at step 2 = {x0, x3} — shrinks 4→2.
+	got := map[string]bool{}
+	for _, v := range steps[2].LiveVars {
+		got[v] = true
+	}
+	if len(got) != 2 || !got["x0"] || !got["x3"] {
+		t.Errorf("step 2 LiveVars want {x0,x3}, got %v", got)
+	}
+	// Without projection, step 2 would carry 4 bound vars. With projection,
+	// only 2 keys per binding map — a 50% shrink at this step alone.
+}
+
+// TestEval_ProjectionPushdown_PeakRowSizeReduction is the spec contract:
+// on a wide chain with a narrow head, peak per-binding row size with
+// projection on must be ≥2x smaller than with projection off.
+//
+// Without projection, the binding at the LAST step carries every var
+// bound so far (x0..xN, N+1 keys). With projection, every step's
+// LiveVars caps the per-row width.
+func TestEval_ProjectionPushdown_PeakRowSizeReduction(t *testing.T) {
+	const n = 8
+	prog := makeChainProgram(n)
+	hints := map[string]int{}
+	for i := 0; i < n; i++ {
+		hints[fmt.Sprintf("A%d", i)] = 100
+	}
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("plan: %v", errs)
+	}
+	steps := ep.Strata[0].Rules[0].JoinOrder
+	// Without projection: per-row width = cumulative bound count after each
+	// step. Peak = (n + 1) at the last step (x0..xN).
+	peakOff := n + 1
+	// With projection: per-row width capped by LiveVars at each step.
+	peakOn := 0
+	for _, s := range steps {
+		if len(s.LiveVars) > peakOn {
+			peakOn = len(s.LiveVars)
+		}
+	}
+	if peakOn == 0 {
+		t.Fatal("LiveVars never populated")
+	}
+	ratio := float64(peakOff) / float64(peakOn)
+	if ratio < 2.0 {
+		t.Errorf("peak row size reduction below 2x target: off=%d on=%d ratio=%.2f",
+			peakOff, peakOn, ratio)
+	}
+	t.Logf("peak per-binding width: off=%d on=%d (%.2fx reduction)", peakOff, peakOn, ratio)
+}
+
+// BenchmarkEval_Chain8_ProjectionOn vs Off — the spec target: at least
+// 2x reduction in peak intermediate row size for a synthetic wide-chain
+// shape with a narrow head.
+func BenchmarkEval_Chain8_ProjectionOn(b *testing.B) {
+	benchChain(b, 8, 5, true)
+}
+
+func BenchmarkEval_Chain8_ProjectionOff(b *testing.B) {
+	benchChain(b, 8, 5, false)
+}
+
+func benchChain(b *testing.B, n, k int, projOn bool) {
+	prog := makeChainProgram(n)
+	hints := map[string]int{}
+	for i := 0; i < n; i++ {
+		hints[fmt.Sprintf("A%d", i)] = k * k
+	}
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		b.Fatalf("plan: %v", errs)
+	}
+	rule := ep.Strata[0].Rules[0]
+	if !projOn {
+		// Strip LiveVars to simulate the pre-P3b world.
+		for i := range rule.JoinOrder {
+			rule.JoinOrder[i].LiveVars = nil
+		}
+	}
+	rels := makeChainRelations(n, k)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := eval.Rule(context.Background(), rule, rels, 0)
+		if err != nil {
+			b.Fatalf("Rule: %v", err)
+		}
+	}
+}

--- a/ql/eval/projection_test.go
+++ b/ql/eval/projection_test.go
@@ -162,40 +162,77 @@ func TestEval_ProjectionPushdown_BindingMapShrinks(t *testing.T) {
 // on a wide chain with a narrow head, peak per-binding row size with
 // projection on must be ≥2x smaller than with projection off.
 //
-// Without projection, the binding at the LAST step carries every var
-// bound so far (x0..xN, N+1 keys). With projection, every step's
-// LiveVars caps the per-row width.
+// We instrument projectBindings via a package-level test hook to observe
+// the actual runtime width of every output binding produced under the
+// projection regime. This proves the *implementation* honours the plan
+// (a buggy projectBindings that ignored keep, or a buggy planner that
+// over-shrunk LiveVars and broke evaluation, would both surface here)
+// rather than asserting a property of LiveVars talking to itself.
 func TestEval_ProjectionPushdown_PeakRowSizeReduction(t *testing.T) {
-	const n = 8
+	const n, k = 8, 3
 	prog := makeChainProgram(n)
 	hints := map[string]int{}
 	for i := 0; i < n; i++ {
-		hints[fmt.Sprintf("A%d", i)] = 100
+		hints[fmt.Sprintf("A%d", i)] = k * k
 	}
 	ep, errs := plan.Plan(prog, hints)
 	if len(errs) != 0 {
 		t.Fatalf("plan: %v", errs)
 	}
 	steps := ep.Strata[0].Rules[0].JoinOrder
-	// Without projection: per-row width = cumulative bound count after each
-	// step. Peak = (n + 1) at the last step (x0..xN).
-	peakOff := n + 1
-	// With projection: per-row width capped by LiveVars at each step.
-	peakOn := 0
+
+	// Planner-side ceiling: max LiveVars across steps. The runtime peak
+	// per-binding width must not exceed this.
+	plannedPeak := 0
 	for _, s := range steps {
-		if len(s.LiveVars) > peakOn {
-			peakOn = len(s.LiveVars)
+		if len(s.LiveVars) > plannedPeak {
+			plannedPeak = len(s.LiveVars)
 		}
 	}
-	if peakOn == 0 {
-		t.Fatal("LiveVars never populated")
+	if plannedPeak == 0 {
+		t.Fatal("LiveVars never populated by planner")
 	}
-	ratio := float64(peakOff) / float64(peakOn)
+
+	// Without projection: per-row width = cumulative bound count after the
+	// last step = n + 1 (x0..xN). This is the baseline we shrink against.
+	peakOff := n + 1
+
+	// Install observer to capture the actual runtime peak per-binding width.
+	observedPeak := 0
+	prev := eval.GetProjectBindingsObserver()
+	eval.SetProjectBindingsObserver(func(width int) {
+		if width > observedPeak {
+			observedPeak = width
+		}
+	})
+	t.Cleanup(func() { eval.SetProjectBindingsObserver(prev) })
+
+	rels := makeChainRelations(n, k)
+	if _, err := eval.Rule(context.Background(), ep.Strata[0].Rules[0], rels, 0); err != nil {
+		t.Fatalf("Rule: %v", err)
+	}
+
+	if observedPeak == 0 {
+		t.Fatal("projectBindings never invoked — projection pushdown not active")
+	}
+	// Implementation honours the plan: every output binding fits within
+	// the planner's LiveVars ceiling.
+	if observedPeak > plannedPeak {
+		t.Errorf("runtime per-binding width exceeds planner ceiling: observed=%d planned=%d",
+			observedPeak, plannedPeak)
+	}
+	// Projection actually shrinks runtime bindings vs the unprojected baseline.
+	if observedPeak >= peakOff {
+		t.Errorf("projection failed to shrink bindings: observed=%d off-baseline=%d",
+			observedPeak, peakOff)
+	}
+	ratio := float64(peakOff) / float64(observedPeak)
 	if ratio < 2.0 {
-		t.Errorf("peak row size reduction below 2x target: off=%d on=%d ratio=%.2f",
-			peakOff, peakOn, ratio)
+		t.Errorf("peak row size reduction below 2x target: off=%d observed=%d ratio=%.2f",
+			peakOff, observedPeak, ratio)
 	}
-	t.Logf("peak per-binding width: off=%d on=%d (%.2fx reduction)", peakOff, peakOn, ratio)
+	t.Logf("peak per-binding width: off=%d observed=%d planned=%d (%.2fx reduction)",
+		peakOff, observedPeak, plannedPeak, ratio)
 }
 
 // BenchmarkEval_Chain8_ProjectionOn vs Off — the spec target: at least

--- a/ql/plan/join.go
+++ b/ql/plan/join.go
@@ -263,6 +263,114 @@ func pickTinySeed(
 	return tinyIdx
 }
 
+// computeLiveVars fills in the LiveVars field of every step in `steps`.
+//
+// For step i, LiveVars is the sorted-deduped set of variable names that:
+//   - are bound by step i or some earlier step (so they actually exist
+//     in the binding when this step finishes), AND
+//   - are referenced by steps[i+1..end] OR finalKeep (the rule head
+//     vars, or the query's Select vars).
+//
+// Restricting to "actually bound by now" makes LiveVars precise — it
+// reports the vars the projectBindings call will retain, not a
+// superset. Vars not yet bound aren't in the binding to drop.
+//
+// finalKeep is allowed to be nil — the rule body whose head has no live
+// vars (e.g. count-only aggregate) projects to empty after the last
+// step. Pass an empty slice to mean "drop everything after the last
+// step" explicitly; nil and empty are treated identically.
+//
+// Algorithm: a single right-to-left pass builds the demand set
+// (everything still needed at or after the cut), then a left-to-right
+// pass tracks the cumulative bound set and intersects.
+func computeLiveVars(steps []JoinStep, finalKeep []string) {
+	if len(steps) == 0 {
+		return
+	}
+	n := len(steps)
+	// demand[i] = vars referenced by steps[i+1..n-1] union finalKeep.
+	demand := make([]map[string]bool, n)
+	post := map[string]bool{}
+	for _, v := range finalKeep {
+		if v != "" && v != "_" {
+			post[v] = true
+		}
+	}
+	for i := n - 1; i >= 0; i-- {
+		// demand[i] = post (snapshot — vars needed AFTER step i).
+		d := make(map[string]bool, len(post))
+		for v := range post {
+			d[v] = true
+		}
+		demand[i] = d
+		for _, v := range varsInLiteral(steps[i].Literal) {
+			if v != "" && v != "_" {
+				post[v] = true
+			}
+		}
+	}
+	// Left-to-right pass: track bound set, intersect with demand.
+	bound := map[string]bool{}
+	for i := 0; i < n; i++ {
+		for _, v := range varsInLiteral(steps[i].Literal) {
+			if v != "" && v != "_" {
+				bound[v] = true
+			}
+		}
+		live := make([]string, 0)
+		for v := range demand[i] {
+			if bound[v] {
+				live = append(live, v)
+			}
+		}
+		// Make non-nil even when empty (signals "projection enabled,
+		// keep nothing"). nil is reserved for legacy hand-built plans.
+		if live == nil {
+			live = []string{}
+		}
+		steps[i].LiveVars = sortStrings(live)
+	}
+}
+
+// sortStrings returns the input slice sorted in place. Small slices, so
+// insertion sort avoids importing the sort package and matches the style
+// of sortUniqueInts in backward.go.
+func sortStrings(xs []string) []string {
+	for i := 1; i < len(xs); i++ {
+		for j := i; j > 0 && xs[j-1] > xs[j]; j-- {
+			xs[j-1], xs[j] = xs[j], xs[j-1]
+		}
+	}
+	return xs
+}
+
+// headVars returns the variable names referenced by an Atom's args, in
+// stable order, deduplicated. Used as finalKeep for rule bodies.
+func headVars(a datalog.Atom) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, arg := range a.Args {
+		if v, ok := arg.(datalog.Var); ok && v.Name != "_" && !seen[v.Name] {
+			seen[v.Name] = true
+			out = append(out, v.Name)
+		}
+	}
+	return out
+}
+
+// selectVars returns the variable names referenced by query Select terms.
+func selectVars(sel []datalog.Term) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, t := range sel {
+		if v, ok := t.(datalog.Var); ok && v.Name != "_" && !seen[v.Name] {
+			seen[v.Name] = true
+			out = append(out, v.Name)
+		}
+	}
+	return out
+}
+
 // orderJoins implements greedy join ordering for a rule body.
 //
 // Selection rule per slot:

--- a/ql/plan/join.go
+++ b/ql/plan/join.go
@@ -317,16 +317,13 @@ func computeLiveVars(steps []JoinStep, finalKeep []string) {
 				bound[v] = true
 			}
 		}
-		live := make([]string, 0)
+		// Allocate non-nil empty slice so "projection enabled, keep
+		// nothing" is distinguishable from nil ("legacy, no projection").
+		live := make([]string, 0, len(demand[i]))
 		for v := range demand[i] {
 			if bound[v] {
 				live = append(live, v)
 			}
-		}
-		// Make non-nil even when empty (signals "projection enabled,
-		// keep nothing"). nil is reserved for legacy hand-built plans.
-		if live == nil {
-			live = []string{}
 		}
 		steps[i].LiveVars = sortStrings(live)
 	}

--- a/ql/plan/plan.go
+++ b/ql/plan/plan.go
@@ -51,6 +51,29 @@ type JoinStep struct {
 	// Note: IsFilter=true on a negative literal (Literal.Positive==false) means anti-join,
 	// not positive membership filter. Callers must check Literal.Positive to distinguish.
 	IsFilter bool
+	// LiveVars is the projection-pushdown frontier (P3b): the sorted, deduped
+	// set of variable names that downstream steps OR the rule head/query
+	// select still need. After this step's bindings are computed, the
+	// evaluator may drop every variable NOT in LiveVars from each binding —
+	// shrinking the per-binding map for every subsequent clone(). On wide
+	// rule bodies (long taint chains) this dramatically reduces peak
+	// intermediate memory.
+	//
+	// Semantics:
+	//   - nil means "no projection — keep all currently-bound vars". This
+	//     is the safe default for hand-built plans (legacy callers who
+	//     construct ExecutionPlans in tests without going through Plan()).
+	//   - Empty non-nil slice means "drop everything not strictly required
+	//     for the head". For the last step of a head-projecting rule body,
+	//     this equals the head var set.
+	//   - The slice is sorted and deduplicated.
+	//
+	// The list contains the vars to KEEP, not to drop — kept (not dropped)
+	// because the kept set is typically smaller and easier to reason about
+	// in tests.
+	//
+	// Computed by computeLiveVars after greedy ordering completes.
+	LiveVars []string
 }
 
 // PlannedAggregate is an aggregate to evaluate after the stratum fixpoint.
@@ -283,6 +306,10 @@ func Plan(prog *datalog.Program, sizeHints map[string]int) (*ExecutionPlan, []er
 		for _, rule := range stratum {
 			headDemand := demand[rule.Head.Predicate]
 			order := orderJoinsWithDemand(rule.Head, rule.Body, sizeHints, headDemand)
+			// P3b: annotate each step with the demand frontier so the
+			// evaluator can drop unused columns from intermediate
+			// bindings.
+			computeLiveVars(order, headVars(rule.Head))
 			ps.Rules = append(ps.Rules, PlannedRule{
 				Head:      rule.Head,
 				Body:      rule.Body,
@@ -305,6 +332,7 @@ func Plan(prog *datalog.Program, sizeHints map[string]int) (*ExecutionPlan, []er
 	// Plan the query.
 	if prog.Query != nil {
 		order := orderJoins(prog.Query.Body, sizeHints)
+		computeLiveVars(order, selectVars(prog.Query.Select))
 		ep.Query = &PlannedQuery{
 			Select:    prog.Query.Select,
 			JoinOrder: order,
@@ -340,6 +368,7 @@ func RePlanStratum(s *Stratum, sizeHints map[string]int) {
 			continue
 		}
 		s.Rules[i].JoinOrder = orderJoins(body, sizeHints)
+		computeLiveVars(s.Rules[i].JoinOrder, headVars(s.Rules[i].Head))
 	}
 }
 
@@ -368,6 +397,7 @@ func RePlanStratumWithDemand(s *Stratum, sizeHints map[string]int, demand Demand
 		}
 		headDemand := demand[s.Rules[i].Head.Predicate]
 		s.Rules[i].JoinOrder = orderJoinsWithDemand(s.Rules[i].Head, body, sizeHints, headDemand)
+		computeLiveVars(s.Rules[i].JoinOrder, headVars(s.Rules[i].Head))
 	}
 }
 
@@ -388,6 +418,7 @@ func RePlanQuery(q *PlannedQuery, sizeHints map[string]int) {
 		body[i] = step.Literal
 	}
 	q.JoinOrder = orderJoins(body, sizeHints)
+	computeLiveVars(q.JoinOrder, selectVars(q.Select))
 }
 
 // collectGroupByVars returns the head variables that are not the aggregate result variable.

--- a/ql/plan/projection_test.go
+++ b/ql/plan/projection_test.go
@@ -1,0 +1,418 @@
+package plan_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// liveVarsAt returns the LiveVars at step i of the first rule's plan, as a
+// set for stable comparison.
+func liveVarsAt(t *testing.T, ep *plan.ExecutionPlan, i int) map[string]bool {
+	t.Helper()
+	if len(ep.Strata) == 0 || len(ep.Strata[0].Rules) == 0 {
+		t.Fatal("no rules in plan")
+	}
+	r := ep.Strata[0].Rules[0]
+	if i < 0 || i >= len(r.JoinOrder) {
+		t.Fatalf("step %d out of range (have %d steps)", i, len(r.JoinOrder))
+	}
+	out := map[string]bool{}
+	for _, v := range r.JoinOrder[i].LiveVars {
+		out[v] = true
+	}
+	return out
+}
+
+func eqSet(a map[string]bool, want ...string) bool {
+	if len(a) != len(want) {
+		return false
+	}
+	for _, w := range want {
+		if !a[w] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestProjectionPushdown_ChainJoin is the load-bearing test from the spec.
+//
+// Body: A(x,y), B(y,z), C(z,w). Head: R(x,w).
+// After step 1 (A⨝B), only {x, z} should survive (y is dead).
+// After step 2 (joining C), only {x, w} should survive (z is dead).
+// After step 3 (last step), only {x, w} (the head vars).
+func TestProjectionPushdown_ChainJoin(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("R", "x", "w"),
+				posLit("A", "x", "y"),
+				posLit("B", "y", "z"),
+				posLit("C", "z", "w"),
+			),
+		},
+	}
+	// Equal sizeHints so greedy ordering picks them in source order.
+	hints := map[string]int{"A": 100, "B": 100, "C": 100}
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+	r := ep.Strata[0].Rules[0]
+	if len(r.JoinOrder) != 3 {
+		t.Fatalf("want 3 steps, got %d", len(r.JoinOrder))
+	}
+	// Order is A, B, C (greedy sticks with source on equal hints).
+	if got := r.JoinOrder[0].Literal.Atom.Predicate; got != "A" {
+		t.Fatalf("step 0 want A, got %s", got)
+	}
+	if got := r.JoinOrder[1].Literal.Atom.Predicate; got != "B" {
+		t.Fatalf("step 1 want B, got %s", got)
+	}
+	if got := r.JoinOrder[2].Literal.Atom.Predicate; got != "C" {
+		t.Fatalf("step 2 want C, got %s", got)
+	}
+	// After A: B needs y,z; C needs z,w; head needs x,w. Live = {x,y}? No —
+	// we want what survives AFTER step 0. B uses {y,z} so y is needed; head
+	// needs x, C needs {z,w}. So after A, live = {x, y} (z and w not yet
+	// bound but referenced by later steps; we keep what's bound — only
+	// x and y are bound at this point AND in the demand set).
+	// LiveVars is the set of CURRENTLY-BOUND vars to KEEP. After step 0, y
+	// must survive because B needs it; x must survive because head needs it.
+	// z, w are not yet bound — they only enter the binding when their step
+	// runs. So after step 0: live = {x, y}.
+	if got := liveVarsAt(t, ep, 0); !eqSet(got, "x", "y") {
+		t.Errorf("after step 0 (A): want {x,y}, got %v", got)
+	}
+	// After step 1 (A⨝B): bindings hold {x, y, z}. Downstream (C, head)
+	// needs {z, w} ∪ {x, w} = {x, z, w}. y is now dead (not in C, not in
+	// head). So keep {x, z}.
+	if got := liveVarsAt(t, ep, 1); !eqSet(got, "x", "z") {
+		t.Errorf("after step 1 (B): want {x,z}, got %v", got)
+	}
+	// After step 2 (last step): only head vars {x, w}.
+	if got := liveVarsAt(t, ep, 2); !eqSet(got, "x", "w") {
+		t.Errorf("after step 2 (C): want {x,w}, got %v", got)
+	}
+}
+
+// TestProjectionPushdown_StarJoin: star-shape, all branches share a hub var.
+// Body: A(h,x), B(h,y), C(h,z). Head: R(x,y,z).
+// All three use h, but head doesn't. So h survives intermediate steps but
+// is dropped at the end.
+func TestProjectionPushdown_StarJoin(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("R", "x", "y", "z"),
+				posLit("A", "h", "x"),
+				posLit("B", "h", "y"),
+				posLit("C", "h", "z"),
+			),
+		},
+	}
+	hints := map[string]int{"A": 100, "B": 100, "C": 100}
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+	_ = ep.Strata[0].Rules[0]
+	// After step 0 (A): bound = {h, x}. Downstream needs h (B,C),
+	// y/z (head, B, C), x (head). So keep {h, x}.
+	if got := liveVarsAt(t, ep, 0); !eqSet(got, "h", "x") {
+		t.Errorf("after step 0: want {h,x}, got %v", got)
+	}
+	// After step 1 (B): bound = {h, x, y}. Downstream needs h (C),
+	// z (head, C), x and y (head). Keep {h, x, y}.
+	if got := liveVarsAt(t, ep, 1); !eqSet(got, "h", "x", "y") {
+		t.Errorf("after step 1: want {h,x,y}, got %v", got)
+	}
+	// After step 2 (last): head = {x,y,z}. h is dropped.
+	if got := liveVarsAt(t, ep, 2); !eqSet(got, "x", "y", "z") {
+		t.Errorf("after step 2: want {x,y,z}, got %v", got)
+	}
+}
+
+// TestProjectionPushdown_HeadEqualsAllBodyVars: when head names every body
+// var, the final-step LiveVars equals all bound vars and projection cannot
+// drop anything at the last step.
+func TestProjectionPushdown_HeadEqualsAllBodyVars(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("R", "x", "y", "z"),
+				posLit("A", "x", "y"),
+				posLit("B", "y", "z"),
+			),
+		},
+	}
+	ep, errs := plan.Plan(prog, map[string]int{"A": 100, "B": 100})
+	if len(errs) != 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+	// Last step LiveVars = {x,y,z}.
+	last := ep.Strata[0].Rules[0].JoinOrder[1]
+	gotLast := map[string]bool{}
+	for _, v := range last.LiveVars {
+		gotLast[v] = true
+	}
+	if !eqSet(gotLast, "x", "y", "z") {
+		t.Errorf("last step LiveVars want {x,y,z}, got %v", gotLast)
+	}
+}
+
+// TestProjectionPushdown_SingleStepBody: body of length 1 — last (and only)
+// step's LiveVars = head vars.
+func TestProjectionPushdown_SingleStepBody(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("R", "x"), posLit("A", "x", "y")),
+		},
+	}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+	got := ep.Strata[0].Rules[0].JoinOrder[0].LiveVars
+	if !reflect.DeepEqual(got, []string{"x"}) {
+		t.Errorf("single-step LiveVars want [x], got %v", got)
+	}
+}
+
+// TestProjectionPushdown_ComparisonDropsOperandAfter: comparison filter
+// uses operand vars at its step, but if neither operand is referenced
+// downstream, both are dropped after.
+func TestProjectionPushdown_ComparisonDropsOperandAfter(t *testing.T) {
+	// R(x) :- A(x,y), C(z,x), y = z.
+	// Greedy ordering will likely place A first (no bound vars), then C
+	// (shares x), then the comparison (both operands now bound). After cmp
+	// (last step), only x survives.
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("R", "x"),
+				posLit("A", "x", "y"),
+				posLit("C", "z", "x"),
+				cmpLit("=", "y", "z"),
+			),
+		},
+	}
+	hints := map[string]int{"A": 100, "C": 100}
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+	r := ep.Strata[0].Rules[0]
+	// Find the comparison step.
+	cmpIdx := -1
+	for i, s := range r.JoinOrder {
+		if s.Literal.Cmp != nil {
+			cmpIdx = i
+		}
+	}
+	if cmpIdx < 0 {
+		t.Fatalf("could not find comparison step in %+v", r.JoinOrder)
+	}
+	// After the comparison step, neither y nor z should remain in LiveVars
+	// — they are pure filter operands once consumed by the comparison and
+	// nothing downstream (or the head, which is just {x}) needs them.
+	cmpLive := map[string]bool{}
+	for _, v := range r.JoinOrder[cmpIdx].LiveVars {
+		cmpLive[v] = true
+	}
+	if cmpLive["y"] {
+		t.Errorf("after comparison step, y should be dropped; got %v", cmpLive)
+	}
+	if cmpLive["z"] {
+		t.Errorf("after comparison step, z should be dropped; got %v", cmpLive)
+	}
+}
+
+// TestProjectionPushdown_NegationKeepsVarsAtItsStep: a negative literal
+// requires its vars at evaluation time, so they must be in the live set
+// at the step IMMEDIATELY before it. After the negation runs, if no
+// further step needs them, they may be dropped.
+func TestProjectionPushdown_NegationKeepsVarsAtItsStep(t *testing.T) {
+	// R(x) :- A(x,y), B(x,z), !N(y,z).
+	// !N requires y,z bound — so steps before !N must keep y, z.
+	// After !N (last step), only x survives.
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("R", "x"),
+				posLit("A", "x", "y"),
+				posLit("B", "x", "z"),
+				negLit("N", "y", "z"),
+			),
+		},
+	}
+	hints := map[string]int{"A": 100, "B": 100, "N": 100}
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+	r := ep.Strata[0].Rules[0]
+	if len(r.JoinOrder) != 3 {
+		t.Fatalf("want 3 steps, got %d", len(r.JoinOrder))
+	}
+	// The negation must be last (its vars y and z are bound by A and B).
+	if r.JoinOrder[2].Literal.Positive {
+		t.Fatalf("expected negative literal last, got %+v", r.JoinOrder[2].Literal)
+	}
+	// Before negation runs (i.e. LiveVars at step 1, the second positive
+	// atom), y and z must both be live.
+	live1 := map[string]bool{}
+	for _, v := range r.JoinOrder[1].LiveVars {
+		live1[v] = true
+	}
+	if !live1["y"] || !live1["z"] {
+		t.Errorf("step 1 must keep y and z for downstream negation; got %v", live1)
+	}
+	// After the negation (last step), only head vars.
+	last := r.JoinOrder[2].LiveVars
+	if !reflect.DeepEqual(last, []string{"x"}) {
+		t.Errorf("last step LiveVars want [x], got %v", last)
+	}
+}
+
+// TestProjectionPushdown_AggregateInBodyDoesNotCrash: an aggregate literal
+// in the rule body is a no-op at the per-step join level (its own body is
+// evaluated separately by Aggregate()). Projection pushdown must not
+// crash on it. The aggregate's result var is not bound by the join step
+// itself — it enters via the result-relation channel — so it does not
+// appear in LiveVars from the projection's perspective. The point of
+// this test is that varsInLiteral handles agg literals safely and
+// computeLiveVars produces a stable plan.
+func TestProjectionPushdown_AggregateInBodyDoesNotCrash(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("R", "c"),
+				posLit("A", "x"),
+				aggLit("count", "A", "x", "c"),
+			),
+		},
+	}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+	r := ep.Strata[0].Rules[0]
+	for i, step := range r.JoinOrder {
+		if step.LiveVars == nil {
+			t.Errorf("step %d LiveVars is nil — projection pushdown skipped", i)
+		}
+	}
+}
+
+// TestProjectionPushdown_QuerySelectVarsHonoured: query Select determines
+// the final LiveVars of the query plan.
+func TestProjectionPushdown_QuerySelectVarsHonoured(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("R", "x", "y"), posLit("A", "x", "y")),
+		},
+		Query: &datalog.Query{
+			Select: []datalog.Term{datalog.Var{Name: "x"}},
+			Body:   []datalog.Literal{posLit("R", "x", "y")},
+		},
+	}
+	ep, errs := plan.Plan(prog, nil)
+	if len(errs) != 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+	if ep.Query == nil || len(ep.Query.JoinOrder) == 0 {
+		t.Fatal("no query plan")
+	}
+	last := ep.Query.JoinOrder[len(ep.Query.JoinOrder)-1].LiveVars
+	if !reflect.DeepEqual(last, []string{"x"}) {
+		t.Errorf("query last-step LiveVars want [x], got %v", last)
+	}
+}
+
+// TestProjectionPushdown_RecursiveRule: recursive rule (Path) — projection
+// must respect that recursive references count as downstream literals.
+// Path(x,z) :- Path(x,y), Edge(y,z). Head needs x,z.
+// After Path step (assume it's first): bound {x,y}; downstream Edge needs
+// y,z; head needs x,z. So live = {x,y}.
+// After Edge: head only — {x,z}.
+func TestProjectionPushdown_RecursiveRule(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("Path", "x", "z"),
+				posLit("Path", "x", "y"),
+				posLit("Edge", "y", "z"),
+			),
+		},
+	}
+	hints := map[string]int{"Path": 100, "Edge": 100}
+	ep, errs := plan.Plan(prog, hints)
+	if len(errs) != 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+	r := ep.Strata[0].Rules[0]
+	if len(r.JoinOrder) != 2 {
+		t.Fatalf("want 2 steps, got %d", len(r.JoinOrder))
+	}
+	// Last step: head vars only.
+	last := r.JoinOrder[1].LiveVars
+	gotLast := map[string]bool{}
+	for _, v := range last {
+		gotLast[v] = true
+	}
+	if !eqSet(gotLast, "x", "z") {
+		t.Errorf("last LiveVars want {x,z}, got %v", gotLast)
+	}
+}
+
+// TestProjectionPushdown_LiveVarsSorted: LiveVars must be sorted-deduped
+// for plan equality and reproducibility.
+func TestProjectionPushdown_LiveVarsSorted(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("R", "z", "a", "m"),
+				posLit("A", "z", "a"),
+				posLit("B", "a", "m"),
+			),
+		},
+	}
+	ep, errs := plan.Plan(prog, map[string]int{"A": 10, "B": 10})
+	if len(errs) != 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+	for i, step := range ep.Strata[0].Rules[0].JoinOrder {
+		for j := 1; j < len(step.LiveVars); j++ {
+			if step.LiveVars[j-1] > step.LiveVars[j] {
+				t.Errorf("step %d LiveVars not sorted: %v", i, step.LiveVars)
+			}
+			if step.LiveVars[j-1] == step.LiveVars[j] {
+				t.Errorf("step %d LiveVars has duplicate: %v", i, step.LiveVars)
+			}
+		}
+	}
+}
+
+// TestProjectionPushdown_RePlanStratumPreservesLiveVars: between-strata
+// refresh must re-annotate LiveVars; otherwise stale plans would fall
+// back to no-projection semantics.
+func TestProjectionPushdown_RePlanStratumPreservesLiveVars(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			rule(atom("R", "x"),
+				posLit("A", "x", "y"),
+				posLit("B", "y", "z"),
+			),
+		},
+	}
+	ep, errs := plan.Plan(prog, map[string]int{"A": 100, "B": 100})
+	if len(errs) != 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+	// Wipe LiveVars to simulate a stale plan, then re-plan.
+	for i := range ep.Strata[0].Rules[0].JoinOrder {
+		ep.Strata[0].Rules[0].JoinOrder[i].LiveVars = nil
+	}
+	plan.RePlanStratum(&ep.Strata[0], map[string]int{"A": 100, "B": 100})
+	for i, step := range ep.Strata[0].Rules[0].JoinOrder {
+		if step.LiveVars == nil {
+			t.Errorf("step %d LiveVars nil after RePlanStratum", i)
+		}
+	}
+}


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Motivation

`binding.clone()` was 89% of inuse memory on the mastodon corpus per `tsq-query-perf-pathology.md`. Most cloned vars are dead: a long taint chain `A(x0,x1), A(x1,x2), ..., A(xN-1,xN)` with head `R(x0,xN)` carries every intermediate `xi` through every later step's clone, even though only `x0` and the latest `xi+1` are ever read again.

P3b is the standard relational-algebra projection pushdown: drop unused columns from intermediate relations as early as possible.

## Design

**Planner (`ql/plan`)**
- `JoinStep` gains `LiveVars []string` — the sorted-deduped set of variable names that are bound by step ≤ i AND referenced by step > i OR the rule head OR the query Select.
- `computeLiveVars` runs at the end of every plan path: `Plan`, `RePlanStratum`, `RePlanStratumWithDemand`, `RePlanQuery`.
- Algorithm: right-to-left pass builds the demand set (vars needed at or after each cut); left-to-right pass intersects with the cumulative bound set so `LiveVars` precisely matches what the projection step will retain — no entry that isn't in the binding to drop.
- `LiveVars=nil` reserved for hand-built plans (back-compat for tests that construct `ExecutionPlan` directly without going through `Plan()`); evaluator treats `nil` as "skip projection".

**Evaluator (`ql/eval`)**
- `projectBindings` narrows each binding map to `LiveVars` after every step in `evalJoinSteps` and `evalJoinStepsWithDelta`.
- Always allocates fresh maps — `applyPositive`'s filter fast path shares one binding across multiple output rows, so in-place narrowing would corrupt siblings. Allocation cost is dwarfed by the downstream `clone()` savings on wide bodies.

## Measurement contract

**Per-binding row width (the load-bearing observable):**

| Shape | Off | On | Reduction |
|---|---|---|---|
| 8-atom chain, head `R(x0,x8)` | 9 keys peak | 2 keys peak | **4.5x** |

Asserted in `TestEval_ProjectionPushdown_PeakRowSizeReduction` — guards the spec target (≥2x).

**End-to-end equivalence** (`TestEval_ProjectionPushdown_ChainProducesCorrectResults`): projection-on results equal projection-off results on a 3-deep chain with k=4 fan-out.

**Per-step shrink** (`TestEval_ProjectionPushdown_BindingMapShrinks`): on a 5-atom chain, step 2's `LiveVars` shrinks 4 bound vars → 2 (50% at that step alone).

**Bench** (`go test ./ql/eval -bench BenchmarkEval_Chain8 -benchmem`):

```
BenchmarkEval_Chain8_ProjectionOn-2     2929926059 ns/op  2181988952 B/op  16602253 allocs/op
BenchmarkEval_Chain8_ProjectionOff-2    3110328240 ns/op  2469326440 B/op  13680213 allocs/op
```

Bytes/op down 12%, wall time down 6%. Allocs/op up 21% (extra map allocations) — net memory still wins because every kept map is smaller. The bench shape (k=5, n=8, k^9 ≈ 2M output rows) is dominated by output-row materialisation, so the per-row width win is partially masked at the aggregate level. The per-row contract test gives the clean 4.5x measurement.

## Tests

- Chain join `A(x,y),B(y,z),C(z,w) :- R(x,w)` — asserts intermediates drop `y` after step 1, drop `z` after step 2 (the spec example).
- Star join — hub var dropped at the head step.
- Single-step body — `LiveVars` = head vars.
- Comparison — operand vars dropped after the cmp step when nothing downstream needs them.
- Negation — vars kept at the step before a negative literal so the probe sees them.
- Aggregate in body — `LiveVars` populated, no crash.
- Query `Select` — last query step's `LiveVars` matches the Select var set.
- Recursive rule (`Path :- Path, Edge`) — last step `LiveVars = head vars`, recursion not broken.
- Sortedness/dedup invariant.
- `RePlanStratum` re-annotates `LiveVars` after stale wipe.
- End-to-end equivalence on/off.
- Per-step binding-width shrink.
- ≥2x peak row-size reduction (4.5x measured).

`go test ./... -race` green. `go vet ./...` clean.

## Explicit deferrals

- **No backward-inference changes** (out of scope for P3b).
- **No eval-engine join-algo changes** — projection happens AFTER each step's `applyStep`, the join itself is unchanged.
- **No flag** — projection is default-on for any plan whose `LiveVars` is non-nil. Hand-built plans without annotation get the pre-P3b path.
- **No Mastodon bench** in this PR — the synthetic 8-chain validates the contract; corpus measurement is a separate task per phase carve-out.
- **No allocation pooling** for the new binding maps. The simple "allocate fresh" approach trades allocs for correctness; if `allocs/op` becomes a hotspot, a `sync.Pool` for binding maps is a clean follow-up.
- **Aggregate inner-body vars** — `varsInLiteral` for an `Agg` literal returns only the result var (the agg's body is evaluated in its own pipeline). This is correct for current aggregate semantics but a future "aggregate over outer-bound vars" feature would need to extend the demand frontier.