### PR TITLE
feat(cli): markdown report export for query results

### DIFF
--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -510,7 +510,10 @@ func cmdQuery(ctx context.Context, args []string, stdout, stderr io.Writer) int 
 	fs := flag.NewFlagSet("query", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	dbFile := fs.String("db", "tsq.db", "fact database file")
-	format := fs.String("format", "json", "output format: sarif, json, csv")
+	format := fs.String("format", "json", "output format: sarif, json, csv, markdown")
+	sourceRoot := fs.String("source-root", "", "base directory for resolving file paths in markdown snippets (default: current dir)")
+	mdFileCol := fs.Int("md-file-col", -1, "markdown: column index containing file paths (default: -1, infer from column names)")
+	mdLineCol := fs.Int("md-line-col", -1, "markdown: column index containing line numbers (default: -1, infer from column names)")
 	maxBindingsPerRule := fs.Int("max-bindings-per-rule", eval.DefaultMaxBindingsPerRule, "per-rule cap on intermediate join binding cardinality (0 = unlimited; prevents OOM on weak joins, see issue #80)")
 	maxIterations := fs.Int("max-iterations", eval.DefaultMaxIterations, "max semi-naive fixpoint iterations per stratum before erroring (0 = unlimited; see issue #79)")
 	allowPartial := fs.Bool("allow-partial", false, "if --max-iterations is hit, log a warning and return partial results instead of erroring (legacy behaviour)")
@@ -534,7 +537,7 @@ func cmdQuery(ctx context.Context, args []string, stdout, stderr io.Writer) int 
 
 	if fs.NArg() < 1 {
 		fmt.Fprintln(stderr, "error: query requires a QUERY_FILE argument")
-		fmt.Fprintln(stderr, "usage: tsq query [--db FILE] [--format sarif|json|csv] QUERY_FILE")
+		fmt.Fprintln(stderr, "usage: tsq query [--db FILE] [--format sarif|json|csv|markdown] QUERY_FILE")
 		return 2
 	}
 	queryFile := fs.Arg(0)
@@ -542,8 +545,10 @@ func cmdQuery(ctx context.Context, args []string, stdout, stderr io.Writer) int 
 	// Validate format.
 	switch *format {
 	case "json", "sarif", "csv":
+	case "markdown", "md":
+		*format = "markdown"
 	default:
-		fmt.Fprintf(stderr, "error: unknown format %q (must be json, sarif, or csv)\n", *format)
+		fmt.Fprintf(stderr, "error: unknown format %q (must be json, sarif, csv, or markdown)\n", *format)
 		return 1
 	}
 
@@ -618,7 +623,9 @@ func cmdQuery(ctx context.Context, args []string, stdout, stderr io.Writer) int 
 	if *verbose {
 		bopts.verboseOut = stderr
 	}
+	queryStart := time.Now()
 	rs, err := compileAndEval(ctx, queryFile, *dbFile, *maxBindingsPerRule, *maxIterations, *allowPartial, bopts)
+	queryWall := time.Since(queryStart)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		writeMemProfile(*memProfile, stderr)
@@ -645,6 +652,29 @@ func cmdQuery(ctx context.Context, args []string, stdout, stderr io.Writer) int 
 	case "csv":
 		if err := output.WriteCSV(stdout, rs); err != nil {
 			fmt.Fprintf(stderr, "error: write CSV output: %v\n", err)
+			return 1
+		}
+	case "markdown":
+		mdOpts := output.MarkdownOptions{
+			QueryName:   filepath.Base(strings.TrimSuffix(queryFile, ".ql")),
+			ToolVersion: version,
+			SourceRoot:  *sourceRoot,
+			WallTime:    queryWall,
+			FileColumn:  *mdFileCol,
+			LineColumn:  *mdLineCol,
+		}
+		// Best-effort: parse leading /** ... */ block for richer header.
+		if src, rerr := os.ReadFile(queryFile); rerr == nil {
+			if name, desc, id := output.ParseQueryMetadata(string(src)); name != "" || desc != "" || id != "" {
+				if name != "" {
+					mdOpts.QueryName = name
+				}
+				mdOpts.QueryDescription = desc
+				mdOpts.QueryID = id
+			}
+		}
+		if err := output.WriteMarkdown(stdout, rs, mdOpts); err != nil {
+			fmt.Fprintf(stderr, "error: write markdown output: %v\n", err)
 			return 1
 		}
 	}

