### PR TITLE
fix(eval): emit saturated-large hint when trivial-IDB pre-pass hits cap

### DIFF
--- a/ql/eval/estimate.go
+++ b/ql/eval/estimate.go
@@ -2,11 +2,31 @@ package eval
 
 import (
 	"context"
+	"errors"
 	"math/rand"
 
 	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
 	"github.com/Gjdoalfnrxu/tsq/ql/plan"
 )
+
+// SaturatedSizeHint is the "definitely huge, exact unknown" size hint
+// the trivial-IDB pre-pass writes when materialisation hits the binding
+// cap. Mirrors the maxSampledHint used on the sampling path so the
+// planner's cardinality scoring sees a single consistent saturation
+// ceiling regardless of which estimator branch produced it.
+//
+// The signal is "we don't know the exact size, but it's at least the
+// cap" — strictly better information than the default 1000-ish hint
+// the planner falls back to when a hint is absent. The planner
+// correspondingly deprioritises this rule's body atoms as join seeds.
+//
+// Trade-off accepted: a rule whose true size is just over the
+// materialisation cap (e.g. 500k) will be misclassified as 1<<30 and
+// never picked as a seed even when it should be. This is strictly
+// better than the prior misclassification (default 1000 → seeded → cap
+// blowup mid-join), which is the failure mode tracked in PR #145's
+// catalog (Mastodon `_disj_2 exceeded binding cap`).
+const SaturatedSizeHint = 1 << 30
 
 // SamplingEnabled toggles the Wander-Join sampling pre-pass inside
 // EstimateNonRecursiveIDBSizes. Default is ON (P2b). A package-level
@@ -386,8 +406,11 @@ func EstimateNonRecursiveIDBSizes(prog *datalog.Program, baseRels map[string]*Re
 				sampled64 += int64(est)
 				sampledOK = true
 			}
-			// Saturate to int (capped at 1<<30 to match per-rule bound).
-			const maxSampledHint = int64(1 << 30)
+			// Saturate to int (capped at SaturatedSizeHint to match
+			// the per-rule bound and the materialisation-cap-hit hint
+			// below — single consistent ceiling across estimator
+			// branches).
+			maxSampledHint := int64(SaturatedSizeHint)
 			if sampled64 > maxSampledHint {
 				sampled64 = maxSampledHint
 			}
