### PR TITLE
fix(desugar): inject class-type constraint for predicate parameters

### DIFF
--- a/ql/desugar/desugar.go
+++ b/ql/desugar/desugar.go
@@ -541,8 +541,28 @@ func (d *desugarer) desugarTopLevelPredicate(pd *ast.PredicateDecl) []datalog.Ru
 	}
 
 	var body []datalog.Literal
+
+	// Type constraints for each typed parameter. This anchors the planner's
+	// joins on the class extent, mirroring how `from` and `exists` decls inject
+	// their type literal (see desugarSelect / desugarExists). Without this,
+	// `predicate p(UseStateSetterCall c) { ... }` would leave `c` untyped and
+	// the planner has no extent to seed from.
+	for _, param := range pd.Params {
+		typeName := param.Type.String()
+		if typeName == "" || isPrimitive(typeName) {
+			continue
+		}
+		body = append(body, datalog.Literal{
+			Positive: true,
+			Atom: datalog.Atom{
+				Predicate: typeName,
+				Args:      []datalog.Term{datalog.Var{Name: param.Name}},
+			},
+		})
+	}
+
 	if pd.Body != nil {
-		body = d.desugarFormula(*pd.Body, gen)
+		body = append(body, d.desugarFormula(*pd.Body, gen)...)
 	}
 
 	return []datalog.Rule{{Head: head, Body: body}}

--- a/ql/desugar/desugar_test.go
+++ b/ql/desugar/desugar_test.go
@@ -671,6 +671,13 @@ predicate p(int c) { c = c }
 			t.Fatalf("int-typed param should not produce an `int(...)` literal, body: %v", r.Body)
 		}
 	}
+	// Stronger guard: body must contain exactly the user-written `c = c`
+	// comparison and nothing else. If a future change ever emitted
+	// synthetic literals for primitive params (e.g. `int(c)`), body length
+	// would grow and this assertion would fire.
+	if len(r.Body) != 1 {
+		t.Fatalf("expected exactly 1 body literal (the user-written c=c), got %d: %v", len(r.Body), r.Body)
+	}
 }
 
 // 19d. Mixed params: only typed (class) params get an extent literal.

--- a/ql/desugar/desugar_test.go
+++ b/ql/desugar/desugar_test.go
@@ -620,6 +620,90 @@ predicate isFoo(Foo f) { f instanceof Foo }
 	}
 }
 