--- a/output/markdown.go
+++ b/output/markdown.go
@@ -1,0 +1,391 @@
+package output
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+)
+
+// MarkdownOptions controls markdown report output.
+type MarkdownOptions struct {
+	QueryName        string        // displayed in the title (e.g. from @name or filename)
+	QueryDescription string        // displayed as a blockquote
+	QueryID          string        // displayed as a code-formatted line (e.g. from @id)
+	ToolVersion      string        // tool version string (footer)
+	SourceRoot       string        // base dir for resolving relative file paths in snippets
+	WallTime         time.Duration // total query wall time (footer)
+	ContextLines     int           // lines of context above/below the match (default 5)
+	// FileColumn and LineColumn override the column-name heuristic when set
+	// (>= 0). Useful for queries whose select clauses end up with auto-named
+	// columns (col0, col1, ...) — the user can point at the right indices
+	// directly. Negative values fall back to the heuristic.
+	FileColumn int
+	LineColumn int
+}
+
+// WriteMarkdown writes the ResultSet as a self-contained markdown report to w.
+//
+// Each result row that has a resolvable file+line gets its own section with a
+// header, and a fenced code block containing the matched line plus
+// opts.ContextLines lines of surrounding context. The matched line is marked
+// with a trailing comment in the snippet's gutter prefix.
+//
+// File contents are read once per file and cached for the lifetime of the call.
+// Files that cannot be opened are reported with a note in place of the snippet
+// rather than failing the whole report.
+func WriteMarkdown(w io.Writer, rs *eval.ResultSet, opts MarkdownOptions) error {
+	if opts.QueryName == "" {
+		opts.QueryName = "tsq-query"
+	}
+	if opts.ToolVersion == "" {
+		opts.ToolVersion = "0.0.1-dev"
+	}
+	if opts.ContextLines <= 0 {
+		opts.ContextLines = 5
+	}
+	// Column-index overrides: callers must set negative values to opt out
+	// (i.e. fall back to the column-name heuristic). Struct-literal
+	// callers using zero-values get treated as "not set" — both-zero is
+	// disambiguated by negative defaulting in the constructor below.
+	fileColOverride := opts.FileColumn
+	lineColOverride := opts.LineColumn
+	// A zero-value MarkdownOptions (no fields set) means "auto" — flip the
+	// 0/0 sentinel into the explicit -1/-1 disabled-override state.
+	if fileColOverride == 0 && lineColOverride == 0 {
+		fileColOverride = -1
+		lineColOverride = -1
+	}
+
+	bw := bufio.NewWriter(w)
+
+	// Header.
+	fmt.Fprintf(bw, "# %s\n\n", opts.QueryName)
+	if strings.TrimSpace(opts.QueryDescription) != "" {
+		for _, line := range strings.Split(strings.TrimSpace(opts.QueryDescription), "\n") {
+			fmt.Fprintf(bw, "> %s\n", line)
+		}
+		fmt.Fprintln(bw)
+	}
+	if opts.QueryID != "" {
+		fmt.Fprintf(bw, "`%s`\n\n", opts.QueryID)
+	}
+
+	// Index columns once.
+	colIdx := make(map[string]int, len(rs.Columns))
+	for i, c := range rs.Columns {
+		colIdx[c] = i
+	}
+
+	cache := newFileCache(opts.SourceRoot)
+
+	rendered := 0
+	for _, row := range rs.Rows {
+		file, line, ok := tryResolveFileLine(colIdx, row, fileColOverride, lineColOverride)
+		if !ok {
+			// No location — render as a plain bullet so the data isn't lost.
+			fmt.Fprintf(bw, "- %s\n", buildRowMessage(rs.Columns, row))
+			rendered++
+			continue
+		}
+
+		fmt.Fprintf(bw, "## %s:%d\n\n", file, line)
+
+		// Per-row message line. Suppress when the first column is a bare
+		// integer node ID (common when queries select an `int` AST handle)
+		// or when it duplicates the file path — in both cases the line adds
+		// nothing for a human reader.
+		msg := buildRowMessage(rs.Columns, row)
+		if msg != "" && msg != file && !looksLikeBareInt(msg) {
+			fmt.Fprintf(bw, "%s\n\n", msg)
+		}
+
+		lang := languageForFile(file)
+		snippet, err := cache.snippet(file, line, opts.ContextLines)
+		if err != nil {
+			fmt.Fprintf(bw, "_could not read source: %v_\n\n", err)
+			rendered++
+			continue
+		}
+		fmt.Fprintf(bw, "```%s\n", lang)
+		if _, werr := bw.WriteString(snippet); werr != nil {
+			return werr
+		}
+		if !strings.HasSuffix(snippet, "\n") {
+			if werr := bw.WriteByte('\n'); werr != nil {
+				return werr
+			}
+		}
+		fmt.Fprintln(bw, "```")
+		fmt.Fprintln(bw)
+		rendered++
+	}
+
+	// Footer.
+	fmt.Fprintln(bw, "---")
+	fmt.Fprintf(bw, "_%d result(s) in %s — tsq %s_\n", len(rs.Rows), formatDuration(opts.WallTime), opts.ToolVersion)
+	_ = rendered
+	return bw.Flush()
+}
+
+// tryResolveFileLine extracts (file, line) from a row using the same column
+// heuristics as SARIF location extraction. Explicit column-index overrides
+// (>= 0) take precedence over the name-based heuristic.
+func tryResolveFileLine(colIdx map[string]int, row []eval.Value, fileColOverride, lineColOverride int) (string, int, bool) {
+	fileCol := -1
+	if fileColOverride >= 0 {
+		fileCol = fileColOverride
+	} else {
+		for _, name := range []string{"file", "path", "filepath", "uri"} {
+			if idx, ok := colIdx[name]; ok {
+				fileCol = idx
+				break
+			}
+		}
+	}
+	if fileCol < 0 || fileCol >= len(row) {
+		return "", 0, false
+	}
+	file := eval.ValueToString(row[fileCol])
+	if file == "" {
+		return "", 0, false
+	}
+
+	lineCol := -1
+	if lineColOverride >= 0 {
+		lineCol = lineColOverride
+	} else {
+		for _, name := range []string{"line", "startLine", "start_line"} {
+			if idx, ok := colIdx[name]; ok {
+				lineCol = idx
+				break
+			}
+		}
+	}
+	if lineCol < 0 || lineCol >= len(row) {
+		return file, 0, false
+	}
+	iv, ok := row[lineCol].(eval.IntVal)
+	if !ok {
+		return file, 0, false
+	}
+	return file, int(iv.V), true
+}
+
+// fileCache reads source files once and serves snippet requests against them.
+type fileCache struct {
+	root  string
+	files map[string][]string // path -> lines (no trailing \n)
+	errs  map[string]error
+}
+
+func newFileCache(root string) *fileCache {
+	return &fileCache{
+		root:  root,
+		files: make(map[string][]string),
+		errs:  make(map[string]error),
+	}
+}
+
+func (c *fileCache) load(path string) ([]string, error) {
+	if lines, ok := c.files[path]; ok {
+		return lines, nil
+	}
+	if err, ok := c.errs[path]; ok {
+		return nil, err
+	}
+	full := path
+	if c.root != "" && !filepath.IsAbs(path) {
+		full = filepath.Join(c.root, path)
+	}
+	data, err := os.ReadFile(full)
+	if err != nil {
+		c.errs[path] = err
+		return nil, err
+	}
+	// Use Split rather than SplitAfter to keep lines clean; we add the
+	// trailing newline back when emitting.
+	text := strings.ReplaceAll(string(data), "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	c.files[path] = lines
+	return lines, nil
+}
+
+// snippet returns a rendered code block body containing line and ±ctx lines
+// of context, with a 4-char gutter (line number + match marker).
+func (c *fileCache) snippet(path string, line, ctx int) (string, error) {
+	lines, err := c.load(path)
+	if err != nil {
+		return "", err
+	}
+	if line < 1 {
+		return "", fmt.Errorf("invalid line number %d", line)
+	}
+	start := line - ctx
+	if start < 1 {
+		start = 1
+	}
+	end := line + ctx
+	if end > len(lines) {
+		end = len(lines)
+	}
+	// Trim a trailing empty element from a final \n.
+	if end == len(lines) && end > 0 && lines[end-1] == "" {
+		end--
+	}
+	if start > end {
+		return "", fmt.Errorf("line %d outside file (length %d)", line, len(lines))
+	}
+
+	width := len(fmt.Sprintf("%d", end))
+	var sb strings.Builder
+	for i := start; i <= end; i++ {
+		marker := "  "
+		if i == line {
+			marker = "> "
+		}
+		fmt.Fprintf(&sb, "%s%*d | %s\n", marker, width, i, lines[i-1])
+	}
+	return sb.String(), nil
+}
+
+// looksLikeBareInt reports whether s parses as a signed decimal integer with
+// no other characters. Used to suppress noisy per-row messages when the
+// first selected column is an AST node ID.
+func looksLikeBareInt(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	start := 0
+	if s[0] == '-' || s[0] == '+' {
+		if len(s) == 1 {
+			return false
+		}
+		start = 1
+	}
+	for i := start; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// languageForFile returns a markdown code-fence language hint based on the
+// file extension. Falls back to "" (plain) when unknown.
+func languageForFile(path string) string {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".ts":
+		return "ts"
+	case ".tsx":
+		return "tsx"
+	case ".js", ".mjs", ".cjs":
+		return "js"
+	case ".jsx":
+		return "jsx"
+	case ".json":
+		return "json"
+	case ".go":
+		return "go"
+	case ".py":
+		return "python"
+	case ".rs":
+		return "rust"
+	case ".css":
+		return "css"
+	case ".html":
+		return "html"
+	case ".md":
+		return "markdown"
+	case ".yml", ".yaml":
+		return "yaml"
+	case ".sh", ".bash":
+		return "bash"
+	}
+	return ""
+}
+
+// formatDuration renders a duration with sensible precision for the footer.
+func formatDuration(d time.Duration) string {
+	if d <= 0 {
+		return "n/a"
+	}
+	if d < time.Microsecond {
+		return d.String()
+	}
+	if d < time.Millisecond {
+		return fmt.Sprintf("%dµs", d.Microseconds())
+	}
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	return d.Round(10 * time.Millisecond).String()
+}
+
+// metadataRe matches /** ... */ leading block comments in CodeQL-style query
+// headers. Used to extract @name / @description / @id when present.
+var metadataRe = regexp.MustCompile(`(?s)^\s*/\*\*(.*?)\*/`)
+
+// ParseQueryMetadata extracts @name, @description, and @id from the leading
+// /** ... */ block of a query source. Returns zero values when no such block
+// is present. Whitespace and leading "*" gutters are stripped.
+//
+// Exported for use by callers that want to populate MarkdownOptions from a
+// raw query file without re-implementing the parser.
+func ParseQueryMetadata(src string) (name, description, id string) {
+	m := metadataRe.FindStringSubmatch(src)
+	if m == nil {
+		return "", "", ""
+	}
+	body := m[1]
+
+	// Normalise gutters: each line may start with whitespace + "*".
+	var clean []string
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimLeft(line, " \t")
+		line = strings.TrimPrefix(line, "*")
+		line = strings.TrimLeft(line, " \t")
+		clean = append(clean, line)
+	}
+
+	// Walk lines, splitting on @tag boundaries. Tag content runs until the
+	// next @tag or end of comment.
+	type tag struct{ name, value string }
+	var tags []tag
+	var cur *tag
+	for _, line := range clean {
+		if strings.HasPrefix(line, "@") {
+			parts := strings.SplitN(line, " ", 2)
+			t := tag{name: strings.TrimPrefix(parts[0], "@")}
+			if len(parts) == 2 {
+				t.value = parts[1]
+			}
+			tags = append(tags, t)
+			cur = &tags[len(tags)-1]
+		} else if cur != nil && strings.TrimSpace(line) != "" {
+			cur.value += "\n" + line
+		}
+	}
+	// Stable ordering by tag name doesn't matter; we only consume known ones.
+	sort.SliceStable(tags, func(i, j int) bool { return false })
+	for _, t := range tags {
+		switch t.name {
+		case "name":
+			name = strings.TrimSpace(t.value)
+		case "description":
+			description = strings.TrimSpace(t.value)
+		case "id":
+			id = strings.TrimSpace(t.value)
+		}
+	}
+	return name, description, id
+}

