### PR TITLE
fix(plan): magic-set rewrite for synth-disj predicates under demand

### DIFF
--- a/ql/eval/magicset_rename_trampoline_test.go
+++ b/ql/eval/magicset_rename_trampoline_test.go
@@ -1,0 +1,153 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// TestEval_RenameTrampolineMagicSet_AvoidsBindingCap is the
+// evaluator-level proof for the PR #149 follow-up that addresses
+// adversarial-review M3: synthesise base-relation EDB tuples large
+// enough that the unrewritten `_disj_N` body trips the binding cap,
+// plan with WithMagicSetAutoOpts (which now lifts demand through the
+// pure-rename trampoline `mid(x,b) :- _disj_N(x,b)`), and assert the
+// rule succeeds post-fix.
+//
+// Pre-fix behaviour (PR #149 alone): _disj_N's body is NOT rewritten
+// (no safe seed could be constructed at the trampoline call site),
+// the BigBase1⋈BigBase2 join blows the cap.
+//
+// Post-fix behaviour (this PR): magic_mid is seeded from the
+// grandparent context (SmallExt(a) ⋈ Bridge(a,x,0)), magic__disj_N
+// is propagated via MagicSetTransform.propagateBindings, and only
+// the demand-restricted slice of BigBase1 is probed — well under the
+// cap.
+func TestEval_RenameTrampolineMagicSet_AvoidsBindingCap(t *testing.T) {
+	// EDB sizing: BigBase1⋈BigBase2 unrestricted is ~bigN*bigN tuples;
+	// SmallExt has 2 entries, Bridge restricts the demand to 2 x-values.
+	const (
+		bigN = 200             // BigBase1, BigBase2 each ~40k tuples
+		cap  = 3 * bigN * bigN // 120k cap; pre-fix product would be ~bigN^3 = 8M
+	)
+
+	// SmallExt: {1, 2} (a-values, the demand source).
+	smallExt := makeRelation("SmallExt", 1, IntVal{V: 1}, IntVal{V: 2})
+
+	// Bridge(a, x, 0): a=1→x=10, a=2→x=20. Constant-bearing base
+	// (third col is 0) — qualifies as a grounding atom in
+	// bodyContextGroundedVars.
+	bridge := makeRelation("Bridge", 3,
+		IntVal{V: 1}, IntVal{V: 10}, IntVal{V: 0},
+		IntVal{V: 2}, IntVal{V: 20}, IntVal{V: 0},
+	)
+
+	// BigBase1(x, m): for every x in [0,bigN), m in [0,bigN). bigN*bigN
+	// pairs. With ALL x-values unrestricted the join product against
+	// BigBase2(m, b) (also bigN*bigN) generates ~bigN^3 intermediate
+	// states — well over the cap.
+	bigBase1Vals := make([]Value, 0, bigN*bigN*2)
+	for x := 0; x < bigN; x++ {
+		for m := 0; m < bigN; m++ {
+			bigBase1Vals = append(bigBase1Vals, IntVal{V: int64(x)}, IntVal{V: int64(m)})
+		}
+	}
+	bigBase1 := makeRelation("BigBase1", 2, bigBase1Vals...)
+
+	bigBase2Vals := make([]Value, 0, bigN*bigN*2)
+	for m := 0; m < bigN; m++ {
+		for b := 0; b < bigN; b++ {
+			bigBase2Vals = append(bigBase2Vals, IntVal{V: int64(m)}, IntVal{V: int64(b)})
+		}
+	}
+	bigBase2 := makeRelation("BigBase2", 2, bigBase2Vals...)
+
+	baseRels := map[string]*Relation{
+		"SmallExt": smallExt,
+		"Bridge":   bridge,
+		"BigBase1": bigBase1,
+		"BigBase2": bigBase2,
+	}
+
+	rules := []datalog.Rule{
+		{
+			Head: datalog.Atom{Predicate: "top", Args: []datalog.Term{datalog.Var{Name: "b"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "SmallExt", Args: []datalog.Term{datalog.Var{Name: "a"}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "Bridge", Args: []datalog.Term{datalog.Var{Name: "a"}, datalog.Var{Name: "x"}, datalog.IntConst{Value: 0}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "mid", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "b"}}}},
+			},
+		},
+		{
+			Head: datalog.Atom{Predicate: "mid", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "b"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "_disj_N", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "b"}}}},
+			},
+		},
+		{
+			Head: datalog.Atom{Predicate: "_disj_N", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "b"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "BigBase1", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "m"}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "BigBase2", Args: []datalog.Term{datalog.Var{Name: "m"}, datalog.Var{Name: "b"}}}},
+			},
+		},
+	}
+	prog := &datalog.Program{
+		Rules: rules,
+		Query: &datalog.Query{
+			Select: []datalog.Term{datalog.Var{Name: "b"}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "top", Args: []datalog.Term{datalog.Var{Name: "b"}}}},
+			},
+		},
+	}
+	hints := map[string]int{
+		"SmallExt": smallExt.Len(),
+		"Bridge":   bridge.Len(),
+		"BigBase1": bigBase1.Len(),
+		"BigBase2": bigBase2.Len(),
+	}
+
+	// Plan A: with magic-set rewrite (this PR's fix).
+	ep, _, errs := plan.WithMagicSetAutoOpts(prog, hints, plan.MagicSetOptions{Strict: true})
+	if len(errs) > 0 {
+		t.Fatalf("WithMagicSetAutoOpts strict failed: %v", errs)
+	}
+	rs, err := Evaluate(context.Background(), ep, baseRels, WithMaxBindingsPerRule(cap))
+	if err != nil {
+		// If we get a binding-cap error here, the magic-set rewrite
+		// did NOT bound _disj_N — the fix is not load-bearing.
+		var capErr *BindingCapError
+		if errors.As(err, &capErr) {
+			t.Fatalf("magic-set-rewritten plan still tripped binding cap: %v", err)
+		}
+		// Some other failure path — surface it raw.
+		if strings.Contains(err.Error(), "binding cap") {
+			t.Fatalf("magic-set-rewritten plan still tripped binding cap (string match): %v", err)
+		}
+		t.Fatalf("Evaluate failed unexpectedly: %v", err)
+	}
+	if len(rs.Rows) == 0 {
+		t.Fatalf("expected at least one `top` row from the demand-restricted join, got 0")
+	}
+
+	// Plan B (control): plain Plan with no magic-set rewrite. This
+	// should hit the binding cap, proving the cap and EDB sizing are
+	// load-bearing for the post-fix assertion above.
+	plainEP, errs := plan.Plan(prog, hints)
+	if len(errs) > 0 {
+		t.Fatalf("plain Plan failed: %v", errs)
+	}
+	_, plainErr := Evaluate(context.Background(), plainEP, baseRels, WithMaxBindingsPerRule(cap))
+	if plainErr == nil {
+		t.Fatalf("control: expected plain plan to trip binding cap on _disj_N body, but it succeeded — EDB sizing is too small to demonstrate the fix")
+	}
+	var capErr *BindingCapError
+	if !errors.As(plainErr, &capErr) && !strings.Contains(plainErr.Error(), "binding cap") {
+		t.Fatalf("control: expected BindingCapError from plain plan, got %v", plainErr)
+	}
+}

--- a/ql/plan/backward.go
+++ b/ql/plan/backward.go
@@ -138,20 +138,36 @@ func InferBackwardDemand(prog *datalog.Program, sizeHints map[string]int) Demand
 		}
 	}
 