@@ -414,20 +437,34 @@ func EstimateNonRecursiveIDBSizes(prog *datalog.Program, baseRels map[string]*Re
 
 		head := NewRelation(t.Name, t.Arity)
 		failed := false
+		capHit := false
 		for _, rule := range t.Rules {
 			planned := plan.SingleRule(rule, sizeHints)
 			// Apply the user-supplied binding cap so a pathological body
 			// (cross-product before a selective join) cannot eat all RAM
-			// here. On cap-exceeded the err branch below treats the IDB as
-			// unestimatable and falls through to the default hint. Issue
-			// #130: passing 0 here meant pre-pass evaluation was unbounded
-			// and OOMed on real corpora before the cap could ever fire on
-			// the main eval pass.
+			// here. On cap-exceeded we record a saturated-large hint so
+			// the planner deprioritises this IDB as a seed (see PR #145
+			// catalog, Mastodon `_disj_2` blowup). Issue #130: passing 0
+			// here meant pre-pass evaluation was unbounded and OOMed on
+			// real corpora before the cap could ever fire on the main
+			// eval pass.
 			tuples, err := Rule(context.Background(), planned, keyed, maxBindingsPerRule)
 			if err != nil {
-				// Best-effort: skip this IDB entirely on any error so we
-				// don't half-populate hints. The default hint will apply
-				// and the between-strata refresh in Evaluate will catch up
+				if errors.Is(err, ErrBindingCapExceeded) {
+					// "We don't know the exact size, but it's at least
+					// the cap" — strictly better than letting the
+					// planner fall back to its default hint and seed
+					// this rule's body. The disjunct shapes generated
+					// by ql/desugar (the `_disj_N` synthetic IDBs)
+					// land here when one branch's body is a wide,
+					// non-selective join with no backward demand.
+					capHit = true
+					break
+				}
+				// Best-effort: skip this IDB entirely on any other
+				// error (context cancellation, etc) so we don't half-
+				// populate hints. The default hint will apply and the
+				// between-strata refresh in Evaluate will catch up
 				// (for non-co-stratified cases at least).
 				failed = true
 				break
@@ -437,6 +474,24 @@ func EstimateNonRecursiveIDBSizes(prog *datalog.Program, baseRels map[string]*Re
 			}
 		}
 		if failed {
+			continue
+		}
+		if capHit {
+			// Saturated-large hint signals "definitely huge, exact
+			// unknown" to the planner — strictly better than default
+			// 1000. Per the multi-rule head contract: if any rule in
+			// the head saturates, the head saturates (the union is at
+			// least as large as any disjunct). Don't add `head` to
+			// `keyed`: we have no materialised relation to expose, so
+			// downstream trivials referencing this IDB will fall back
+			// to sampling/materialising and hit their own cap if the
+			// shape is genuinely huge — same fail-soft contract as
+			// before, just with a usable hint left behind for the
+			// planner.
+			if cur, exists := sizeHints[t.Name]; !exists || SaturatedSizeHint > cur {
+				sizeHints[t.Name] = SaturatedSizeHint
+			}
+			updates[t.Name] = SaturatedSizeHint
 			continue
 		}
 		// Make this IDB visible to subsequent trivial rules that reference

--- a/ql/eval/estimate_test.go
+++ b/ql/eval/estimate_test.go
@@ -184,18 +184,29 @@ func TestEstimateNonRecursiveIDBSizesHonoursBindingCap(t *testing.T) {
 	base := map[string]*eval.Relation{"A": a, "B": b}
 	hints := map[string]int{"A": 200, "B": 200}
 
+	// Disable sampling so this test exercises the materialising path
+	// only — otherwise the sampling pre-pass may produce its own
+	// (possibly small) hint on this 200×200 cross product before the
+	// materialiser ever runs.
+	prevSampling := eval.SamplingEnabled
+	eval.SamplingEnabled = false
+	t.Cleanup(func() { eval.SamplingEnabled = prevSampling })
+
 	updates := eval.EstimateNonRecursiveIDBSizes(prog, base, hints, 1000)
 
 	// Bug case: cap ignored, full 40k cross-product computed.
 	if updates["Q"] == 40000 {
 		t.Fatalf("issue #130 regression: pre-pass ignored binding cap and materialised full %d-tuple cross-product", updates["Q"])
 	}
-	// Expected: cap fired, IDB skipped, no entry written.
-	if _, ok := updates["Q"]; ok {
-		t.Errorf("Q exceeded cap; expected best-effort skip, got updates[Q]=%d", updates["Q"])
+	// Updated contract (PR for #145 catalog): on cap-hit the pre-pass
+	// records a saturated-large hint (`SaturatedSizeHint`) so the
+	// planner can deprioritise this IDB as a seed instead of falling
+	// back to its default 1000-ish hint and picking it as a seed.
+	if updates["Q"] != eval.SaturatedSizeHint {
+		t.Errorf("Q cap-hit: want updates[Q]=%d (SaturatedSizeHint), got %d", eval.SaturatedSizeHint, updates["Q"])
 	}
-	if _, ok := hints["Q"]; ok {
-		t.Errorf("Q hint should be absent on cap-skip; got hints[Q]=%d", hints["Q"])
+	if hints["Q"] != eval.SaturatedSizeHint {
+		t.Errorf("Q cap-hit: want hints[Q]=%d (SaturatedSizeHint), got %d", eval.SaturatedSizeHint, hints["Q"])
 	}
 }
 
@@ -257,5 +268,99 @@ func TestEstimateNonRecursiveIDBSizesSkipsRecursive(t *testing.T) {
 	}
 	if _, ok := hints["Path"]; ok {
 		t.Errorf("Path hint should be absent, got %d", hints["Path"])
+	}
+}
+
+// TestEstimateNonRecursiveIDBSizes_CapHitWritesSaturatedHint is the
+// load-bearing assertion for the PR #145 catalog fix: when
+// materialisation hits the binding cap, the pre-pass writes
+// SaturatedSizeHint instead of leaving the hint at the planner's
+// default ~1000. Mirrors TestEstimateNonRecursiveIDBSizesHonoursBindingCap
+// but asserts on the new hint value contract.
+//
+// Mutation-killable: revert the cap-hit branch to `failed=true; break`
+// (the pre-PR behaviour) and this test fails.
+func TestEstimateNonRecursiveIDBSizes_CapHitWritesSaturatedHint(t *testing.T) {
+	prevSampling := eval.SamplingEnabled
+	eval.SamplingEnabled = false
+	t.Cleanup(func() { eval.SamplingEnabled = prevSampling })
+
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: datalog.Atom{Predicate: "Q", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "y"}}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{datalog.Var{Name: "x"}}}},
+					{Positive: true, Atom: datalog.Atom{Predicate: "B", Args: []datalog.Term{datalog.Var{Name: "y"}}}},
+				},
+			},
+		},
+	}
+	a := eval.NewRelation("A", 1)
+	b := eval.NewRelation("B", 1)
+	for i := int64(0); i < 200; i++ {
+		a.Add(eval.Tuple{eval.IntVal{V: i}})
+		b.Add(eval.Tuple{eval.IntVal{V: i + 10000}})
+	}
+	base := map[string]*eval.Relation{"A": a, "B": b}
+	hints := map[string]int{"A": 200, "B": 200}
+
+	updates := eval.EstimateNonRecursiveIDBSizes(prog, base, hints, 1000)
+
+	if updates["Q"] != eval.SaturatedSizeHint {
+		t.Errorf("cap-hit updates[Q] = %d, want %d (SaturatedSizeHint)", updates["Q"], eval.SaturatedSizeHint)
+	}
+	if hints["Q"] != eval.SaturatedSizeHint {
+		t.Errorf("cap-hit hints[Q] = %d, want %d (SaturatedSizeHint)", hints["Q"], eval.SaturatedSizeHint)
+	}
+	if hints["Q"] == 0 || hints["Q"] == 1000 {
+		t.Errorf("cap-hit hints[Q] regressed to placeholder/default value %d — planner will seed this rule and blow the cap", hints["Q"])
+	}
+}
+
+// TestEstimateNonRecursiveIDBSizes_CapHitMultiRuleHeadSaturates: two
+// rules under the same head, both blow the cap. The head must
+// saturate cleanly (no overflow, no double-saturation arithmetic).
+// Documents the multi-rule-head contract: union of saturated rules is
+// saturated.
+func TestEstimateNonRecursiveIDBSizes_CapHitMultiRuleHeadSaturates(t *testing.T) {
+	prevSampling := eval.SamplingEnabled
+	eval.SamplingEnabled = false
+	t.Cleanup(func() { eval.SamplingEnabled = prevSampling })
+
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: datalog.Atom{Predicate: "Q", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "y"}}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{datalog.Var{Name: "x"}}}},
+					{Positive: true, Atom: datalog.Atom{Predicate: "B", Args: []datalog.Term{datalog.Var{Name: "y"}}}},
+				},
+			},
+			{
+				Head: datalog.Atom{Predicate: "Q", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "y"}}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "B", Args: []datalog.Term{datalog.Var{Name: "x"}}}},
+					{Positive: true, Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{datalog.Var{Name: "y"}}}},
+				},
+			},
+		},
+	}
+	a := eval.NewRelation("A", 1)
+	b := eval.NewRelation("B", 1)
+	for i := int64(0); i < 200; i++ {
+		a.Add(eval.Tuple{eval.IntVal{V: i}})
+		b.Add(eval.Tuple{eval.IntVal{V: i + 10000}})
+	}
+	base := map[string]*eval.Relation{"A": a, "B": b}
+	hints := map[string]int{"A": 200, "B": 200}
+
+	eval.EstimateNonRecursiveIDBSizes(prog, base, hints, 1000)
+
+	if hints["Q"] != eval.SaturatedSizeHint {
+		t.Errorf("multi-rule cap-hit head hints[Q] = %d, want %d (SaturatedSizeHint)", hints["Q"], eval.SaturatedSizeHint)
+	}
+	if hints["Q"] < 0 {
+		t.Errorf("multi-rule cap-hit overflowed: hints[Q] = %d (negative)", hints["Q"])
 	}
 }