+// 19b. Top-level predicate with class-typed param injects an extent literal.
+// Mirrors the from/exists injection pattern (desugar.go ~558, ~789).
+// Without this, the planner sees `c` as untyped and has no extent anchor
+// — joins on `c` go badly.
+func TestDesugarTopLevelPredicateInjectsParamType(t *testing.T) {
+	src := `
+class Foo { Foo() { any() } }
+predicate p(Foo c) { c = c }
+`
+	rm := parseAndResolve(t, src)
+	prog := desugarOK(t, rm)
+
+	r := findRuleExact(prog, "p")
+	if r == nil {
+		t.Fatal("expected top-level rule p")
+	}
+	if len(r.Body) == 0 {
+		t.Fatalf("p body should not be empty (expected leading Foo(c) constraint)")
+	}
+	// Leading literal must be Foo(c).
+	first := r.Body[0]
+	if !first.Positive || first.Atom.Predicate != "Foo" {
+		t.Fatalf("leading body literal should be Foo(c), got %v", first)
+	}
+	if len(first.Atom.Args) != 1 {
+		t.Fatalf("Foo extent literal should take 1 arg, got %d", len(first.Atom.Args))
+	}
+	v, ok := first.Atom.Args[0].(datalog.Var)
+	if !ok || v.Name != "c" {
+		t.Fatalf("Foo extent literal should bind param var c, got %v", first.Atom.Args[0])
+	}
+}
+
+// 19c. Primitive-typed (e.g. int) params must NOT get a type literal.
+// `int` has no class extent — emitting `int(c)` would fail to resolve.
+func TestDesugarTopLevelPredicateSkipsPrimitiveParamType(t *testing.T) {
+	src := `
+predicate p(int c) { c = c }
+`
+	rm := parseAndResolve(t, src)
+	prog := desugarOK(t, rm)
+
+	r := findRuleExact(prog, "p")
+	if r == nil {
+		t.Fatal("expected top-level rule p")
+	}
+	for _, lit := range r.Body {
+		if lit.Atom.Predicate == "int" {
+			t.Fatalf("int-typed param should not produce an `int(...)` literal, body: %v", r.Body)
+		}
+	}
+}
+
+// 19d. Mixed params: only typed (class) params get an extent literal.
+func TestDesugarTopLevelPredicateMixedParamTypes(t *testing.T) {
+	src := `
+class Foo { Foo() { any() } }
+predicate p(Foo c, int n) { c = c and n = n }
+`
+	rm := parseAndResolve(t, src)
+	prog := desugarOK(t, rm)
+
+	r := findRuleExact(prog, "p")
+	if r == nil {
+		t.Fatal("expected top-level rule p")
+	}
+	fooCount := 0
+	intCount := 0
+	for _, lit := range r.Body {
+		switch lit.Atom.Predicate {
+		case "Foo":
+			fooCount++
+		case "int":
+			intCount++
+		}
+	}
+	if fooCount != 1 {
+		t.Errorf("expected exactly 1 Foo(c) extent literal, got %d, body: %v", fooCount, r.Body)
+	}
+	if intCount != 0 {
+		t.Errorf("expected no int(...) literals, got %d, body: %v", intCount, r.Body)
+	}
+}
+
 // 20. Fresh var counter resets per rule (determinism).
 func TestDesugarFreshVarDeterminism(t *testing.T) {
 	src := `


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Motivation

PR #145 catalog item, **bug 2**: `desugarTopLevelPredicate` does NOT inject parameter-type constraints.

In QL, when a predicate parameter has a class type — e.g.

```ql
predicate p(UseStateSetterCall c) { Foo(c, _) }
```

the desugarer is supposed to constrain `c` to the class extent (`UseStateSetterCall(c) and ...`), the same way `from`-clause and `exists`-clause var decls already are (see `ql/desugar/desugar.go` ~558 and ~789).

It did not. Top-level predicate params were emitted into the rule head and then forgotten — the body started with whatever the user wrote. From the planner's perspective, `c` was an untyped variable with no extent anchor; magic-set / backward inference had nothing to seed on, and joins on `c` degenerated.

## Failure mode

- `desugarTopLevelPredicate` builds head args from `pd.Params` but never iterates the param list for type-literal injection.
- `desugarSelect` (from clauses) and `desugarExists` (exists decls) both do the right thing already with the `isPrimitive(typeName)` skip.
- Net effect: predicates with class-typed params behave correctly only when the user manually re-asserts the type inside the body. Otherwise the planner picks whatever ordering it wants, frequently the worst one.

## Fix

In `desugarTopLevelPredicate`, before desugaring the body, iterate `pd.Params` and for each non-primitive type emit a leading literal `<TypeName>(paramVar)`. Mirror the existing from/exists pattern verbatim.

- Primitive params (`int`, `float`, `string`, `boolean`, `date`) are skipped — they have no class extent.
- Empty/missing type strings are skipped defensively.
- Injected literals go at the *front* of the body so the planner sees them before any user-written atom — exactly how `from`-clause type literals are positioned.
- No dedupe pass: if the user redundantly wrote `c instanceof Foo` themselves, we'll have two `Foo(c)` literals; that's idempotent at the relational level. Matches the from/exists pattern (which also doesn't dedupe).

## Tests

Three new desugar tests:
- **`TestDesugarTopLevelPredicateInjectsParamType`** — `predicate p(Foo c) { c = c }`: assert the rule body's leading literal is `Foo(c)`.
- **`TestDesugarTopLevelPredicateSkipsPrimitiveParamType`** — `predicate p(int c) { c = c }`: assert no `int(...)` literal is emitted.
- **`TestDesugarTopLevelPredicateMixedParamTypes`** — `predicate p(Foo c, int n) { ... }`: assert exactly one `Foo(c)` and zero `int(...)` literals.

`go test ./... -race` green across the repo. Existing `TestDesugarTopLevelPredicate` still passes (it asserts head shape, which is unchanged).

## Notes

End-to-end planner-seed assertion was considered but skipped — there's no QL→plan helper in the test suite, and the desugar-level guarantee (leading position, correct predicate name, correct var) is exactly what the planner already consumes for `from`-clause type literals. Wiring up a bespoke harness for this fix would be more complex than the fix itself; happy to add it in a follow-up if reviewers want it.