### PR TITLE
fix(eval): propagate bindings for var-var equality

### DIFF
--- a/ql/eval/join.go
+++ b/ql/eval/join.go
@@ -293,21 +293,80 @@ func applyStep(step plan.JoinStep, rels map[string]*Relation, bindings []binding
 }
 
 // applyComparison filters bindings by evaluating the comparison against each.
+//
+// For equality (`=`) comparisons, applyComparison also propagates bindings
+// when one side is bound and the other is an unbound variable: the unbound
+// var is bound to the value of the bound side, and the row is emitted. This
+// turns `x = y` (with one side already bound) into a binding step rather
+// than a silent zero-result filter. See PR #145 catalog item #1.
+//
+// For non-equality comparisons (!=, <, >, <=, >=) propagation is undefined
+// (we cannot pick a value satisfying `x < y` when y is unbound), so the old
+// "skip if either side unbound" behaviour is preserved.
+//
+// If both sides are unbound under EqOp, this is a planner-level bug — the
+// equality should have been ordered after some step that binds at least one
+// side. Returning an empty result here is a graceful failure (no panic,
+// no fabricated rows) rather than silent corruption.
+//
+// Binding mutation respects the same shared-vs-cloned rules as
+// applyPositive: when a new variable is introduced we allocate a fresh
+// binding map via b.clone(), so input bindings shared across rows are
+// never mutated in place.
 func applyComparison(cmp *datalog.Comparison, bindings []binding) []binding {
+	isEq := cmp.Op == "="
 	var out []binding
 	for _, b := range bindings {
 		lv, lok := lookupTerm(cmp.Left, b)
 		rv, rok := lookupTerm(cmp.Right, b)
-		if !lok || !rok {
-			// Unbound variable in comparison — skip (shouldn't happen with valid plans).
+
+		if lok && rok {
+			ok, err := Compare(cmp.Op, lv, rv)
+			if err == nil && ok {
+				out = append(out, b)
+			}
 			continue
 		}
-		ok, err := Compare(cmp.Op, lv, rv)
-		if err == nil && ok {
-			out = append(out, b)
+
+		if !isEq {
+			// Non-equality with an unbound side: cannot evaluate, drop.
+			continue
+		}
+
+		// EqOp with at least one unbound side. Try to propagate.
+		leftVar, leftIsVar := unboundVar(cmp.Left, b)
+		rightVar, rightIsVar := unboundVar(cmp.Right, b)
+
+		switch {
+		case lok && rightIsVar:
+			nb := b.clone()
+			nb[rightVar] = lv
+			out = append(out, nb)
+		case rok && leftIsVar:
+			nb := b.clone()
+			nb[leftVar] = rv
+			out = append(out, nb)
+		default:
+			// Neither side bound (or unbound side isn't a nameable var):
+			// planner should have ordered this after a binding step. Drop
+			// the row rather than fabricate one.
+			continue
 		}
 	}
 	return out
+}
+
+// unboundVar reports whether t is a non-wildcard Datalog variable that is
+// currently unbound under b. Returns the variable name when so.
+func unboundVar(t datalog.Term, b binding) (string, bool) {
+	v, ok := t.(datalog.Var)
+	if !ok || v.Name == "" || v.Name == "_" {
+		return "", false
+	}
+	if _, bound := b[v.Name]; bound {
+		return "", false
+	}
+	return v.Name, true
 }
 
 // applyPositive extends bindings by probing the named relation.

--- a/ql/eval/varvar_equality_test.go
+++ b/ql/eval/varvar_equality_test.go
@@ -1,0 +1,225 @@
+package eval
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// TestApplyComparison_VarVarEq_PropagatesForward exercises the bug fix
+// from PR #145 catalog item #1: `var = var` equality with the left side
+// bound and the right side unbound must bind the right and emit a row.
+//
+// Before the fix, applyComparison silently dropped any binding where
+// either side was unbound, so a rule like `R(x, y) :- A(x), x = y`
+// produced zero results. After the fix, y is bound to x's value and the
+// rule produces |A| tuples.
+func TestApplyComparison_VarVarEq_PropagatesForward(t *testing.T) {
+	cmp := &datalog.Comparison{
+		Op:    "=",
+		Left:  datalog.Var{Name: "x"},
+		Right: datalog.Var{Name: "y"},
+	}
+	in := []binding{
+		{"x": IntVal{1}},
+		{"x": IntVal{2}},
+		{"x": IntVal{3}},
+	}
+	out := applyComparison(cmp, in)
+	if len(out) != 3 {
+		t.Fatalf("expected 3 propagated bindings, got %d: %+v", len(out), out)
+	}
+	for i, b := range out {
+		x, xok := b["x"].(IntVal)
+		y, yok := b["y"].(IntVal)
+		if !xok || !yok {
+			t.Fatalf("row %d: missing x or y: %+v", i, b)
+		}
+		if x.V != y.V {
+			t.Fatalf("row %d: expected x==y, got x=%d y=%d", i, x.V, y.V)
+		}
+	}
+}
+
+// TestApplyComparison_VarVarEq_PropagatesReverse covers right-bound,
+// left-unbound — the symmetric case.
+func TestApplyComparison_VarVarEq_PropagatesReverse(t *testing.T) {
+	cmp := &datalog.Comparison{
+		Op:    "=",
+		Left:  datalog.Var{Name: "x"},
+		Right: datalog.Var{Name: "y"},
+	}
+	in := []binding{
+		{"y": StrVal{"a"}},
+		{"y": StrVal{"b"}},
+	}
+	out := applyComparison(cmp, in)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 bindings, got %d", len(out))
+	}
+	for _, b := range out {
+		if b["x"] == nil || b["y"] == nil {
+			t.Fatalf("expected both x and y bound: %+v", b)
+		}
+		if b["x"].(StrVal).V != b["y"].(StrVal).V {
+			t.Fatalf("expected x==y, got %+v", b)
+		}
+	}
+}
+
+// TestApplyComparison_VarVarEq_NeitherBound is the negative case: when
+// neither side is bound the planner has misordered the rule. Eval must
+// fail gracefully (empty result, no panic, no fabricated rows).
+func TestApplyComparison_VarVarEq_NeitherBound(t *testing.T) {
+	cmp := &datalog.Comparison{
+		Op:    "=",
+		Left:  datalog.Var{Name: "x"},
+		Right: datalog.Var{Name: "y"},
+	}
+	in := []binding{{}, {"z": IntVal{99}}}
+	out := applyComparison(cmp, in)
+	if len(out) != 0 {
+		t.Fatalf("expected 0 bindings (graceful empty), got %d: %+v", len(out), out)
+	}
+}
+
+// TestApplyComparison_VarVarEq_DoesNotMutateSharedBinding verifies the
+// cloned-on-write contract: when applyComparison binds a new variable it
+// must not write into the input binding map (which may be shared across
+// rows after applyPositive's filter-fast-path).
+func TestApplyComparison_VarVarEq_DoesNotMutateSharedBinding(t *testing.T) {
+	shared := binding{"x": IntVal{42}}
+	in := []binding{shared, shared}
+	cmp := &datalog.Comparison{
+		Op:    "=",
+		Left:  datalog.Var{Name: "x"},
+		Right: datalog.Var{Name: "y"},
+	}
+	out := applyComparison(cmp, in)
+	if _, ok := shared["y"]; ok {
+		t.Fatalf("input binding mutated; shared map now has y: %+v", shared)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 outputs, got %d", len(out))
+	}
+	for _, b := range out {
+		if _, ok := b["y"]; !ok {
+			t.Fatalf("output missing y: %+v", b)
+		}
+	}
+}
+
+// TestApplyComparison_VarVarInequality_UnboundDropped pins the
+// non-equality behaviour: `x < y` with one side unbound is undefined and
+// must drop the row, exactly as before. Binding propagation only applies
+// to EqOp.
+func TestApplyComparison_VarVarInequality_UnboundDropped(t *testing.T) {
+	for _, op := range []string{"!=", "<", ">", "<=", ">="} {
+		cmp := &datalog.Comparison{
+			Op:    op,
+			Left:  datalog.Var{Name: "x"},
+			Right: datalog.Var{Name: "y"},
+		}
+		in := []binding{{"x": IntVal{1}}}
+		out := applyComparison(cmp, in)
+		if len(out) != 0 {
+			t.Fatalf("op %s with unbound y: expected drop, got %+v", op, out)
+		}
+	}
+}
+
+// TestApplyComparison_BothBound_StillFilters is the regression guard:
+// the both-bound branch must keep filtering — the fix must not turn `=`
+// into a pure binder when both sides are already bound to different
+// values.
+func TestApplyComparison_BothBound_StillFilters(t *testing.T) {
+	cmp := &datalog.Comparison{
+		Op:    "=",
+		Left:  datalog.Var{Name: "x"},
+		Right: datalog.Var{Name: "y"},
+	}
+	in := []binding{
+		{"x": IntVal{1}, "y": IntVal{1}}, // pass
+		{"x": IntVal{1}, "y": IntVal{2}}, // drop
+		{"x": IntVal{3}, "y": IntVal{3}}, // pass
+	}
+	out := applyComparison(cmp, in)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 surviving bindings, got %d: %+v", len(out), out)
+	}
+}
+
+// TestRule_VarVarEq_EndToEnd_Forward exercises the fix through the full
+// Rule evaluator. R(x, y) :- A(x), x = y. Input A = {1, 2, 3}; expected
+// output {(1,1), (2,2), (3,3)}.
+func TestRule_VarVarEq_EndToEnd_Forward(t *testing.T) {
+	A := makeRelation("A", 1, IntVal{1}, IntVal{2}, IntVal{3})
+	rels := RelsOf(A)
+
+	rule := plan.PlannedRule{
+		Head: datalog.Atom{Predicate: "R", Args: []datalog.Term{
+			datalog.Var{Name: "x"}, datalog.Var{Name: "y"},
+		}},
+		JoinOrder: []plan.JoinStep{
+			{Literal: datalog.Literal{
+				Positive: true,
+				Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{
+					datalog.Var{Name: "x"},
+				}},
+			}},
+			{Literal: datalog.Literal{Cmp: &datalog.Comparison{
+				Op:    "=",
+				Left:  datalog.Var{Name: "x"},
+				Right: datalog.Var{Name: "y"},
+			}}},
+		},
+	}
+	out, err := Rule(context.Background(), rule, rels, 0)
+	if err != nil {
+		t.Fatalf("Rule: %v", err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("expected 3 head tuples, got %d: %+v", len(out), out)
+	}
+	for _, tup := range out {
+		if tup[0].(IntVal).V != tup[1].(IntVal).V {
+			t.Fatalf("expected x==y in head tuple, got %+v", tup)
+		}
+	}
+}
+
+// TestRule_VarVarEq_EndToEnd_Reverse is the symmetric end-to-end test:
+// R(x, y) :- A(y), x = y. The y side is bound first; equality must
+// propagate to x.
+func TestRule_VarVarEq_EndToEnd_Reverse(t *testing.T) {
+	A := makeRelation("A", 1, IntVal{10}, IntVal{20})
+	rels := RelsOf(A)
+
+	rule := plan.PlannedRule{
+		Head: datalog.Atom{Predicate: "R", Args: []datalog.Term{
+			datalog.Var{Name: "x"}, datalog.Var{Name: "y"},
+		}},
+		JoinOrder: []plan.JoinStep{
+			{Literal: datalog.Literal{
+				Positive: true,
+				Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{
+					datalog.Var{Name: "y"},
+				}},
+			}},
+			{Literal: datalog.Literal{Cmp: &datalog.Comparison{
+				Op:    "=",
+				Left:  datalog.Var{Name: "x"},
+				Right: datalog.Var{Name: "y"},
+			}}},
+		},
+	}
+	out, err := Rule(context.Background(), rule, rels, 0)
+	if err != nil {
+		t.Fatalf("Rule: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 head tuples, got %d: %+v", len(out), out)
+	}
+}