-	// Initialise: every IDB predicate starts "fully demanded" (all
-	// columns assumed bound). Intersection shrinks this over time.
-	// Sentinel nil slice means "unknown / top" — an unset name in the
-	// map means "no caller observed yet", which is distinct from
-	// "observed with zero bound cols". We use a sentinel map
-	// (initialised[name] = true) to distinguish.
-	demand := DemandMap{}
+	// Per-iteration recomputation. The original in-place intersect
+	// design had a soundness gap: when caller R's head demand grew
+	// LATER in the fixed point (e.g. because the query/grandparent
+	// pass had not yet observed R's own demand on iter 0), the early
+	// intersect of R's body literal demand with the empty initial
+	// observation became permanent — `intersect([], [0]) == []` and
+	// no subsequent iteration could grow it back.
+	//
+	// Concretely (Mastodon `_disj_2` failure mode): the rename rule
+	// `functionContainsStar :- _disj_2` was visited on iter 1 with
+	// `demand[functionContainsStar] = []` (still uninitialised from
+	// the rule passes the rename appears before in source order),
+	// observed `_disj_2 -> []` and initialised `demand[_disj_2]=[]`.
+	// Iter 2: setStateUpdaterCallsFn raised
+	// `demand[functionContainsStar]` to [0], the rename re-ran and
+	// now observed `_disj_2 -> [0]`, but `intersect([],[0]) = []`
+	// stuck. Result: `_disj_2` looked unbound to the magic-set
+	// rewrite even though there's a real rename-trampoline path.
+	//
+	// Fix: each pass computes a fresh `observation` map by walking
+	// every caller (query + every rule body) and intersecting their
+	// per-pass observed columns. Head context for each rule is taken
+	// from `prevDemand` (the previous iteration's result), so as
+	// prevDemand grows monotonically across iterations, observation
+	// grows monotonically too. We assign newDemand := observation
+	// directly (no cross-iteration intersect) — the all-callers
+	// intersect is fully captured WITHIN each pass.
+	prevDemand := DemandMap{}
 	initialised := map[string]bool{}
 
-	changed := true
-	// Bound iterations defensively: each pass only ever shrinks demand
-	// sets. With P positions summed across all IDBs, at most P+1
-	// passes before we stabilise. Add a buffer just in case of
-	// implementation slip.
 	maxIter := 1
 	for name := range idbArity {
 		maxIter += idbArity[name] + 1
@@ -160,28 +176,23 @@ func InferBackwardDemand(prog *datalog.Program, sizeHints map[string]int) Demand
 		maxIter = 8
 	}
 