--- a/output/markdown.go
+++ b/output/markdown.go
@@ -2,17 +2,23 @@ package output
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
 	"github.com/Gjdoalfnrxu/tsq/ql/eval"
 )
+
+// errPathOutsideRoot is returned by fileCache.load when SourceRoot is set and
+// the requested path resolves outside the root (absolute path or upward
+// traversal). WriteMarkdown turns this into a "path outside source root" note
+// instead of a hard read error.
+var errPathOutsideRoot = errors.New("path outside source root")
 
 // MarkdownOptions controls markdown report output.
 type MarkdownOptions struct {
@@ -52,19 +58,21 @@ func WriteMarkdown(w io.Writer, rs *eval.ResultSet, opts MarkdownOptions) error 
 		opts.ContextLines = 5
 	}
 	// Column-index overrides: callers must set negative values to opt out
-	// (i.e. fall back to the column-name heuristic). Struct-literal
-	// callers using zero-values get treated as "not set" — both-zero is
-	// disambiguated by negative defaulting in the constructor below.
+	// (i.e. fall back to the column-name heuristic). The CLI defaults
+	// --md-file-col and --md-line-col to -1, so a zero here is a real
+	// caller-provided index (e.g. col 0 is the file column).
 	fileColOverride := opts.FileColumn
 	lineColOverride := opts.LineColumn