--- a/ql/eval/sample_regression_test.go
+++ b/ql/eval/sample_regression_test.go
@@ -143,14 +143,25 @@ func TestP2bRegression_DisjShape_SamplingOff_BindingCapHits(t *testing.T) {
 		t.Fatal("nil execution plan")
 	}
 
-	// With sampling off, the materialising pre-pass tries to evaluate
-	// Disj fully, hits disjShapeBindingCap (1M product vs 100k cap),
-	// and bails — leaving NO hint for Disj. (A zero-valued hint also
-	// satisfies the discriminator; the contract is "not the sampled
-	// large value".)
-	if h, ok := hints["Disj"]; ok && h >= 50_000 {
-		t.Errorf("Disj hint = %d with sampling OFF — expected unset or small (binding cap should have fired); "+
-			"this means the regression test no longer discriminates sampling vs materialising", h)
+	// Updated contract (PR for #145 catalog): with sampling off, the
+	// materialising pre-pass tries to evaluate Disj fully, hits
+	// disjShapeBindingCap (1M product vs 100k cap), and now records
+	// the saturated-large hint instead of leaving Disj unestimated.
+	// This is the load-bearing fix — the planner needs *some* signal
+	// that Disj is huge, not the default 1000.
+	//
+	// The original discriminator (sampling off ⇒ no hint) is no
+	// longer the right shape because both paths now produce a large
+	// hint on cap-hit. The discriminator now is: with sampling off,
+	// the hint must be *exactly* SaturatedSizeHint (not a sampled
+	// estimate, which would be in the 500k–2M noise band).
+	h, ok := hints["Disj"]
+	if !ok {
+		t.Fatalf("Disj hint missing with sampling OFF — cap-hit path should emit SaturatedSizeHint")
+	}
+	if h != eval.SaturatedSizeHint {
+		t.Errorf("Disj hint = %d with sampling OFF — want SaturatedSizeHint=%d (cap-hit should saturate, not sample)",
+			h, eval.SaturatedSizeHint)
 	}
 }
 