-	iter := 0
-	for changed && iter < maxIter {
-		changed = false
-		iter++
-
-		// The query body is a first-class caller of any IDB it references.
-		// Treating it as such tightens the all-callers intersect: a column
-		// the rule callers happen to bind but the query does not is NOT
-		// safely demand-bound at planning time. Adversarial-review
-		// Finding 1 on PR #143.
-		//
-		// The query has no head, so headBoundVars is empty. We synthesise
-		// a Rule with an empty head and the query body so the same
-		// bodyContextGroundedVars / literalBoundCols / intersect path
-		// reused below applies uniformly.
-		if prog.Query != nil && len(prog.Query.Body) > 0 {
-			queryRule := datalog.Rule{
-				Head: datalog.Atom{},
-				Body: prog.Query.Body,
+	for iter := 0; iter < maxIter; iter++ {
+		observation := map[string][]int{}
+		observed := map[string]bool{}
+		recordObservation := func(pred string, cols []int) {
+			if !observed[pred] {
+				observation[pred] = append([]int(nil), cols...)
+				observed[pred] = true
+				return
 			}
-			queryHeadBound := map[string]bool{}
-			ctxBoundVars := bodyContextGroundedVars(queryRule, sizeHints, queryHeadBound)
+			observation[pred] = intersectSortedCols(observation[pred], cols)
+		}
+
+		// The query body is a first-class caller of any IDB it
+		// references. Adversarial-review Finding 1 on PR #143.
+		if prog.Query != nil && len(prog.Query.Body) > 0 {
+			queryRule := datalog.Rule{Head: datalog.Atom{}, Body: prog.Query.Body}
+			ctxBoundVars := bodyContextGroundedVars(queryRule, sizeHints, map[string]bool{})
 			for _, lit := range prog.Query.Body {
 				if lit.Cmp != nil || lit.Agg != nil || !lit.Positive {
 					continue
@@ -193,27 +204,16 @@ func InferBackwardDemand(prog *datalog.Program, sizeHints map[string]int) Demand
 				if mixedArity[pred] {
 					continue
 				}
-				observed := literalBoundCols(lit, ctxBoundVars)
-				if !initialised[pred] {
-					demand[pred] = append([]int(nil), observed...)
-					initialised[pred] = true
-					changed = true
-					continue
-				}
-				prev := demand[pred]
-				next := intersectSortedCols(prev, observed)
-				if !sameCols(prev, next) {
-					demand[pred] = next
-					changed = true
-				}
+				recordObservation(pred, literalBoundCols(lit, ctxBoundVars))
 			}
 		}
 
 		for _, rule := range prog.Rules {
-			// Compute which of this rule's own head vars are demand-bound.
-			// On the first pass, treat them as unbound (nothing proven
-			// yet). On subsequent passes use the current demand map.
-			headDemandCols := demand[rule.Head.Predicate]
+			// Use PREVIOUS iteration's demand for head-context
+			// computation. As prevDemand grows monotonically,
+			// growing head demand re-flows through this rule's body
+			// observations on the next pass.
+			headDemandCols := prevDemand[rule.Head.Predicate]
 			headBoundVars := map[string]bool{}
 			for _, col := range headDemandCols {
 				if col < 0 || col >= len(rule.Head.Args) {
@@ -223,16 +223,6 @@ func InferBackwardDemand(prog *datalog.Program, sizeHints map[string]int) Demand
 					headBoundVars[v.Name] = true
 				}
 			}
-
-			// Walk the body and determine, for each positive-atom literal
-			// over an IDB predicate, which of its columns are bound by
-			// rule context. Then intersect into demand[pred].
-			//
-			// "Bound by context" here means: bound by constants in the
-			// atom itself, by `var = const` comparisons anywhere in the
-			// body, by a shared variable with a known-small positive
-			// atom (sizeHint <= SmallExtentThreshold), or by a shared
-			// variable with a head arg that is already demand-bound.
 			ctxBoundVars := bodyContextGroundedVars(rule, sizeHints, headBoundVars)
 
 			for _, lit := range rule.Body {
@@ -246,25 +236,43 @@ func InferBackwardDemand(prog *datalog.Program, sizeHints map[string]int) Demand
 				if mixedArity[pred] {
 					continue
 				}
-				observed := literalBoundCols(lit, ctxBoundVars)
-				if !initialised[pred] {
-					demand[pred] = append([]int(nil), observed...)
-					initialised[pred] = true
-					// Always flag changed on first initialisation: even if
-					// observed is empty, a downstream rule whose body
-					// references `pred` in a chain might now see a
-					// different head-demand propagation path. Conservative
-					// re-iteration beats missing a fixed-point update.
-					changed = true
-					continue
-				}
-				prev := demand[pred]
-				next := intersectSortedCols(prev, observed)
-				if !sameCols(prev, next) {
-					demand[pred] = next
-					changed = true
+				recordObservation(pred, literalBoundCols(lit, ctxBoundVars))
+			}
+		}
+
+		// newDemand := observation (no intersect with prevDemand —
+		// each pass's observation already contains the full
+		// all-callers intersect for this pass).
+		newDemand := DemandMap{}
+		newInitialised := map[string]bool{}
+		for pred, cols := range observation {
+			newDemand[pred] = cols
+			newInitialised[pred] = true
+		}
+		// Carry over previously-initialised preds that weren't
+		// observed this pass (defensive — shouldn't occur in
+		// practice since callers don't change between iterations).
+		for pred := range initialised {
+			if _, ok := newInitialised[pred]; !ok {
+				newDemand[pred] = prevDemand[pred]
+				newInitialised[pred] = true
+			}
+		}
+
+		converged := len(newInitialised) == len(initialised)
+		if converged {
+			for pred, cols := range newDemand {
+				if !sameCols(cols, prevDemand[pred]) {
+					converged = false
+					break
 				}
 			}
+		}
+
+		prevDemand = newDemand
+		initialised = newInitialised
+		if converged {
+			break
 		}
 	}
 
@@ -274,6 +282,12 @@ func InferBackwardDemand(prog *datalog.Program, sizeHints map[string]int) Demand
 	// from "demand is the empty set" (in map, zero cols) — the latter
 	// means "observed, but no column reliably bound", which is still
 	// useful signal to tests.
+	demand := DemandMap{}
+	for pred, cols := range prevDemand {
+		if initialised[pred] {
+			demand[pred] = cols
+		}
+	}
 	for name := range idbArity {
 		if !initialised[name] {
 			delete(demand, name)

--- a/ql/plan/backward_test.go
+++ b/ql/plan/backward_test.go
@@ -559,6 +559,88 @@ func TestSmallExtentThreshold_Boundary(t *testing.T) {
 	}
 }
 
+// Adversarial-review F2 on PR #149: regression guard for the per-iteration
+// recompute fix in InferBackwardDemand (commit 30c32f1). Without that fix,
+// the original in-place intersect had a soundness gap when caller demand
+// grew LATER in the fixed point than the trampoline rule was first
+// visited: `intersect([], [0]) == []` would stick permanently and demand
+// could not lift back through a pure-rename trampoline.
+//
+// Source-order failure mode (mirrors the Mastodon `_disj_2` case from the
+// commit message):
+//
+//	rule 0 (trampoline):  functionContainsStar(fn, n) :- _disj_2(fn, n).
+//	rule 1 (grandparent): setStateUpdaterCallsFn(c, _) :-
+//	                          isUseStateSetterCall(c),
+//	                          CallArg(c, 0, argFn),
+//	                          functionContainsStar(argFn, _).
+//	rule 2 (disj defn):   _disj_2(fn, n) :- BigBase(fn, n).
+//
+// On iter 1 the trampoline (rule 0) is visited before the grandparent
+// (rule 1), so demand[functionContainsStar] is still uninitialised; the
+// trampoline records `_disj_2 -> []`. The grandparent then observes
+// `functionContainsStar -> [0]` (argFn bound by CallArg's constant col 1
+// shared with isUseStateSetterCall, which is small-extent). On iter 2 the
+// trampoline re-runs with demand[functionContainsStar] = [0] and observes
+// `_disj_2 -> [0]`. Per-iteration recompute: this is the converged value.
+// In-place intersect (the buggy pre-30c32f1 form): `intersect([], [0]) =
+// []`, stuck.
+//
+// Assertion: post-fix, `demand[_disj_2] == [0]`. The accompanying comment
+// records what the BUGGY behaviour would have been (`[]`) so that any
+// future refactor that silently re-introduces the gap will fail this test
+// with the diagnostic in plain sight.
+func TestInferBackwardDemand_RenameTrampolineLiftsAcrossIterations(t *testing.T) {
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			// rule 0: pure-rename trampoline — must appear BEFORE its
+			// grandparent caller in source order to trigger the gap.
+			{Head: datalog.Atom{Predicate: "functionContainsStar", Args: []datalog.Term{v("fn"), v("n")}},
+				Body: []datalog.Literal{atom("_disj_2", v("fn"), v("n"))}},
+			// rule 1: grandparent. isUseStateSetterCall is small-extent
+			// (binds c); CallArg(c, 0, argFn) shares c and carries a
+			// constant in col 1 → argFn is bound by the time
+			// functionContainsStar is probed, so col 0 is demanded.
+			{Head: datalog.Atom{Predicate: "setStateUpdaterCallsFn", Args: []datalog.Term{v("c"), v("_")}},
+				Body: []datalog.Literal{
+					atom("isUseStateSetterCall", v("c")),
+					atom("CallArg", v("c"), ic(0), v("argFn")),
+					atom("functionContainsStar", v("argFn"), v("_")),
+				}},
+			// rule 2: defining rule for _disj_2 (irrelevant to the
+			// inference shape — just makes _disj_2 a real IDB).
+			{Head: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{v("fn"), v("n")}},
+				Body: []datalog.Literal{atom("BigBase", v("fn"), v("n"))}},
+		},
+	}
+	hints := map[string]int{
+		"isUseStateSetterCall": 5,      // small extent → binds c
+		"CallArg":              500000, // unhinted-large; col 1 const + shared c grounds argFn
+		"BigBase":              500000,
+	}
+	d := InferBackwardDemand(prog, hints)
+
+	// Sanity: the grandparent must observe functionContainsStar col 0
+	// bound (otherwise we're not actually exercising the gap).
+	got, ok := d["functionContainsStar"]
+	if !ok || len(got) != 1 || got[0] != 0 {
+		t.Fatalf("precondition: expected functionContainsStar demand = [0], got %v (entry present=%v)", got, ok)
+	}
+
+	// The actual regression guard: demand must lift through the
+	// trampoline to _disj_2.
+	got, ok = d["_disj_2"]
+	if !ok {
+		t.Fatalf("expected _disj_2 in demand map (trampoline observed), got %v", d)
+	}
+	if len(got) != 1 || got[0] != 0 {
+		t.Fatalf("expected _disj_2 demand = [0] (lifted across iterations); "+
+			"got %v. If this is [], the per-iteration recompute in "+
+			"InferBackwardDemand has likely been reverted to in-place "+
+			"intersect — see commit 30c32f1.", got)
+	}
+}
+
 // Benchmark planning time for a taint-shaped rule. Regression guard:
 // P3a adds a fixed-point pass over all rules before orderJoins runs,
 // which is O(rules × body × iterations). Acceptable overhead per the

--- a/ql/plan/magicset_demand.go
+++ b/ql/plan/magicset_demand.go
@@ -1,0 +1,351 @@
+// Package plan — demand-driven magic-set augmentation for synthesised
+// predicates (the `_disj_N`, `_neg_N` shapes emitted by the desugarer).
+//
+// Background. The original `WithMagicSetAuto` path infers magic-set
+// bindings only from `prog.Query` — it walks the query body, looks for
+// constants / equalities / preceding base-relation literals that ground
+// IDB-literal arguments, and emits seed rules. It never looks at the
+// rule bodies that CALL an IDB. That's fine for a flat query like
+// `from Path(1, b)` but blind for the desugared shape:
+//
+//	Caller(c) :- ClassExt(c), _disj_2(c, _).         // small ClassExt
+//	_disj_2(c, y) :- A(c, y).                        // base join branch 1
+//	_disj_2(c, y) :- B(c, m), C(m, n), D(n, y).      // 4-atom branch 2
+//
+// Here `_disj_2` has no query-side binding (the query may just want
+// `Caller(c)`). But every CALL site of `_disj_2` binds head column 0
+// (via `ClassExt(c)`, a small extent). The native rule-body backward
+// inference (`InferBackwardDemand`, P3a) already records this fact in
+// its `DemandMap`. P3a uses it only to bias the greedy join planner's
+// scoring inside `_disj_2`'s body — it does NOT push that demand into
+// the program rewrite, so at evaluation time `_disj_2` still computes
+// every tuple of B⋈C⋈D before the cap fires.
+//
+// This file closes that gap. When the demand map says "_disj_2 column
+// 0 is bound at every call site", we synthesise:
+//
+//  1. A magic-set binding entry `{"_disj_2": [0]}`, fed into
+//     `MagicSetTransform` so `_disj_2`'s rules get rewritten to
+//     `_disj_2(c, y) :- magic__disj_2(c), <body>`.
+//
+//  2. A demand-seed rule per caller, of the form
+//     `magic__disj_2(c) :- <caller's grounding context for c>.`
+//     Without this seed, the rewritten `_disj_2` produces no tuples
+//     (the magic predicate would be empty).
+//
+// The seed body is the caller's preceding/grounding literals, NOT the
+// caller's whole body. We need just enough to ground the demanded head
+// vars at evaluation time — typically the small-extent atom that gave
+// rise to the demand observation in the first place. Including the
+// full caller body would risk re-introducing the very cardinality
+// blowup we're trying to bound.
+//
+// Conservative-by-design (mirroring the rest of the magic-set
+// machinery): if we cannot construct a safe, side-effect-free seed
+// for a demanded predicate, we drop that predicate from the rewrite
+// set rather than emit a broken seed. The non-strict
+// `WithMagicSetAutoOpts` path still falls back to plain `Plan` on
+// any subsequent planning error.
+
+package plan
+
+import (
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// InferRuleBodyDemandBindings walks `prog`'s rules, computes the
+// backward demand map (per `InferBackwardDemand`), and converts it
+// into a magic-set bindings map plus the seed rules required to make
+// the magic predicates produce tuples at evaluation time from caller
+// context.
+//
+// idbPreds is the set of predicate names eligible for rewriting (rule
+// heads). Any demand entry referencing a non-IDB name is skipped.
+//
+// Returns:
+//   - bindings: predicate → bound column positions, suitable for
+//     MagicSetTransform. Only includes predicates for which we could
+//     construct AT LEAST ONE safe demand seed.
+//   - seedRules: the demand-seed rules to append to the augmented
+//     program after MagicSetTransform.
+//
+// When the demand map is empty or no safe seed could be constructed
+// for any demanded predicate, returns (nil, nil) — caller should then
+// skip the rule-body magic-set augmentation entirely.
+func InferRuleBodyDemandBindings(
+	prog *datalog.Program,
+	idbPreds map[string]bool,
+	sizeHints map[string]int,
+) (map[string][]int, []datalog.Rule) {
+	if prog == nil || len(prog.Rules) == 0 {
+		return nil, nil
+	}
+	demand := InferBackwardDemand(prog, sizeHints)
+	if len(demand) == 0 {
+		return nil, nil
+	}
+
+	bindings := map[string][]int{}
+	var seeds []datalog.Rule
+
+	// For each predicate with non-empty demand that's also a rewritable
+	// IDB, walk every rule body that calls it and emit a seed per call
+	// site. The seed body is the caller's grounding context: those
+	// preceding body literals that establish bindings for the demanded
+	// head vars.
+	for pred, cols := range demand {
+		if len(cols) == 0 {
+			continue
+		}
+		if !idbPreds[pred] {
+			continue
+		}
+		// Restrict to synthesised desugar shapes (`_disj_*`, `_neg_*`).
+		// These are the predicates the desugarer emits as cardinality-
+		// dangerous joins where backward demand is the load-bearing
+		// fix. Hand-written IDBs have well-tested join orderings under
+		// the existing planner, and rewriting them risks introducing
+		// new stratification edges (e.g. recursive negation cycles via
+		// taint-style helper predicates) that flip a previously-plain-
+		// planned program into "augmented program is unplannable" and
+		// fall back to plain Plan with a noisy warning. Conservative
+		// scope: synth-name only. Broaden later once measured.
+		if !isSynthDesugarName(pred) {
+			continue
+		}
+		// A predicate already covered by query-binding inference is
+		// handled by the existing InferQueryBindings path. We only
+		// fire here when the demand source is a RULE body. Detect
+		// this by checking the query body: if the pred appears with
+		// any constant / equality-grounded / base-grounded arg there,
+		// skip — the query-binding path will (or already did) emit a
+		// seed for it.
+		if predHasQueryBinding(prog, pred, cols) {
+			continue
+		}
+
+		predSeeds := buildDemandSeedsForPred(prog, pred, cols, sizeHints)
+		if len(predSeeds) == 0 {
+			continue
+		}
+		bindings[pred] = append([]int(nil), cols...)
+		seeds = append(seeds, predSeeds...)
+	}
+
+	if len(bindings) == 0 {
+		return nil, nil
+	}
+	return bindings, seeds
+}
+
+// predHasQueryBinding returns true iff prog.Query.Body contains a
+// positive atom for pred whose `cols` positions are all bound by query
+// context (constants, equalities, or preceding base atoms with shared
+// vars). When true, the existing InferQueryBindings pipeline will emit
+// the seed rules; we don't want to double up.
+//
+// Conservative: false positives here just mean we DON'T emit a
+// demand-seed and let the query-binding path handle it (correct).
+// False negatives mean we emit a demand-seed in addition to the
+// query-binding seed — also safe, the magic predicate just gets seeded
+// from two sources.
+func predHasQueryBinding(prog *datalog.Program, pred string, cols []int) bool {
+	if prog.Query == nil || len(prog.Query.Body) == 0 {
+		return false
+	}
+	for _, lit := range prog.Query.Body {
+		if lit.Cmp != nil || lit.Agg != nil || !lit.Positive {
+			continue
+		}
+		if lit.Atom.Predicate != pred {
+			continue
+		}
+		// Match: the query references pred. Trust InferQueryBindings
+		// to produce the seed; we step aside.
+		return true
+	}
+	return false
+}
+
+// buildDemandSeedsForPred constructs one demand-seed rule per call
+// site of pred in prog.Rules.
+//
+// For each rule R that has `pred(args...)` as a positive body literal
+// at index i:
+//   - The seed head is `magic_pred(args[c0], args[c1], ...)` for c
+//     in the demand cols.
+//   - The seed body is the subset of R.Body[0..i-1] needed to ground
+//     the head args. Specifically, we include literals that
+//     transitively bind any head-arg variable.
+//
+// Skip a call site (silently — it just doesn't produce a seed) if:
+//   - the head args at the demanded positions aren't variables
+//     (constants are already-bound, no seed needed for those args
+//     specifically, but we still need the others — for now we skip
+//     mixed-shape sites);
+//   - the resulting seed wouldn't be safe (head vars not all bound
+//     by the constructed body).
+//
+// This mirrors the structural conservatism of InferQueryBindings.
+func buildDemandSeedsForPred(
+	prog *datalog.Program,
+	pred string,
+	cols []int,
+	sizeHints map[string]int,
+) []datalog.Rule {
+	var seeds []datalog.Rule
+	magicPred := magicName(pred)
+
+	for _, rule := range prog.Rules {
+		// Skip self-recursion on pred — a rule whose head IS pred
+		// can't seed itself in a useful way (it would create a magic
+		// rule for the recursive case that depends on the very
+		// predicate we're trying to bound).
+		if rule.Head.Predicate == pred {
+			continue
+		}
+		for i, lit := range rule.Body {
+			if lit.Cmp != nil || lit.Agg != nil || !lit.Positive {
+				continue
+			}
+			if lit.Atom.Predicate != pred {
+				continue
+			}
+			if len(lit.Atom.Args) < maxColIndex(cols)+1 {
+				continue
+			}
+
+			// Build the seed head args: pull from the call-site's atom
+			// at the demanded column positions. If a position is a
+			// constant, it lifts directly into the magic head as a
+			// constant — no body needed for that column. If it's a
+			// variable, we need the body to bind it.
+			seedHeadArgs := make([]datalog.Term, len(cols))
+			demandedVars := map[string]bool{}
+			malformed := false
+			for k, col := range cols {
+				if col < 0 || col >= len(lit.Atom.Args) {
+					malformed = true
+					break
+				}
+				arg := lit.Atom.Args[col]
+				seedHeadArgs[k] = arg
+				if v, ok := arg.(datalog.Var); ok && v.Name != "_" {
+					demandedVars[v.Name] = true
+				}
+			}
+			if malformed {
+				continue
+			}
+
+			// Construct the seed body: caller's preceding literals
+			// (j < i), preserving order, but we keep only literals
+			// that contribute to grounding the demanded vars. A
+			// literal qualifies if it shares a variable with the
+			// demanded set OR it is a comparison / small-extent atom
+			// that grounds a transitively-shared variable. To keep
+			// the algorithm simple and conservative, we include ALL
+			// preceding positive atoms over base relations (non-IDB)
+			// plus comparisons — these are the cheap, side-effect-
+			// free literals the desugarer typically emits as the
+			// "guard" before a synth-disj call. Including a preceding
+			// IDB atom would risk re-introducing the very cardinality
+			// blowup we're trying to bound, so we drop those.
+			var seedBody []datalog.Literal
+			idb := IDBPredicates(prog)
+			for j := 0; j < i; j++ {
+				prev := rule.Body[j]
+				if prev.Agg != nil {
+					continue
+				}
+				if prev.Cmp != nil {
+					seedBody = append(seedBody, prev)
+					continue
+				}
+				if !prev.Positive {
+					// Negative literals require all their vars bound;
+					// we can include them only if all their vars are
+					// already in the bound set built so far. Keep it
+					// simple — drop them.
+					continue
+				}
+				// Positive atom: include if it's a base relation
+				// (not an IDB head), OR if it's an IDB head whose
+				// hint marks it as small-extent (safe to evaluate as
+				// part of the seed).
+				bodyPred := prev.Atom.Predicate
+				if idb[bodyPred] && !isSmallExtent(bodyPred, sizeHints) {
+					// Risk re-introducing the blowup; drop.
+					continue
+				}
+				seedBody = append(seedBody, prev)
+			}
+
+			seedHead := datalog.Atom{Predicate: magicPred, Args: seedHeadArgs}
+			if !isSafe(seedHead, seedBody) {
+				continue
+			}
+			seeds = append(seeds, datalog.Rule{Head: seedHead, Body: seedBody})
+		}
+	}
+	return seeds
+}
+
+// isSynthDesugarName returns true for predicate names emitted by
+// `ql/desugar.freshSynthName` for the disjunction / negation
+// helper-IDB shapes. The desugarer uses fixed prefixes (`_disj_`,
+// `_neg_`) for these synth predicates; restricting demand-driven
+// magic-set augmentation to those names keeps the scope tight to
+// the cardinality-dangerous case (Mastodon `_disj_2`) while
+// avoiding accidental rewrites on hand-written IDBs.
+func isSynthDesugarName(pred string) bool {
+	const disjPrefix = "_disj_"
+	const negPrefix = "_neg_"
+	return (len(pred) > len(disjPrefix) && pred[:len(disjPrefix)] == disjPrefix) ||
+		(len(pred) > len(negPrefix) && pred[:len(negPrefix)] == negPrefix)
+}
+
+func maxColIndex(cols []int) int {
+	m := 0
+	for _, c := range cols {
+		if c > m {
+			m = c
+		}
+	}
+	return m
+}
+
+// MergeBindings merges two magic-set binding maps. When the same
+// predicate appears in both with different column sets, the union is
+// taken (both call sites' bindings are valid demand evidence; the
+// rewrite simply needs to bind ANY of them at runtime). The result
+// is a fresh map; inputs are not mutated.
+func MergeBindings(a, b map[string][]int) map[string][]int {
+	out := map[string][]int{}
+	for k, v := range a {
+		out[k] = append([]int(nil), v...)
+	}
+	for k, v := range b {
+		if existing, ok := out[k]; ok {
+			out[k] = unionSortedCols(existing, v)
+		} else {
+			out[k] = append([]int(nil), v...)
+		}
+	}
+	return out
+}
+
+func unionSortedCols(a, b []int) []int {
+	seen := map[int]bool{}
+	for _, x := range a {
+		seen[x] = true
+	}
+	for _, x := range b {
+		seen[x] = true
+	}
+	out := make([]int, 0, len(seen))
+	for x := range seen {
+		out = append(out, x)
+	}
+	return sortUniqueInts(out)
+}

--- a/ql/plan/magicset_demand.go
+++ b/ql/plan/magicset_demand.go
@@ -124,12 +124,28 @@ func InferRuleBodyDemandBindings(
 			continue
 		}
 
-		predSeeds := buildDemandSeedsForPred(prog, pred, cols, sizeHints)
-		if len(predSeeds) == 0 {
+		predSeeds, parentBindings, parentSeeds := buildDemandSeedsForPredWithParents(prog, pred, cols, sizeHints, demand)
+		if len(predSeeds) == 0 && len(parentSeeds) == 0 {
 			continue
 		}
 		bindings[pred] = append([]int(nil), cols...)
 		seeds = append(seeds, predSeeds...)
+		// Fold in any parent-pred bindings/seeds discovered while
+		// chasing demand back through pure-rename trampolines (the
+		// `functionContainsStar(fn,node) :- _disj_2(fn,node)` shape
+		// from Mastodon). Without this, a synth pred whose only
+		// caller is a rename rule has no preceding grounding context
+		// to construct a safe seed body, so the rewrite drops on the
+		// floor — the bug PR #149 originally aimed to fix but missed
+		// (run_005 still cap-hit identically).
+		for parentPred, parentCols := range parentBindings {
+			if existing, ok := bindings[parentPred]; ok {
+				bindings[parentPred] = unionSortedCols(existing, parentCols)
+			} else {
+				bindings[parentPred] = append([]int(nil), parentCols...)
+			}
+		}
+		seeds = append(seeds, parentSeeds...)
 	}
 
 	if len(bindings) == 0 {
@@ -289,6 +305,185 @@ func buildDemandSeedsForPred(
 		}
 	}
 	return seeds
+}
+
+// buildDemandSeedsForPredWithParents extends buildDemandSeedsForPred
+// to traverse pure-rename trampoline rules upward when a direct seed
+// cannot be safely constructed at the call site.
+//
+// Motivation (Mastodon `_disj_2` / PR #149 follow-up). The desugarer
+// can emit a chain like:
+//
+//	functionContainsStar(fn, node) :- FunctionContains(fn, node).
+//	functionContainsStar(fn, node) :- _disj_2(fn, node).
+//
+//	_disj_2(fn, node) :- ...big base join...
+//
+// `_disj_2`'s only call site is the rename rule, which has zero
+// preceding literals. `buildDemandSeedsForPred` therefore can't ground
+// the demanded `fn` and emits no seeds — `_disj_2` stays unbound at
+// runtime and blows the binding cap.
+//
+// The grounding `fn` actually exists at the GRAND-caller of
+// `functionContainsStar`, e.g. `setStateUpdaterCallsFn` whose body has
+// `isUseStateSetterCall(c) and CallArg(c,0,argFn) and
+// functionContainsStar(argFn, innerCall)`. P3a's `InferBackwardDemand`
+// already records this — `demand[functionContainsStar] = [0]`. We
+// just have to lift it into the magic-set bindings.
+//
+// Algorithm (single hop only — extend later if needed):
+//
+//  1. Direct: try `buildDemandSeedsForPred(prog, pred, cols, ...)`.
+//     If it returns at least one seed, we're done — return it with
+//     empty parent maps.
+//  2. Rename traversal: for each call site of `pred` that is a "pure
+//     rename" (rule whose body is exactly the single positive
+//     `pred(...)` literal, and whose head shares variables with that
+//     literal at the demanded positions), the rule's HEAD is the
+//     parent. Look up `demand[parent]`. If it covers the renamed
+//     positions, mark the parent for magic-set inclusion (bindings)
+//     and emit seeds for `magic_<parent>` from ITS callers using the
+//     same `buildDemandSeedsForPred` logic — but keyed on the parent
+//     name so the magic-set transform's `propagateBindings` chains
+//     `magic_<parent>` → `magic_<pred>` automatically.
+//
+// Returning parents in a separate map (rather than recursing into
+// `InferRuleBodyDemandBindings`) keeps the scope-and-shape filtering
+// (synth-only) untouched — parents are typically NON-synth IDBs like
+// `functionContainsStar`, which the synth-only filter would otherwise
+// reject.
+//
+// Bound on traversal depth: 1 hop. Multi-hop rename chains are rare
+// in practice (the desugarer doesn't synthesise them) and a single
+// hop covers the Mastodon shape. Generalising to N-hops would require
+// cycle detection and is left for a follow-up if measurement shows
+// it matters.
+func buildDemandSeedsForPredWithParents(
+	prog *datalog.Program,
+	pred string,
+	cols []int,
+	sizeHints map[string]int,
+	demand DemandMap,
+) (predSeeds []datalog.Rule, parentBindings map[string][]int, parentSeeds []datalog.Rule) {
+	predSeeds = buildDemandSeedsForPred(prog, pred, cols, sizeHints)
+	if len(predSeeds) > 0 {
+		// Direct seeds already cover the demanded positions; no need
+		// to chase parents.
+		return predSeeds, nil, nil
+	}
+
+	parentBindings = map[string][]int{}
+	seenParent := map[string]bool{}
+
+	for _, rule := range prog.Rules {
+		if rule.Head.Predicate == pred {
+			continue
+		}
+		// A rule qualifies as a "rename trampoline" for pred iff its
+		// body is a single positive atom over pred. Comparisons or
+		// extra literals disqualify — those would require more
+		// careful per-position grounding analysis than we attempt
+		// here.
+		if len(rule.Body) != 1 {
+			continue
+		}
+		only := rule.Body[0]
+		if only.Cmp != nil || only.Agg != nil || !only.Positive {
+			continue
+		}
+		if only.Atom.Predicate != pred {
+			continue
+		}
+		if len(only.Atom.Args) < maxColIndex(cols)+1 {
+			continue
+		}
+
+		// Map the demanded body-atom column positions to head
+		// positions via variable correspondence. If body arg
+		// `cols[k]` is a var that also appears in the head at
+		// position `hPos`, then demand on body col cols[k] lifts to
+		// demand on head col hPos.
+		var headCols []int
+		mappedAll := true
+		for _, col := range cols {
+			arg := only.Atom.Args[col]
+			v, ok := arg.(datalog.Var)
+			if !ok || v.Name == "_" {
+				// Constant body arg or wildcard — no mapping needed
+				// (the constant is already-bound at the trampoline
+				// itself). We skip without disqualifying.
+				continue
+			}
+			hPos := -1
+			for hi, ha := range rule.Head.Args {
+				if hv, ok := ha.(datalog.Var); ok && hv.Name == v.Name {
+					hPos = hi
+					break
+				}
+			}
+			if hPos < 0 {
+				mappedAll = false
+				break
+			}
+			headCols = append(headCols, hPos)
+		}
+		if !mappedAll || len(headCols) == 0 {
+			continue
+		}
+
+		parent := rule.Head.Predicate
+		if seenParent[parent] {
+			continue
+		}
+		// Only honour parents that the demand pass already proves
+		// have demand on AT LEAST the head positions we need. This
+		// is the load-bearing soundness check — we never invent
+		// demand the analysis didn't already validate.
+		parentDemand, hasParentDemand := demand[parent]
+		if !hasParentDemand {
+			continue
+		}
+		if !subsetSortedCols(sortUniqueInts(headCols), parentDemand) {
+			continue
+		}
+
+		// Build seeds for the parent's magic predicate from ITS
+		// callers' grounding context.
+		grandSeeds := buildDemandSeedsForPred(prog, parent, sortUniqueInts(headCols), sizeHints)
+		if len(grandSeeds) == 0 {
+			continue
+		}
+		seenParent[parent] = true
+		if existing, ok := parentBindings[parent]; ok {
+			parentBindings[parent] = unionSortedCols(existing, headCols)
+		} else {
+			parentBindings[parent] = sortUniqueInts(headCols)
+		}
+		parentSeeds = append(parentSeeds, grandSeeds...)
+	}
+
+	if len(parentBindings) == 0 {
+		return nil, nil, nil
+	}
+	return nil, parentBindings, parentSeeds
+}
+
+// subsetSortedCols returns true iff every element of `sub` is in
+// `super`. Both must be sorted-unique slices.
+func subsetSortedCols(sub, super []int) bool {
+	if len(sub) == 0 {
+		return true
+	}
+	i := 0
+	for _, x := range super {
+		if x == sub[i] {
+			i++
+			if i == len(sub) {
+				return true
+			}
+		}
+	}
+	return i == len(sub)
 }
 
 // isSynthDesugarName returns true for predicate names emitted by

--- a/ql/plan/magicset_demand.go
+++ b/ql/plan/magicset_demand.go
@@ -155,10 +155,18 @@ func InferRuleBodyDemandBindings(
 }
 
 // predHasQueryBinding returns true iff prog.Query.Body contains a
-// positive atom for pred whose `cols` positions are all bound by query
+// positive atom for pred whose `cols` positions are ALL bound by query
 // context (constants, equalities, or preceding base atoms with shared
 // vars). When true, the existing InferQueryBindings pipeline will emit
 // the seed rules; we don't want to double up.
+//
+// Adversarial-review F1 on PR #149: the previous version returned true
+// on any positive occurrence of pred regardless of binding. That makes
+// the demand-seed path silently bail for queries like `_disj_2(c, y)`
+// where neither var is grounded by query context — InferQueryBindings
+// also produces no seed, and the magic rewrite drops on the floor. We
+// must verify cols ⊆ query-context-bound-cols at the occurrence; only
+// then can we trust the query-binding pipeline to handle it.
 //
 // Conservative: false positives here just mean we DON'T emit a
 // demand-seed and let the query-binding path handle it (correct).
@@ -169,6 +177,8 @@ func predHasQueryBinding(prog *datalog.Program, pred string, cols []int) bool {
 	if prog.Query == nil || len(prog.Query.Body) == 0 {
 		return false
 	}
+	queryRule := datalog.Rule{Head: datalog.Atom{}, Body: prog.Query.Body}
+	ctxBoundVars := bodyContextGroundedVars(queryRule, nil, map[string]bool{})
 	for _, lit := range prog.Query.Body {
 		if lit.Cmp != nil || lit.Agg != nil || !lit.Positive {
 			continue
@@ -176,11 +186,33 @@ func predHasQueryBinding(prog *datalog.Program, pred string, cols []int) bool {
 		if lit.Atom.Predicate != pred {
 			continue
 		}
-		// Match: the query references pred. Trust InferQueryBindings
-		// to produce the seed; we step aside.
-		return true
+		// Match: the query references pred. Verify the demanded cols
+		// are actually grounded at this occurrence before stepping
+		// aside for InferQueryBindings.
+		boundCols := literalBoundCols(lit, ctxBoundVars)
+		if containsAllInts(boundCols, cols) {
+			return true
+		}
 	}
 	return false
+}
+
+// containsAllInts returns true iff every element of need appears in
+// haystack. haystack is assumed sorted-unique; need need not be.
+func containsAllInts(haystack, need []int) bool {
+	if len(need) == 0 {
+		return true
+	}
+	set := make(map[int]bool, len(haystack))
+	for _, v := range haystack {
+		set[v] = true
+	}
+	for _, v := range need {
+		if !set[v] {
+			return false
+		}
+	}
+	return true
 }
 
 // buildDemandSeedsForPred constructs one demand-seed rule per call

--- a/ql/plan/magicset_demand_test.go
+++ b/ql/plan/magicset_demand_test.go
@@ -253,6 +253,172 @@ func TestWithMagicSetAuto_SynthDisjNoDemandFallsThrough(t *testing.T) {
 	}
 }
 
+// TestInferRuleBodyDemandBindings_RenameTrampolinePropagation
+// mirrors the Mastodon `_disj_2` shape that PR #149 missed and this
+// follow-up fixes:
+//
+//	top(b) :- SmallExt(a), Bridge(a, x), mid(x, b).
+//	mid(x, b) :- _disj_N(x, b).
+//	_disj_N(x, b) :- BigBase1(x, m), BigBase2(m, b).
+//
+// `_disj_N`'s only call site is the pure-rename trampoline `mid(x,b)
+// :- _disj_N(x,b)`. The trampoline has zero preceding literals to
+// ground `x`, so `buildDemandSeedsForPred` cannot synthesise a safe
+// `magic__disj_N(x)` seed at that site. The grounding actually
+// exists at the grandparent `top` rule via `SmallExt(a)` (small
+// extent) → `Bridge(a, x)` (constant-bearing base shares `a`).
+//
+// The fix lifts the demand into `mid` (the parent of the rename) so
+// `magic_mid(x)` is seeded from `top`'s body, and the magic-set
+// transform's `propagateBindings` then chains
+// `magic_mid` → `magic__disj_N` automatically.
+func TestInferRuleBodyDemandBindings_RenameTrampolinePropagation(t *testing.T) {
+	rules := []datalog.Rule{
+		{
+			Head: datalog.Atom{Predicate: "top", Args: []datalog.Term{datalog.Var{Name: "b"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "SmallExt", Args: []datalog.Term{datalog.Var{Name: "a"}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "Bridge", Args: []datalog.Term{datalog.Var{Name: "a"}, datalog.Var{Name: "x"}, datalog.IntConst{Value: 0}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "mid", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "b"}}}},
+			},
+		},
+		// Pure rename: mid(x,b) :- _disj_N(x,b). No preceding
+		// literals to ground x.
+		{
+			Head: datalog.Atom{Predicate: "mid", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "b"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "_disj_N", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "b"}}}},
+			},
+		},
+		// Big base join — the cardinality-dangerous body.
+		{
+			Head: datalog.Atom{Predicate: "_disj_N", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "b"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "BigBase1", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "m"}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "BigBase2", Args: []datalog.Term{datalog.Var{Name: "m"}, datalog.Var{Name: "b"}}}},
+			},
+		},
+	}
+	prog := &datalog.Program{
+		Rules: rules,
+		Query: &datalog.Query{
+			Select: []datalog.Term{datalog.Var{Name: "b"}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "top", Args: []datalog.Term{datalog.Var{Name: "b"}}}},
+			},
+		},
+	}
+	hints := map[string]int{
+		"SmallExt": 7,
+		"Bridge":   100000,
+		"BigBase1": 100000,
+		"BigBase2": 100000,
+	}
+	idb := IDBPredicates(prog)
+
+	bindings, seeds := InferRuleBodyDemandBindings(prog, idb, hints)
+	if len(bindings) == 0 {
+		t.Fatalf("expected non-empty bindings (parent-lifted), got nil")
+	}
+	if cols, ok := bindings["_disj_N"]; !ok || len(cols) == 0 || cols[0] != 0 {
+		t.Fatalf("expected _disj_N bound at col 0, got %v", bindings["_disj_N"])
+	}
+	if cols, ok := bindings["mid"]; !ok || len(cols) == 0 || cols[0] != 0 {
+		t.Fatalf("expected parent `mid` lifted into bindings at col 0, got %v", bindings["mid"])
+	}
+	// Seeds must include a magic_mid(x) :- SmallExt(a), Bridge(a,x,0)
+	// (or similar shape) — the grandparent grounding context.
+	foundParentSeed := false
+	for _, sr := range seeds {
+		if sr.Head.Predicate != "magic_mid" {
+			continue
+		}
+		for _, lit := range sr.Body {
+			if lit.Atom.Predicate == "SmallExt" {
+				foundParentSeed = true
+			}
+		}
+	}
+	if !foundParentSeed {
+		t.Fatalf("expected magic_mid seed grounding x via SmallExt; seeds=%+v", seeds)
+	}
+}
+
+// TestWithMagicSetAuto_RenameTrampolineEndToEnd asserts that the
+// rename-trampoline shape produces a fully wired augmented program:
+// magic_mid is seeded from the grandparent context, magic__disj_N is
+// derived from magic_mid by `propagateBindings`, and `_disj_N`'s
+// body is rewritten with `magic__disj_N(x)` as its first literal.
+func TestWithMagicSetAuto_RenameTrampolineEndToEnd(t *testing.T) {
+	rules := []datalog.Rule{
+		{
+			Head: datalog.Atom{Predicate: "top", Args: []datalog.Term{datalog.Var{Name: "b"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "SmallExt", Args: []datalog.Term{datalog.Var{Name: "a"}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "Bridge", Args: []datalog.Term{datalog.Var{Name: "a"}, datalog.Var{Name: "x"}, datalog.IntConst{Value: 0}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "mid", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "b"}}}},
+			},
+		},
+		{
+			Head: datalog.Atom{Predicate: "mid", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "b"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "_disj_N", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "b"}}}},
+			},
+		},
+		{
+			Head: datalog.Atom{Predicate: "_disj_N", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "b"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "BigBase1", Args: []datalog.Term{datalog.Var{Name: "x"}, datalog.Var{Name: "m"}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "BigBase2", Args: []datalog.Term{datalog.Var{Name: "m"}, datalog.Var{Name: "b"}}}},
+			},
+		},
+	}
+	prog := &datalog.Program{
+		Rules: rules,
+		Query: &datalog.Query{
+			Select: []datalog.Term{datalog.Var{Name: "b"}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "top", Args: []datalog.Term{datalog.Var{Name: "b"}}}},
+			},
+		},
+	}
+	hints := map[string]int{
+		"SmallExt": 7,
+		"Bridge":   100000,
+		"BigBase1": 100000,
+		"BigBase2": 100000,
+	}
+	ep, inf, errs := WithMagicSetAutoOpts(prog, hints, MagicSetOptions{Strict: true})
+	if len(errs) > 0 {
+		t.Fatalf("WithMagicSetAutoOpts strict failed: %v", errs)
+	}
+	if ep == nil {
+		t.Fatalf("nil execution plan")
+	}
+	if cols, ok := inf.Bindings["_disj_N"]; !ok || len(cols) == 0 || cols[0] != 0 {
+		t.Fatalf("expected _disj_N bound at col 0 in inf.Bindings, got %v", inf.Bindings)
+	}
+	if cols, ok := inf.Bindings["mid"]; !ok || len(cols) == 0 || cols[0] != 0 {
+		t.Fatalf("expected mid lifted into inf.Bindings at col 0, got %v", inf.Bindings)
+	}
+	// _disj_N rules must be rewritten to lead with magic__disj_N.
+	disjRewritten := 0
+	for _, st := range ep.Strata {
+		for _, r := range st.Rules {
+			if r.Head.Predicate != "_disj_N" {
+				continue
+			}
+			disjRewritten++
+			if len(r.Body) == 0 || r.Body[0].Atom.Predicate != "magic__disj_N" {
+				t.Errorf("expected first body literal of _disj_N to be magic__disj_N; got %s", r.Body[0].Atom.Predicate)
+			}
+		}
+	}
+	if disjRewritten == 0 {
+		t.Fatalf("no _disj_N rules in augmented plan")
+	}
+}
+
 func dumpJoinOrder(steps []JoinStep) string {
 	parts := make([]string, 0, len(steps))
 	for _, s := range steps {

--- a/ql/plan/magicset_demand_test.go
+++ b/ql/plan/magicset_demand_test.go
@@ -1,0 +1,262 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// progSynthDisjShape mirrors what the desugarer emits for a 2-arg
+// synthesised disjunction predicate called from a class-extent-guarded
+// caller:
+//
+//	Caller(c, y) :- ClassExt(c), _disj_2(c, y).
+//	_disj_2(c, y) :- A(c, y).
+//	_disj_2(c, y) :- B(c, m), C(m, n), D(n, y).
+//	_disj_2(c, y) :- E(c, m), F(m, y).
+//
+// ClassExt is a small extent (well below SmallExtentThreshold).
+// A, B, C, D, E, F are large-ish base relations.
+//
+// The query asks for `Caller(c, y)`. With magic-set augmentation
+// applied to the rule-body demand, _disj_2 should be rewritten so
+// `magic__disj_2(c)` filters its body, and a seed rule
+// `magic__disj_2(c) :- ClassExt(c)` provides the magic extension.
+func progSynthDisjShape() (*datalog.Program, map[string]int) {
+	rules := []datalog.Rule{
+		// Caller binds head col 0 of _disj_2 via the small ClassExt.
+		{
+			Head: datalog.Atom{Predicate: "Caller", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "ClassExt", Args: []datalog.Term{datalog.Var{Name: "c"}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}}},
+			},
+		},
+		// _disj_2 disjunction branches: each is a base-relation join
+		// with multiple atoms sharing a mid-var (the canonical synth
+		// shape from desugar.go:625-651).
+		{
+			Head: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}}},
+			},
+		},
+		{
+			Head: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "B", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "m"}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "C", Args: []datalog.Term{datalog.Var{Name: "m"}, datalog.Var{Name: "n"}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "D", Args: []datalog.Term{datalog.Var{Name: "n"}, datalog.Var{Name: "y"}}}},
+			},
+		},
+		{
+			Head: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "E", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "m"}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "F", Args: []datalog.Term{datalog.Var{Name: "m"}, datalog.Var{Name: "y"}}}},
+			},
+		},
+	}
+	prog := &datalog.Program{
+		Rules: rules,
+		Query: &datalog.Query{
+			Select: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "Caller", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}}},
+			},
+		},
+	}
+	hints := map[string]int{
+		"ClassExt": 7,      // small extent — well under SmallExtentThreshold
+		"A":        100000, // each branch large
+		"B":        100000,
+		"C":        100000,
+		"D":        100000,
+		"E":        100000,
+		"F":        100000,
+	}
+	return prog, hints
+}
+
+func TestInferRuleBodyDemandBindings_SynthDisjFires(t *testing.T) {
+	prog, hints := progSynthDisjShape()
+	idb := IDBPredicates(prog)
+
+	bindings, seeds := InferRuleBodyDemandBindings(prog, idb, hints)
+	if bindings == nil {
+		t.Fatalf("expected non-nil bindings for _disj_2 under demand from ClassExt, got nil")
+	}
+	cols, ok := bindings["_disj_2"]
+	if !ok {
+		t.Fatalf("expected _disj_2 in bindings, got %v", bindings)
+	}
+	if len(cols) != 1 || cols[0] != 0 {
+		t.Fatalf("expected _disj_2 bound at col 0, got %v", cols)
+	}
+
+	// Seed rule shape: magic__disj_2(c) :- ClassExt(c).
+	if len(seeds) == 0 {
+		t.Fatalf("expected at least one demand-seed rule for magic__disj_2, got 0")
+	}
+	foundClassExtSeed := false
+	for _, sr := range seeds {
+		if sr.Head.Predicate != "magic__disj_2" {
+			continue
+		}
+		if len(sr.Head.Args) != 1 {
+			t.Errorf("seed head arity: want 1, got %d", len(sr.Head.Args))
+		}
+		// Body should ground head var via ClassExt
+		for _, lit := range sr.Body {
+			if lit.Atom.Predicate == "ClassExt" {
+				foundClassExtSeed = true
+			}
+		}
+	}
+	if !foundClassExtSeed {
+		t.Fatalf("expected a demand-seed body grounding c via ClassExt; seeds=%+v", seeds)
+	}
+}
+
+func TestWithMagicSetAuto_SynthDisjRewriteFires(t *testing.T) {
+	prog, hints := progSynthDisjShape()
+	ep, inf, errs := WithMagicSetAutoOpts(prog, hints, MagicSetOptions{Strict: true})
+	if len(errs) > 0 {
+		t.Fatalf("WithMagicSetAutoOpts strict failed: %v", errs)
+	}
+	if ep == nil {
+		t.Fatalf("nil execution plan")
+	}
+	cols, ok := inf.Bindings["_disj_2"]
+	if !ok || len(cols) == 0 || cols[0] != 0 {
+		t.Fatalf("expected _disj_2 in inf.Bindings with col 0, got %v", inf.Bindings)
+	}
+
+	// The augmented program should include rewritten _disj_2 rules
+	// whose body starts with magic__disj_2(c). Walk strata to find
+	// _disj_2 plans and assert.
+	rewrittenDisjSeen := 0
+	for _, st := range ep.Strata {
+		for _, r := range st.Rules {
+			if r.Head.Predicate != "_disj_2" {
+				continue
+			}
+			rewrittenDisjSeen++
+			if len(r.Body) == 0 {
+				t.Fatalf("_disj_2 rule has empty body")
+			}
+			first := r.Body[0]
+			if first.Atom.Predicate != "magic__disj_2" {
+				t.Errorf("expected first body literal of _disj_2 to be magic__disj_2, got %s", first.Atom.Predicate)
+			}
+		}
+	}
+	if rewrittenDisjSeen == 0 {
+		t.Fatalf("no _disj_2 rules found in augmented plan; strata=%+v", ep.Strata)
+	}
+
+	// And: a magic__disj_2 seed must be present in the augmented
+	// program (otherwise rewritten _disj_2 produces zero tuples).
+	seedSeen := false
+	for _, st := range ep.Strata {
+		for _, r := range st.Rules {
+			if r.Head.Predicate == "magic__disj_2" {
+				seedSeen = true
+				// At least one of the magic_disj_2 rules should ground
+				// c via ClassExt (the small-extent demand source).
+				for _, lit := range r.Body {
+					if lit.Atom.Predicate == "ClassExt" {
+						return // success
+					}
+				}
+			}
+		}
+	}
+	if !seedSeen {
+		t.Fatalf("no magic__disj_2 seed rule found in augmented plan")
+	}
+	t.Fatalf("magic__disj_2 seeded but no ClassExt-grounded variant found")
+}
+
+// TestWithMagicSetAuto_SynthDisjJoinSeedSelectsMagic asserts that
+// once the rewrite fires, each _disj_2 rule's planned join order
+// places the magic literal first — that's the runtime mechanism by
+// which the binding-cap blowup is bounded.
+func TestWithMagicSetAuto_SynthDisjJoinSeedSelectsMagic(t *testing.T) {
+	prog, hints := progSynthDisjShape()
+	// Provide a small hint for magic__disj_2 too — the size is
+	// bounded by ClassExt cardinality, so it's tiny by construction.
+	hints["magic__disj_2"] = 7
+
+	ep, _, errs := WithMagicSetAutoOpts(prog, hints, MagicSetOptions{Strict: true})
+	if len(errs) > 0 {
+		t.Fatalf("plan failed: %v", errs)
+	}
+	for _, st := range ep.Strata {
+		for _, r := range st.Rules {
+			if r.Head.Predicate != "_disj_2" {
+				continue
+			}
+			if len(r.JoinOrder) == 0 {
+				t.Fatalf("_disj_2 plan has no join order")
+			}
+			seed := r.JoinOrder[0].Literal
+			if seed.Atom.Predicate != "magic__disj_2" {
+				t.Errorf("expected magic__disj_2 to be the first join step (cardinality-bounded seed); got %s. Full join order: %s",
+					seed.Atom.Predicate, dumpJoinOrder(r.JoinOrder))
+			}
+		}
+	}
+}
+
+// TestWithMagicSetAuto_SynthDisjQueryOnlyFallsThrough is the negative
+// control: when there's no caller-side small-extent grounding, the
+// rule-body magic-set augmentation should NOT fire and the planner
+// should produce the plain Plan output. This confirms the gating is
+// driven by the demand map rather than blanket-rewriting every
+// `_disj_*` predicate by name.
+func TestWithMagicSetAuto_SynthDisjNoDemandFallsThrough(t *testing.T) {
+	rules := []datalog.Rule{
+		// Caller has NO small-extent atom — only large IDBs and base
+		// relations of unknown size. _disj_2 has no demand source.
+		{
+			Head: datalog.Atom{Predicate: "Caller", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}}},
+			},
+		},
+		{
+			Head: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}}},
+			},
+		},
+	}
+	prog := &datalog.Program{
+		Rules: rules,
+		Query: &datalog.Query{
+			Select: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "Caller", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}}},
+			},
+		},
+	}
+	hints := map[string]int{"A": 100000}
+	idb := IDBPredicates(prog)
+	bindings, seeds := InferRuleBodyDemandBindings(prog, idb, hints)
+	if len(bindings) != 0 {
+		t.Fatalf("expected no rule-body bindings without small-extent demand; got %v", bindings)
+	}
+	if len(seeds) != 0 {
+		t.Fatalf("expected no rule-body seeds; got %d", len(seeds))
+	}
+}
+
+func dumpJoinOrder(steps []JoinStep) string {
+	parts := make([]string, 0, len(steps))
+	for _, s := range steps {
+		parts = append(parts, s.Literal.Atom.Predicate)
+	}
+	return strings.Join(parts, " -> ")
+}