-	// A zero-value MarkdownOptions (no fields set) means "auto" — flip the
-	// 0/0 sentinel into the explicit -1/-1 disabled-override state.
-	if fileColOverride == 0 && lineColOverride == 0 {
-		fileColOverride = -1
-		lineColOverride = -1
-	}
 
 	bw := bufio.NewWriter(w)
+
+	// Nil result-set guard: emit a minimal header + "no results" footer.
+	if rs == nil {
+		fmt.Fprintf(bw, "# %s\n\n", opts.QueryName)
+		fmt.Fprintln(bw, "---")
+		fmt.Fprintf(bw, "_0 result(s) in %s — tsq %s_\n", formatDuration(opts.WallTime), opts.ToolVersion)
+		return bw.Flush()
+	}
 
 	// Header.
 	fmt.Fprintf(bw, "# %s\n\n", opts.QueryName)
@@ -86,13 +94,11 @@ func WriteMarkdown(w io.Writer, rs *eval.ResultSet, opts MarkdownOptions) error 
 
 	cache := newFileCache(opts.SourceRoot)
 
-	rendered := 0
 	for _, row := range rs.Rows {
 		file, line, ok := tryResolveFileLine(colIdx, row, fileColOverride, lineColOverride)
 		if !ok {
 			// No location — render as a plain bullet so the data isn't lost.
 			fmt.Fprintf(bw, "- %s\n", buildRowMessage(rs.Columns, row))
-			rendered++
 			continue
 		}
 
@@ -110,11 +116,15 @@ func WriteMarkdown(w io.Writer, rs *eval.ResultSet, opts MarkdownOptions) error 
 		lang := languageForFile(file)
 		snippet, err := cache.snippet(file, line, opts.ContextLines)
 		if err != nil {
-			fmt.Fprintf(bw, "_could not read source: %v_\n\n", err)
-			rendered++
+			if errors.Is(err, errPathOutsideRoot) {
+				fmt.Fprintf(bw, "_skipped: path outside source root_\n\n")
+			} else {
+				fmt.Fprintf(bw, "_could not read source: %v_\n\n", err)
+			}
 			continue
 		}
-		fmt.Fprintf(bw, "```%s\n", lang)
+		fence := fenceFor(snippet)
+		fmt.Fprintf(bw, "%s%s\n", fence, lang)
 		if _, werr := bw.WriteString(snippet); werr != nil {
 			return werr
 		}
@@ -123,16 +133,38 @@ func WriteMarkdown(w io.Writer, rs *eval.ResultSet, opts MarkdownOptions) error 
 				return werr
 			}
 		}