--- a/ql/plan/join.go
+++ b/ql/plan/join.go
@@ -32,6 +32,28 @@ func varsInTerm(t datalog.Term) []string {
 	return nil
 }
 
+// allBound reports whether every name in vs is present in bound. The empty
+// slice (e.g. a constant term) is trivially bound.
+func allBound(vs []string, bound map[string]bool) bool {
+	for _, v := range vs {
+		if v == "_" {
+			// Wildcard names should not appear in comparisons; treat as
+			// unbound for safety.
+			return false
+		}
+		if !bound[v] {
+			return false
+		}
+	}
+	return true
+}
+
+// isVarTerm reports whether t is a non-wildcard Datalog variable.
+func isVarTerm(t datalog.Term) bool {
+	v, ok := t.(datalog.Var)
+	return ok && v.Name != "" && v.Name != "_"
+}
+
 // varsInLiteral returns all variable names referenced in a literal.
 func varsInLiteral(lit datalog.Literal) []string {
 	var vs []string
@@ -56,20 +78,25 @@ func varsInLiteral(lit datalog.Literal) []string {
 // isEligible returns true if lit can be placed given the currently bound variables.
 func isEligible(lit datalog.Literal, bound map[string]bool) bool {
 	if lit.Cmp != nil {
-		// Comparison is eligible when both operands are bound (or are constants).
 		leftVars := varsInTerm(lit.Cmp.Left)
 		rightVars := varsInTerm(lit.Cmp.Right)
-		for _, v := range leftVars {
-			if !bound[v] {
-				return false
+		leftAllBound := allBound(leftVars, bound)
+		rightAllBound := allBound(rightVars, bound)
+		if leftAllBound && rightAllBound {
+			return true
+		}
+		// Equality var-var: eligible when at least one side is fully bound;
+		// applyComparison will propagate the binding to the other side.
+		// See PR #145 catalog item #1 and applyComparison in ql/eval.
+		if lit.Cmp.Op == "=" {
+			if leftAllBound && isVarTerm(lit.Cmp.Right) {
+				return true
+			}
+			if rightAllBound && isVarTerm(lit.Cmp.Left) {
+				return true
 			}
 		}
-		for _, v := range rightVars {
-			if !bound[v] {
-				return false
-			}
-		}
-		return true
+		return false
 	}
 	if lit.Agg != nil {
 		// Aggregate: eligible when all body literal vars used in the outer rule are bound.

--- a/ql/plan/varvar_equality_test.go
+++ b/ql/plan/varvar_equality_test.go
@@ -1,0 +1,80 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// TestOrderJoins_VarVarEq_OrderedAfterBindingStep verifies that the
+// planner places `x = y` only after some step has bound at least one
+// side. Combined with applyComparison's propagation, this means the
+// equality acts as a binding step rather than dropping rows.
+//
+// Bug ref: PR #145 catalog item #1.
+func TestOrderJoins_VarVarEq_OrderedAfterBindingStep(t *testing.T) {
+	body := []datalog.Literal{
+		{Cmp: &datalog.Comparison{
+			Op:    "=",
+			Left:  datalog.Var{Name: "x"},
+			Right: datalog.Var{Name: "y"},
+		}},
+		{Positive: true, Atom: datalog.Atom{
+			Predicate: "A",
+			Args:      []datalog.Term{datalog.Var{Name: "x"}},
+		}},
+	}
+	steps := orderJoins(body, nil)
+	if len(steps) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(steps))
+	}
+	// The first step must be the A(x) atom — equality cannot lead.
+	if steps[0].Literal.Cmp != nil {
+		t.Fatalf("equality placed first; expected A(x) first: %+v", steps)
+	}
+	if steps[1].Literal.Cmp == nil {
+		t.Fatalf("equality not placed second: %+v", steps)
+	}
+}
+
+// TestOrderJoins_VarVarEq_EligibleWithOneBoundSide is the unit-level
+// gate on isEligible: equality with one side bound must now be eligible
+// (it acts as a binder). Pre-fix it was rejected, leading to "no
+// eligible literal" planner stalls or unsolvable rules.
+func TestOrderJoins_VarVarEq_EligibleWithOneBoundSide(t *testing.T) {
+	bound := map[string]bool{"x": true}
+	lit := datalog.Literal{Cmp: &datalog.Comparison{
+		Op:    "=",
+		Left:  datalog.Var{Name: "x"},
+		Right: datalog.Var{Name: "y"},
+	}}
+	if !isEligible(lit, bound) {
+		t.Fatalf("var=var equality with left bound should be eligible")
+	}
+	// Symmetric.
+	bound2 := map[string]bool{"y": true}
+	if !isEligible(lit, bound2) {
+		t.Fatalf("var=var equality with right bound should be eligible")
+	}
+	// Neither bound: still ineligible.
+	if isEligible(lit, map[string]bool{}) {
+		t.Fatalf("var=var equality with neither bound must remain ineligible")
+	}
+}
+
+// TestOrderJoins_VarVarInequality_RequiresBothBound is the regression
+// guard: the new isEligible relaxation applies ONLY to EqOp. `x < y`
+// with one side unbound must remain ineligible.
+func TestOrderJoins_VarVarInequality_RequiresBothBound(t *testing.T) {
+	for _, op := range []string{"!=", "<", ">", "<=", ">="} {
+		bound := map[string]bool{"x": true}
+		lit := datalog.Literal{Cmp: &datalog.Comparison{
+			Op:    op,
+			Left:  datalog.Var{Name: "x"},
+			Right: datalog.Var{Name: "y"},
+		}}
+		if isEligible(lit, bound) {
+			t.Fatalf("op %s with unbound y must be ineligible", op)
+		}
+	}
+}


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Motivation

PR #145 catalog item #1: `applyComparison` at `ql/eval/join.go` only filtered when both sides were already bound. When the comparison was `var = var` and only one (or neither) side was bound, it was silently skipped — the unbound var stayed unbound, downstream joins got nothing, and the rule produced zero rows with no error.

Discovered when `line = c.getLine()` in a QL predicate body silently produced zero rows.

## Failure mode

```
R(x, y) :- A(x), x = y.
```

Pre-fix: planner refused to place the equality (both sides not bound), or eval-side `applyComparison` silently dropped every row because `y` was still unbound under the binding map. Either way: zero results, no diagnostic.

## Fix

`applyComparison` now treats `EqOp` as a binding step when only one side is bound:

- **Both sides bound:** filter as today.
- **Left bound, right unbound Var:** clone the binding, set `right := left's value`, emit the row.
- **Right bound, left unbound Var:** symmetric.
- **Neither bound:** planner-level bug. Drop the row (graceful empty result, no panic, no fabricated rows).

Binding mutation respects the same shared-vs-cloned-binding rules as `applyPositive` after P3b's projection-pushdown work — every new bind allocates a fresh map via `b.clone()`, never mutates shared state. There's a regression test pinning that contract.

Planner side: `isEligible` relaxed so an EqOp with one fully-bound side and a bare Var on the other is now schedulable (was previously rejected, which is why these rules silently failed at plan time before they ever reached eval). Inequalities (`!=`, `<`, `>`, `<=`, `>=`) keep their strict both-sides-bound rule.

## What's NOT changing

- **Inequality semantics:** `x < y` with one side unbound is still dropped. Binding propagation only makes sense for `=` — there's no canonical value to pick that satisfies `<`.
- **Both-bound filter behaviour:** an `=` with both sides already bound still acts as a filter, not a no-op.
- **Negative literals, aggregates, builtins:** untouched.

## Tests

`ql/eval/varvar_equality_test.go`:
- Forward propagation (`x` bound, `y` unbound)
- Reverse propagation (`y` bound, `x` unbound)
- Neither-bound: empty result, no panic
- Shared-binding mutation guard
- Inequalities with unbound side: dropped (regression guard)
- Both-bound `=`: still filters
- End-to-end through `Rule()` in both directions

`ql/plan/varvar_equality_test.go`:
- Planner orders `x = y` after the binding step
- `isEligible` accepts EqOp with one bound side
- `isEligible` still rejects inequalities with one unbound side

`go test ./... -race -count=1`: green.