@@ -193,5 +204,65 @@ func TestP2bRegression_SamplingDisabledStillWorks(t *testing.T) {
 	}
 	if len(tuples) != 5 {
 		t.Errorf("Q output: want 5 tuples, got %d", len(tuples))
+	}
+}
+
+// TestCapHitHintDeprioritisesBigRule_PlannerIntegration: sampling OFF
+// (so we exercise the materialising cap-hit path), big IDB +
+// small base relation in a consumer rule. With the saturated-large
+// hint correctly written, the planner must seed the consumer rule on
+// the small base relation, not the big IDB.
+//
+// This is the planner integration test for the PR #145 catalog fix.
+// Pre-fix: cap-hit left no hint → planner used default ~1000 → seeded
+// the IDB → main eval blew the cap. Post-fix: cap-hit emits
+// SaturatedSizeHint → planner sees IDB as huge → seeds the small
+// base instead.
+func TestCapHitHintDeprioritisesBigRule_PlannerIntegration(t *testing.T) {
+	prevEnabled := eval.SamplingEnabled
+	eval.SamplingEnabled = false
+	t.Cleanup(func() { eval.SamplingEnabled = prevEnabled })
+
+	prog, base, hints := buildDisjShape()
+	hook := eval.MakeEstimatorHook(base)
+
+	execPlan, planErrs := plan.EstimateAndPlan(prog, hints, disjShapeBindingCap, hook, plan.Plan)
+	if len(planErrs) > 0 {
+		t.Fatalf("plan errors: %v", planErrs)
+	}
+	if execPlan == nil {
+		t.Fatal("nil execution plan")
+	}
+
+	// The cap-hit hint must be the saturated value, not default and
+	// not absent.
+	disjHint, ok := hints["Disj"]
+	if !ok {
+		t.Fatalf("Disj hint missing — cap-hit path should have emitted SaturatedSizeHint")
+	}
+	if disjHint != eval.SaturatedSizeHint {
+		t.Fatalf("Disj hint = %d, want SaturatedSizeHint=%d", disjHint, eval.SaturatedSizeHint)
+	}
+
+	// Find the Consumer rule and confirm the planner picked Tiny (the
+	// small base) as the seed, not Disj (the saturated-huge IDB).
+	var consumerPlanned *plan.PlannedRule
+	for si := range execPlan.Strata {
+		for ri := range execPlan.Strata[si].Rules {
+			if execPlan.Strata[si].Rules[ri].Head.Predicate == "Consumer" {
+				consumerPlanned = &execPlan.Strata[si].Rules[ri]
+			}
+		}
+	}
+	if consumerPlanned == nil {
+		t.Fatal("Consumer rule not found in plan")
+	}
+	if len(consumerPlanned.JoinOrder) == 0 {
+		t.Fatal("Consumer rule has empty JoinOrder")
+	}
+	first := consumerPlanned.JoinOrder[0].Literal
+	if first.Atom.Predicate != "Tiny" {
+		t.Errorf("Consumer first join step: got %q, want %q (planner did not honour saturated cap-hit hint — would seed Disj and blow cap on main eval)",
+			first.Atom.Predicate, "Tiny")
 	}
 }


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Motivation — PR #145 catalog, Mastodon `_disj_2` blowup