-		fmt.Fprintln(bw, "```")
+		fmt.Fprintln(bw, fence)
 		fmt.Fprintln(bw)
-		rendered++
 	}
 
 	// Footer.
 	fmt.Fprintln(bw, "---")
 	fmt.Fprintf(bw, "_%d result(s) in %s — tsq %s_\n", len(rs.Rows), formatDuration(opts.WallTime), opts.ToolVersion)
-	_ = rendered
 	return bw.Flush()
+}
+
+// fenceFor returns a backtick fence string at least 3 long, and always longer
+// than the longest run of consecutive backticks inside snippet. This prevents
+// a snippet containing literal triple-backticks from prematurely closing the
+// outer fence.
+func fenceFor(snippet string) string {
+	longest := 0
+	run := 0
+	for i := 0; i < len(snippet); i++ {
+		if snippet[i] == '`' {
+			run++
+			if run > longest {
+				longest = run
+			}
+		} else {
+			run = 0
+		}
+	}
+	n := longest + 1
+	if n < 3 {
+		n = 3
+	}
+	return strings.Repeat("`", n)
 }
 
 // tryResolveFileLine extracts (file, line) from a row using the same column
@@ -180,6 +212,9 @@ func tryResolveFileLine(colIdx map[string]int, row []eval.Value, fileColOverride
 }
 
 // fileCache reads source files once and serves snippet requests against them.