--- a/ql/plan/magicset_infer.go
+++ b/ql/plan/magicset_infer.go
@@ -268,6 +268,22 @@ func WithMagicSetAuto(prog *datalog.Program, sizeHints map[string]int) (*Executi
 func WithMagicSetAutoOpts(prog *datalog.Program, sizeHints map[string]int, opts MagicSetOptions) (*ExecutionPlan, QueryBindingInference, []error) {
 	idb := IDBPredicates(prog)
 	inf := InferQueryBindings(prog, idb)
+
+	// Augment query-side inference with rule-body backward demand
+	// (P3a-derived magic-set seeds for synth-disj / synth-neg shapes).
+	// This closes the gap where a synthesised IDB like `_disj_2` is
+	// called from a rule whose context binds the head args, but the
+	// query body doesn't reference `_disj_2` directly. Without this
+	// augmentation, the magic-set transform would never fire for
+	// `_disj_2` and its body would compute every tuple of B⋈C⋈D
+	// before the binding cap fires (Mastodon `_disj_2` failure mode,
+	// roadmap "Magic-set on synth-disj" section).
+	demandBindings, demandSeeds := InferRuleBodyDemandBindings(prog, idb, sizeHints)
+	if len(demandBindings) > 0 {
+		inf.Bindings = MergeBindings(inf.Bindings, demandBindings)
+		inf.SeedRules = append(inf.SeedRules, demandSeeds...)
+	}
+
 	if len(inf.Bindings) == 0 {
 		ep, errs := Plan(prog, sizeHints)
 		return ep, inf, errs


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Root cause

Mastodon `_disj_2` was blowing the binding cap during its own body evaluation: 5-atom synth-disj IDB joining four base relations on a mid-var, with no small seed and no caller-side magic seed pushing demand into the body.

`WithMagicSetAuto` only inferred bindings from the query body (`InferQueryBindings`). It never looked at rule callers, so a synthesised `_disj_N` IDB called from a rule whose body bound the head args via a small extent (e.g. `ClassExt`) got zero magic-set treatment. P3a's `InferBackwardDemand` records exactly that demand fact, but it was used only to bias the planner's greedy join scoring — never to push a magic predicate into the program rewrite.

## Fix

New `InferRuleBodyDemandBindings(prog, idb, hints)` converts the backward-demand map into magic-set bindings + per-call-site demand seed rules (`magic__disj_N(c) :- ClassExt(c), ...preceding-grounding-literals...`). `WithMagicSetAutoOpts` merges these with query-binding inference before calling `MagicSetTransform`.

Scope guard: restricted to `_disj_*` / `_neg_*` synth-name predicates. Hand-written IDBs excluded (rewriting them risks new stratification edges that flip plain plans into "augmented program is unplannable" + noisy fallback). Conservative; broaden later once measured.

## Tests

- `TestInferRuleBodyDemandBindings_SynthDisjFires` — direct API
- `TestWithMagicSetAuto_SynthDisjRewriteFires` — end-to-end rewrite assertion
- `TestWithMagicSetAuto_SynthDisjJoinSeedSelectsMagic` — runtime cardinality contract
- `TestWithMagicSetAuto_SynthDisjNoDemandFallsThrough` — negative control

`go test ./... -race -count=1` green across all 17 packages.

## Mastodon expectation

With `--magic-sets`, `_disj_2`'s join step 1 should now have `magic__disj_2` as the seed, capping intermediate cardinality at the small-extent caller's count rather than the cross-product. Previous failure mode `exceeded binding cap of 5000000 at join step 1 (intermediate cardinality=5000001)` should not recur for shapes matching this pattern.