Mastodon bench fails with:
```
_disj_2 exceeded binding cap of 5000000 at join step 1
```

`_disj_2` is a synthesised disjunct rule generated by `ql/desugar/desugar.go` (`freshSynthName("_disj")`) when desugaring an `ast.Disjunction`. Each disjunct becomes a separate rule with the same head; the disjunct bodies are joined inside the synthesised rule. On `functionContainsStar`'s depth-3 disjunction, one branch's body is a 5-atom join of `Function`/`FunctionContains` that the planner orders badly because it has no cardinality estimate.

## Failure mode — default 1000 hint → bad seed → cap-hit

Investigation chain (from the catalog):
1. P2b sampling estimator (`SampleJoinCardinality`) returns `ok=false` on this body shape — Wander-Join's seed walk dies before completing K samples.
2. Trivial-IDB pre-pass (`EstimateNonRecursiveIDBSizes`) falls through to materialising under the cap, hits cap, marks `failed=true`, leaves the size hint at default 1000.
3. Backward demand for `_disj_2` is empty (caller passes both args free).
4. **Net:** the planner sees `_disj_2` as size 1000 and orders the 5-atom branch with a bad seed — which then blows the cap on the main eval pass.

## The fix — saturated-large hint on cap-hit

When `EstimateNonRecursiveIDBSizes` materialises a rule and hits the binding cap (`errors.Is(err, ErrBindingCapExceeded)`), write `SaturatedSizeHint = 1<<30` into `sizeHints` for that rule, instead of marking failed and skipping. Mirrors the existing `maxSampledHint` saturation on the P2b sampling path (refactored to share the same constant).

Rationale: "we don't know the exact size, but we know it's at least the cap" is strictly better information than "default 1000". The planner correspondingly deprioritises this rule's body atoms as join seeds.

This is the **load-bearing fix** because it benefits ANY query, not just class-typed callers. Path A from the catalog (push class-extent type constraints into each synthesised disjunct) would also help, but only when callers use class-typed vars — orthogonal and worth doing later.

## Trade-off accepted

A rule whose true size is just over the materialisation cap (e.g. 500k — over the 100k–5M materialisation cap range, but way under the sampling threshold) gets misclassified as 1B and never becomes a seed even when it should be.

This is **strictly better** than the prior misclassification (default 1000 → seeded → cap blowup mid-join), which is the failure mode being fixed.

## What's NOT changing

- Sampling (P2b) path still runs first and wins when it succeeds.
- Other errors from the pre-pass (context cancellation, etc) still fall through to the existing best-effort skip — only the specific `ErrBindingCapExceeded` path gets the new hint.
- Per-rule binding cap (#130) is unchanged; we still bound RAM on the pre-pass.
- Multi-rule head sum (#142 minor 2): the materialising path is a `Relation` accumulator (not int sum), so saturation is by union — no overflow path exists. Two saturated rules under one head produce one saturated head hint.

## Tests

New:
- `TestEstimateNonRecursiveIDBSizes_CapHitWritesSaturatedHint` — asserts `updates[Q] = SaturatedSizeHint`, not default/0/missing. Mutation-killable.
- `TestEstimateNonRecursiveIDBSizes_CapHitMultiRuleHeadSaturates` — two rules under one head, both cap-hit, head saturates without overflow.
- `TestCapHitHintDeprioritisesBigRule_PlannerIntegration` — sampling off, big IDB + small base relation in a consumer rule. Asserts the planner picks the small base as the seed (i.e., the saturated hint correctly deprioritises the big rule). **This is the planner integration test for the fix.**

Updated to assert the new contract:
- `TestEstimateNonRecursiveIDBSizesHonoursBindingCap` — was "absent on cap-skip", now "saturated on cap-hit". Cap-honouring guard preserved.
- `TestP2bRegression_DisjShape_SamplingOff_BindingCapHits` — was "no hint with sampling off", now "exactly SaturatedSizeHint with sampling off" (the discriminator now distinguishes saturated cap-hit hints from sampled estimates in the 500k–2M noise band).

`go test ./... -race` green across all 17 packages.