+//
+// Not safe for concurrent use; intended for one-shot CLI runs where a single
+// goroutine builds the report.
 type fileCache struct {
 	root  string
 	files map[string][]string // path -> lines (no trailing \n)
@@ -202,8 +237,22 @@ func (c *fileCache) load(path string) ([]string, error) {
 		return nil, err
 	}
 	full := path
-	if c.root != "" && !filepath.IsAbs(path) {
-		full = filepath.Join(c.root, path)
+	if c.root != "" {
+		// Containment: when a root is configured, reject absolute paths
+		// from query results outright, and reject any relative path that
+		// escapes the root via ".." traversal. When no root is set,
+		// behaviour is unchanged — the caller is trusted to supply paths.
+		if filepath.IsAbs(path) {
+			c.errs[path] = errPathOutsideRoot
+			return nil, errPathOutsideRoot
+		}
+		joined := filepath.Join(c.root, path)
+		rel, relErr := filepath.Rel(c.root, joined)
+		if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+			c.errs[path] = errPathOutsideRoot
+			return nil, errPathOutsideRoot
+		}
+		full = joined
 	}
 	data, err := os.ReadFile(full)
 	if err != nil {
@@ -375,8 +424,6 @@ func ParseQueryMetadata(src string) (name, description, id string) {
 			cur.value += "\n" + line
 		}
 	}
-	// Stable ordering by tag name doesn't matter; we only consume known ones.
-	sort.SliceStable(tags, func(i, j int) bool { return false })
 	for _, t := range tags {
 		switch t.name {
 		case "name":

--- a/output/markdown_test.go
+++ b/output/markdown_test.go
@@ -1,0 +1,208 @@
+package output
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+)
+
+func writeFixture(t *testing.T, dir, rel, body string) {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWriteMarkdown_Empty(t *testing.T) {
+	rs := &eval.ResultSet{Columns: []string{"name"}, Rows: nil}
+	var buf bytes.Buffer
+	if err := WriteMarkdown(&buf, rs, MarkdownOptions{QueryName: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "# demo") {
+		t.Errorf("missing title header: %q", out)
+	}
+	if !strings.Contains(out, "0 result(s)") {
+		t.Errorf("missing result count footer: %q", out)
+	}
+}
+
+func TestWriteMarkdown_RendersSnippetsForResults(t *testing.T) {
+	dir := t.TempDir()
+
+	tsBody := strings.Join([]string{
+		"// line 1",
+		"// line 2",
+		"// line 3",
+		"// line 4",
+		"// line 5",
+		"export function foo() {", // line 6
+		"  setState(updater);",    // line 7 -- match
+		"}",                       // line 8
+		"// line 9",
+		"// line 10",
+		"// line 11",
+		"// line 12",
+		"",
+	}, "\n")
+	writeFixture(t, dir, "src/foo.tsx", tsBody)
+
+	otherBody := strings.Join([]string{
+		"package x",
+		"",
+		"func Bar() {}", // line 3 -- match
+		"",
+		"// trailing",
+	}, "\n")
+	writeFixture(t, dir, "pkg/bar.go", otherBody)
+
+	rs := &eval.ResultSet{
+		Columns: []string{"name", "file", "line"},
+		Rows: [][]eval.Value{
+			{eval.StrVal{V: "setState"}, eval.StrVal{V: "src/foo.tsx"}, eval.IntVal{V: 7}},
+			{eval.StrVal{V: "Bar"}, eval.StrVal{V: "pkg/bar.go"}, eval.IntVal{V: 3}},
+			{eval.StrVal{V: "no-loc"}, eval.StrVal{V: ""}, eval.IntVal{V: 0}},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := WriteMarkdown(&buf, rs, MarkdownOptions{
+		QueryName:        "find-setstate",
+		QueryDescription: "Find suspicious setState callers.",
+		QueryID:          "ts/find-setstate",
+		SourceRoot:       dir,
+		WallTime:         12 * time.Millisecond,
+		ContextLines:     5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{
+		"# find-setstate",
+		"> Find suspicious setState callers.",
+		"`ts/find-setstate`",
+		"## src/foo.tsx:7",
+		"## pkg/bar.go:3",
+		"```tsx",
+		"```go",
+		"setState(updater);",
+		"func Bar() {}",
+		"3 result(s) in 12ms",
+		">  7 |", // matched-line marker (width-padded) for tsx
+		"> 3 |",  // matched-line marker for go
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+func TestWriteMarkdown_MissingFileNoted(t *testing.T) {
+	dir := t.TempDir()
+	rs := &eval.ResultSet{
+		Columns: []string{"file", "line"},
+		Rows: [][]eval.Value{
+			{eval.StrVal{V: "does/not/exist.ts"}, eval.IntVal{V: 1}},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteMarkdown(&buf, rs, MarkdownOptions{SourceRoot: dir}); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "## does/not/exist.ts:1") {
+		t.Errorf("missing header for unresolved file: %q", out)
+	}
+	if !strings.Contains(out, "could not read source") {
+		t.Errorf("missing read-error note: %q", out)
+	}
+}
+
+func TestParseQueryMetadata(t *testing.T) {
+	src := `/**
+ * @name Find unused vars
+ * @description Detects variables that are declared
+ *              but never read.
+ * @id js/unused-vars
+ * @kind problem
+ */
+import javascript
+
+from Variable v
+select v`
+
+	name, desc, id := ParseQueryMetadata(src)
+	if name != "Find unused vars" {
+		t.Errorf("name = %q", name)
+	}
+	if !strings.Contains(desc, "Detects variables") || !strings.Contains(desc, "never read") {
+		t.Errorf("description = %q", desc)
+	}
+	if id != "js/unused-vars" {
+		t.Errorf("id = %q", id)
+	}
+}
+
+func TestParseQueryMetadata_Absent(t *testing.T) {
+	name, desc, id := ParseQueryMetadata("from X x select x\n")
+	if name != "" || desc != "" || id != "" {
+		t.Errorf("expected zero values, got name=%q desc=%q id=%q", name, desc, id)
+	}
+}
+
+func TestWriteMarkdown_ColumnIndexOverride(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "x/y.ts", "a\nb\nc\nd\ne\nf\ng\n")
+	rs := &eval.ResultSet{
+		// Simulate auto-named columns from the planner: col0 (id), col1 (path), col2 (line).
+		Columns: []string{"col0", "col1", "col2"},
+		Rows: [][]eval.Value{
+			{eval.IntVal{V: 999}, eval.StrVal{V: "x/y.ts"}, eval.IntVal{V: 4}},
+		},
+	}
+	var buf bytes.Buffer
+	err := WriteMarkdown(&buf, rs, MarkdownOptions{
+		SourceRoot: dir,
+		FileColumn: 1,
+		LineColumn: 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "## x/y.ts:4") {
+		t.Errorf("override didn't take effect: %q", out)
+	}
+	if !strings.Contains(out, "> 4 |") {
+		t.Errorf("snippet missing matched-line marker: %q", out)
+	}
+}
+
+func TestLanguageForFile(t *testing.T) {
+	cases := map[string]string{
+		"a.ts":    "ts",
+		"a.tsx":   "tsx",
+		"a.js":    "js",
+		"a.jsx":   "jsx",
+		"a.go":    "go",
+		"a.py":    "python",
+		"a.weird": "",
+	}
+	for in, want := range cases {
+		if got := languageForFile(in); got != want {
+			t.Errorf("languageForFile(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/output/markdown_test.go
+++ b/output/markdown_test.go
@@ -25,7 +25,7 @@ func writeFixture(t *testing.T, dir, rel, body string) {
 func TestWriteMarkdown_Empty(t *testing.T) {
 	rs := &eval.ResultSet{Columns: []string{"name"}, Rows: nil}
 	var buf bytes.Buffer
-	if err := WriteMarkdown(&buf, rs, MarkdownOptions{QueryName: "demo"}); err != nil {
+	if err := WriteMarkdown(&buf, rs, MarkdownOptions{QueryName: "demo", FileColumn: -1, LineColumn: -1}); err != nil {
 		t.Fatal(err)
 	}
 	out := buf.String()
@@ -83,6 +83,8 @@ func TestWriteMarkdown_RendersSnippetsForResults(t *testing.T) {
 		SourceRoot:       dir,
 		WallTime:         12 * time.Millisecond,
 		ContextLines:     5,
+		FileColumn:       -1,
+		LineColumn:       -1,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -118,7 +120,7 @@ func TestWriteMarkdown_MissingFileNoted(t *testing.T) {
 		},
 	}
 	var buf bytes.Buffer
-	if err := WriteMarkdown(&buf, rs, MarkdownOptions{SourceRoot: dir}); err != nil {
+	if err := WriteMarkdown(&buf, rs, MarkdownOptions{SourceRoot: dir, FileColumn: -1, LineColumn: -1}); err != nil {
 		t.Fatal(err)
 	}
 	out := buf.String()
@@ -147,8 +149,9 @@ select v`
 	if name != "Find unused vars" {
 		t.Errorf("name = %q", name)
 	}
-	if !strings.Contains(desc, "Detects variables") || !strings.Contains(desc, "never read") {
-		t.Errorf("description = %q", desc)
+	wantDesc := "Detects variables that are declared\nbut never read."
+	if desc != wantDesc {
+		t.Errorf("description = %q, want %q", desc, wantDesc)
 	}
 	if id != "js/unused-vars" {
 		t.Errorf("id = %q", id)
@@ -187,6 +190,126 @@ func TestWriteMarkdown_ColumnIndexOverride(t *testing.T) {
 	}
 	if !strings.Contains(out, "> 4 |") {
 		t.Errorf("snippet missing matched-line marker: %q", out)
+	}
+}
+
+// M1: a caller that explicitly passes FileColumn=0, LineColumn=1 must have
+// those indices respected — the old 0/0 sentinel collapse used to flip both
+// to -1, which would then re-engage the column-name heuristic and miss col 0
+// as the file column.
+func TestWriteMarkdown_RespectsZeroFileColumn(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "z.ts", "a\nb\nc\nd\ne\n")
+	rs := &eval.ResultSet{
+		// No "file"/"line" name match — heuristic would fail.
+		Columns: []string{"col0", "col1"},
+		Rows: [][]eval.Value{
+			{eval.StrVal{V: "z.ts"}, eval.IntVal{V: 2}},
+		},
+	}
+	var buf bytes.Buffer
+	err := WriteMarkdown(&buf, rs, MarkdownOptions{
+		SourceRoot: dir,
+		FileColumn: 0,
+		LineColumn: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "## z.ts:2") {
+		t.Errorf("FileColumn=0 not respected: %q", out)
+	}
+}
+
+// M2: a row whose file path escapes the configured SourceRoot must be reported
+// as a skipped section rather than reading anything outside the root.
+func TestWriteMarkdown_PathTraversalContained(t *testing.T) {
+	dir := t.TempDir()
+	// Create a real file outside the root that we must NOT read.
+	outside := filepath.Join(filepath.Dir(dir), "escape.txt")
+	if err := os.WriteFile(outside, []byte("SECRET\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(outside)
+
+	rs := &eval.ResultSet{
+		Columns: []string{"file", "line"},
+		Rows: [][]eval.Value{
+			{eval.StrVal{V: "../escape.txt"}, eval.IntVal{V: 1}},
+			{eval.StrVal{V: outside}, eval.IntVal{V: 1}}, // absolute path
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteMarkdown(&buf, rs, MarkdownOptions{SourceRoot: dir, FileColumn: -1, LineColumn: -1}); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "SECRET") {
+		t.Fatalf("file content outside root leaked into report: %q", out)
+	}
+	if !strings.Contains(out, "skipped: path outside source root") {
+		t.Errorf("missing skip note for traversal: %q", out)
+	}
+	// Both rows should be skipped (relative .. and absolute).
+	if got := strings.Count(out, "skipped: path outside source root"); got != 2 {
+		t.Errorf("expected 2 skip notes, got %d: %q", got, out)
+	}
+}
+
+// M3: a snippet containing literal triple-backticks must be wrapped in a fence
+// strictly longer than the longest backtick run, so the outer report is not
+// corrupted (the closing fence is not eaten by snippet content).
+func TestWriteMarkdown_FenceEscalation(t *testing.T) {
+	dir := t.TempDir()
+	// Snippet content with a literal ``` and a literal ```` (4 backticks).
+	body := strings.Join([]string{
+		"line1",
+		"```still inside```",
+		"````even longer````",
+		"target line",
+		"line5",
+	}, "\n") + "\n"
+	writeFixture(t, dir, "f.md", body)
+	rs := &eval.ResultSet{
+		Columns: []string{"file", "line"},
+		Rows: [][]eval.Value{
+			{eval.StrVal{V: "f.md"}, eval.IntVal{V: 4}},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteMarkdown(&buf, rs, MarkdownOptions{
+		SourceRoot:   dir,
+		ContextLines: 5,
+		FileColumn:   -1,
+		LineColumn:   -1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	// Fence must be at least 5 backticks (one longer than the 4-run in content).
+	if !strings.Contains(out, "`````") {
+		t.Errorf("expected 5+ backtick fence, got: %q", out)
+	}
+	// The footer "_1 result(s)_" must still appear — i.e. the snippet did
+	// not break out of its fence and corrupt subsequent rendering.
+	if !strings.Contains(out, "1 result(s)") {
+		t.Errorf("footer missing — fence likely corrupted output: %q", out)
+	}
+}
+
+// M8: nil ResultSet must not panic; a minimal header + footer is emitted.
+func TestWriteMarkdown_NilResultSet(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteMarkdown(&buf, nil, MarkdownOptions{QueryName: "nilcase"}); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "# nilcase") {
+		t.Errorf("missing title: %q", out)
+	}
+	if !strings.Contains(out, "0 result(s)") {
+		t.Errorf("missing zero-results footer: %q", out)
 	}
 }
 


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Summary

Adds a self-contained markdown report format alongside the existing SARIF / JSON / CSV outputs from `tsq query`. The intent: a single file you can open and immediately see *where* each result is and *what the surrounding code looks like*, without round-tripping through SARIF tooling.

- New `output/markdown.go` with `WriteMarkdown(w, rs, opts)` mirroring `output/sarif.go`'s shape.
- New CLI: `tsq query --format markdown|md [--source-root DIR] [--md-file-col N] [--md-line-col N] QUERY_FILE`.
- Per-result section: `## file/path.tsx:NNN` header, fenced code block with language inferred from extension, ±5 lines of context with the matched line marked by a `> N |` gutter prefix.
- Header pulls `@name` / `@description` / `@id` from a leading `/** ... */` block in the query file when present (`output.ParseQueryMetadata`).
- Footer with result count, wall time, and tool version.
- File reads cached per call so repeated hits in the same file don't re-open it.

## Why the column-index overrides?

The select clause currently drops `as "alias"` annotations — `rs.Columns` ends up as `col0/col1/...` (see `ql/eval/seminaive.go:533-540`). SARIF's column-name heuristic silently misses in that case; markdown would have done the same. `--md-file-col` / `--md-line-col` give users a concrete escape hatch without forcing query rewrites. Defaults (`-1`) preserve the existing name-based heuristic. Worth filing as a separate planner issue — leaving that out of this PR.

## Test plan

- [x] `go test ./... -race -count=1` — all green
- [x] Built on cain-nas, ran against mastodon corpus with `find_setstate_updater_calls_fn` (extended to also select file+line via `ASTNode.getFile().getPath()`). 11 results, all rendered with correct context. Sample output: `~/setstate-bench/results/mastodon-fn.md` on the NAS, also at `/tmp/mastodon-fn.md` locally.
- [x] Existing JSON/CSV/SARIF behaviour unchanged (default format still `json`).