### PR TITLE
feat(cli): query/check diagnostic flags

### DIFF
--- a/cmd/tsq/diag.go
+++ b/cmd/tsq/diag.go
@@ -1,0 +1,195 @@
+package main
+
+// Diagnostic helpers for the `tsq query` and `tsq check` commands. These
+// support the --print-rel-sizes, --dump-plan, and --dump-rewritten-rules
+// flags added to help debug planner/eval issues on production fact DBs
+// (see the _disj_2 step-2 cap-hit investigation, branch
+// investigate/disj2-step2-cap).
+//
+// Kept in a standalone file so the diagnostic surface can be extended
+// (and tested) without continuing to bloat main.go.
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/Gjdoalfnrxu/tsq/extract/db"
+	"github.com/Gjdoalfnrxu/tsq/extract/schema"
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+)
+
+// printRelSizes writes one line per non-empty fact relation in factDB to w,
+// sorted by descending row count. Format: `rel <name> <rowCount>`.
+//
+// Iteration uses schema.Registry as the source of truth for which relations
+// exist (matching buildSizeHints in main.go); db.DB does not expose its
+// internal map. Relations with zero rows are suppressed so the output stays
+// useful on extracted DBs that only populate a subset of the schema.
+func printRelSizes(w io.Writer, factDB *db.DB) {
+	type entry struct {
+		name string
+		rows int
+	}
+	entries := make([]entry, 0, len(schema.Registry))
+	for _, def := range schema.Registry {
+		n := factDB.Relation(def.Name).Tuples()
+		if n == 0 {
+			continue
+		}
+		entries = append(entries, entry{def.Name, n})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].rows != entries[j].rows {
+			return entries[i].rows > entries[j].rows
+		}
+		return entries[i].name < entries[j].name
+	})
+	for _, e := range entries {
+		fmt.Fprintf(w, "rel %s %d\n", e.name, e.rows)
+	}
+}
+
+// dumpPlan writes a human-readable rendering of the planned join order for
+// every rule (and the top-level select query, if any) to w. For each step we
+// annotate each argument as bound (B) or free (F) at the point that step is
+// reached. "Bound" means the variable was introduced by an earlier join step
+// in the same rule; constants and wildcards are shown verbatim.
+func dumpPlan(w io.Writer, ep *plan.ExecutionPlan) {
+	if ep == nil {
+		fmt.Fprintln(w, "[dump-plan] (nil execution plan)")
+		return
+	}
+	fmt.Fprintln(w, "[dump-plan] planned join orders:")
+	for si, st := range ep.Strata {
+		fmt.Fprintf(w, "  stratum %d (%d rules)\n", si, len(st.Rules))
+		for _, r := range st.Rules {
+			fmt.Fprintf(w, "    rule %s :-\n", atomDump(r.Head))
+			bound := map[string]bool{}
+			for i, step := range r.JoinOrder {
+				marker := "+"
+				if step.IsFilter {
+					marker = "f"
+				}
+				fmt.Fprintf(w, "      %s[%d] %s\n", marker, i, literalDump(step.Literal, bound))
+				// After this step, every variable in the literal becomes bound
+				// (positive joins introduce bindings; negative/anti-join
+				// literals do not, but for the bound/free annotation on
+				// subsequent steps the conservative thing is to mark them
+				// bound only when the literal contributes bindings).
+				if step.Literal.Positive && step.Literal.Atom.Predicate != "" {
+					for _, t := range step.Literal.Atom.Args {
+						if v, ok := t.(datalog.Var); ok {
+							bound[v.Name] = true
+						}
+					}
+				}
+			}
+		}
+	}
+	if ep.Query != nil {
+		fmt.Fprintln(w, "  query:")
+		bound := map[string]bool{}
+		for i, step := range ep.Query.JoinOrder {
+			marker := "+"
+			if step.IsFilter {
+				marker = "f"
+			}
+			fmt.Fprintf(w, "    %s[%d] %s\n", marker, i, literalDump(step.Literal, bound))
+			if step.Literal.Positive && step.Literal.Atom.Predicate != "" {
+				for _, t := range step.Literal.Atom.Args {
+					if v, ok := t.(datalog.Var); ok {
+						bound[v.Name] = true
+					}
+				}
+			}
+		}
+		sels := make([]string, len(ep.Query.Select))
+		for i, t := range ep.Query.Select {
+			sels[i] = termDump(t, nil)
+		}
+		fmt.Fprintf(w, "    select %s\n", strings.Join(sels, ", "))
+	}
+}
+
+// atomDump renders an atom without bound/free annotation (used for rule
+// heads, where every variable is by construction free until the body binds it).
+func atomDump(a datalog.Atom) string {
+	parts := make([]string, len(a.Args))
+	for i, t := range a.Args {
+		parts[i] = termDump(t, nil)
+	}
+	return a.Predicate + "(" + strings.Join(parts, ", ") + ")"
+}
+
+// literalDump renders a literal with bound/free annotations on each variable
+// argument given the bound-set entering this step.
+func literalDump(lit datalog.Literal, bound map[string]bool) string {
+	if lit.Cmp != nil {
+		s := termDump(lit.Cmp.Left, bound) + " " + lit.Cmp.Op + " " + termDump(lit.Cmp.Right, bound)
+		if !lit.Positive {
+			return "not(" + s + ")"
+		}
+		return s
+	}
+	if lit.Agg != nil {
+		// Aggregate sub-goals: dump the function and var only; the inner body
+		// has its own join structure that the planner doesn't expose here.
+		return fmt.Sprintf("%s(%s %s | ...)", lit.Agg.Func, lit.Agg.TypeName, lit.Agg.Var)
+	}
+	parts := make([]string, len(lit.Atom.Args))
+	for i, t := range lit.Atom.Args {
+		parts[i] = termDump(t, bound)
+	}
+	s := lit.Atom.Predicate + "(" + strings.Join(parts, ", ") + ")"
+	if !lit.Positive {
+		return "not " + s
+	}
+	return s
+}
+
+// termDump renders a term, annotating Vars with [B] (bound entering this
+// step) or [F] (free) when bound is non-nil.
+func termDump(t datalog.Term, bound map[string]bool) string {
+	switch v := t.(type) {
+	case datalog.Var:
+		if bound == nil {
+			return v.Name
+		}
+		if bound[v.Name] {
+			return v.Name + "[B]"
+		}
+		return v.Name + "[F]"
+	case datalog.IntConst:
+		return fmt.Sprintf("%d", v.Value)
+	case datalog.StringConst:
+		return fmt.Sprintf("%q", v.Value)
+	case datalog.Wildcard:
+		return "_"
+	default:
+		return "?"
+	}
+}
+
+// dumpRewrittenRules prints the program AFTER magic-set rewriting. If
+// queryBindings is empty the magic-set transform is a no-op, so this falls
+// back to printing the input program unchanged with a header noting that.
+//
+// Stringification reuses (*datalog.Program).String for fidelity with the
+// rest of the toolchain.
+func dumpRewrittenRules(w io.Writer, prog *datalog.Program, queryBindings map[string][]int) {
+	if prog == nil {
+		fmt.Fprintln(w, "[dump-rewritten-rules] (nil program)")
+		return
+	}
+	if len(queryBindings) == 0 {
+		fmt.Fprintln(w, "[dump-rewritten-rules] no inferable query bindings; printing input program unchanged:")
+		fmt.Fprintln(w, prog.String())
+		return
+	}
+	transformed := plan.MagicSetTransform(prog, queryBindings)
+	fmt.Fprintf(w, "[dump-rewritten-rules] magic-set transform applied with bindings=%v\n", queryBindings)
+	fmt.Fprintln(w, transformed.String())
+}

--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -527,6 +527,9 @@ func cmdQuery(ctx context.Context, args []string, stdout, stderr io.Writer) int 
 	cpuProfile := fs.String("cpu-profile", "", "write a CPU profile to this `file` for the duration of the query (analyse with 'go tool pprof')")
 	memProfile := fs.String("mem-profile", "", "write a heap profile to this `file` after the query completes (analyse with 'go tool pprof')")
 	memSnapshotDir := fs.String("mem-snapshot-dir", "", "write a heap profile every 10s into this `dir` while the query runs; useful for diagnosing eval-time memory blow-ups (see issue #130)")
+	printRelSizes := fs.Bool("print-rel-sizes", false, "print one line per non-empty fact relation to stderr at evaluation start (descending row count); diagnostic for planner cap-hit investigations")
+	dumpPlan := fs.Bool("dump-plan", false, "after planning, print the planned join order for every rule to stderr with bound/free variable annotations")
+	dumpRewrittenRules := fs.Bool("dump-rewritten-rules", false, "print the rules AFTER magic-set rewrites (before evaluation) to stderr; no-op when --magic-sets is off or no bindings are inferable")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -622,6 +625,15 @@ func cmdQuery(ctx context.Context, args []string, stdout, stderr io.Writer) int 
 	bopts := buildOptions{useMagicSets: *magicSets, magicSetsStrict: *magicSetsStrict, warnOut: stderr}
 	if *verbose {
 		bopts.verboseOut = stderr
+	}
+	if *printRelSizes {
+		bopts.printRelSizesOut = stderr
+	}
+	if *dumpPlan {
+		bopts.dumpPlanOut = stderr
+	}
+	if *dumpRewrittenRules {
+		bopts.dumpRewrittenRulesOut = stderr
 	}
 	queryStart := time.Now()
 	rs, err := compileAndEval(ctx, queryFile, *dbFile, *maxBindingsPerRule, *maxIterations, *allowPartial, bopts)
@@ -721,6 +733,20 @@ func writeMemProfile(path string, stderr io.Writer) {
 func cmdCheck(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("check", flag.ContinueOnError)
 	fs.SetOutput(stderr)
+	// Custom usage so `tsq check --help` (and unknown-flag errors) print a
+	// one-liner describing the subcommand instead of the bare flag dump.
+	// Previously cmdCheck registered no flags and no Usage, so unknown
+	// flags fell through silently — caller-confusing, especially since
+	// the planner-fix investigation involves passing diagnostic flags
+	// to cmdQuery and cmdCheck side by side.
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: tsq check QUERY_FILE")
+		fmt.Fprintln(stderr, "  Validate that QUERY_FILE parses, resolves, desugars, and plans without errors.")
+		fmt.Fprintln(stderr, "  No fact DB is loaded; planning uses default cardinality heuristics.")
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "flags:")
+		fs.PrintDefaults()
+	}
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -808,6 +834,14 @@ type buildOptions struct {
 	magicSetsStrict bool      // when true, surfaces magic-set planning errors instead of silently falling back (issue #112)
 	verboseOut      io.Writer // if non-nil, magic-set-fired diagnostics (verbose) are written here
 	warnOut         io.Writer // if non-nil, magic-set-fallback warnings (always-on) are written here
+
+	// Diagnostic outputs (off when nil). Plumbed from the --print-rel-sizes,
+	// --dump-plan, and --dump-rewritten-rules flags on `tsq query`. Each
+	// writer, when non-nil, receives the corresponding dump at the
+	// appropriate point in compileAndEval. See cmd/tsq/diag.go.
+	printRelSizesOut      io.Writer
+	dumpPlanOut           io.Writer
+	dumpRewrittenRulesOut io.Writer
 }
 
 func buildProgram(src, file string, importLoader func(string) (*ast.Module, error), sizeHints map[string]int) (*plan.ExecutionPlan, *ast.Module, []resolve.Warning, []error) {
@@ -976,6 +1010,13 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string, maxBindingsPe
 	// order joins by true relation size rather than a uniform default of 1000.
 	sizeHints := buildSizeHints(factDB)
 
+	// --print-rel-sizes: emit one line per non-empty fact relation before
+	// any further work, so even an OOM/cap-hit downstream still leaves the
+	// caller with the relation-size snapshot they came for.
+	if opts.printRelSizesOut != nil {
+		printRelSizes(opts.printRelSizesOut, factDB)
+	}
+
 	// Compile (parse → resolve → desugar → MergeSystemRules) WITHOUT planning.
 	// Planning happens below via plan.EstimateAndPlan — the single
 	// estimate-then-plan entry point (P1 of the planner roadmap, replacing
@@ -988,6 +1029,23 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string, maxBindingsPe
 		// by phase and join with newline-indented messages so callers see one
 		// error per phase boundary rather than a flat error.Join blob.
 		return nil, joinPhaseErrors(buildErrs)
+	}
+
+	// --dump-rewritten-rules: emit the program after magic-set rewriting (or
+	// the unmodified program if magic sets are disabled / no bindings are
+	// inferable). Done here, before planning/evaluation, so a cap-hit during
+	// eval still leaves the rewritten rules visible.
+	if opts.dumpRewrittenRulesOut != nil {
+		var bindings map[string][]int
+		if opts.useMagicSets {
+			idb := map[string]bool{}
+			for _, r := range prog.Rules {
+				idb[r.Head.Predicate] = true
+			}
+			inf := plan.InferQueryBindings(prog, idb)
+			bindings = inf.Bindings
+		}
+		dumpRewrittenRules(opts.dumpRewrittenRulesOut, prog, bindings)
 	}
 
 	// Load base relations once and reuse them for both the pre-pass (via the
@@ -1022,6 +1080,13 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string, maxBindingsPe
 			errs = append(errs, fmt.Errorf("plan: %w", e))
 		}
 		return nil, joinPhaseErrors(errs)
+	}
+
+	// --dump-plan: emit the planned join order after the estimate-aware
+	// plan is final but before evaluation. Same rationale as the rewritten-
+	// rules dump: surface diagnostics before any cap-hit can hide them.
+	if opts.dumpPlanOut != nil {
+		dumpPlan(opts.dumpPlanOut, execPlan)
 	}
 
 	// Evaluate.


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Summary
Diagnostic flags to help debug planner/eval issues on production fact DBs (motivated by the `_disj_2` step-2 cap-hit investigation on `investigate/disj2-step2-cap`). Separate from the planner fix itself — pure observability.

- `--print-rel-sizes` on `tsq query` — emits `rel <name> <rowCount>` per non-empty fact relation to stderr at the start of evaluation, sorted by descending row count. Iterates `schema.Registry` (matches `buildSizeHints`); zero-row relations suppressed.
- `--dump-plan` on `tsq query` — after planning, prints planned join order for every rule (and the top-level select) to stderr with bound/free variable annotations (`[B]`/`[F]`) per step, plus filter (`f[i]`) vs. join (`+[i]`) markers. New helper in `cmd/tsq/diag.go` (no existing dump function in `ql/plan`).
- `--dump-rewritten-rules` on `tsq query` — prints rules AFTER magic-set rewriting via `plan.MagicSetTransform` + `(*datalog.Program).String()`. No-op (with explanatory header) when `--magic-sets` is off or `InferQueryBindings` returns no bindings.
- `tsq check --help` / usage block — `fs.Usage` now prints a one-line description and `flag.PrintDefaults` so unknown flags surface a useful message instead of silently failing.

Diagnostic outputs are plumbed through new `buildOptions` fields (`printRelSizesOut`, `dumpPlanOut`, `dumpRewrittenRulesOut`) and emitted inside `compileAndEval` BEFORE evaluation runs, so a downstream cap-hit/OOM still leaves the diagnostic snapshot visible to the caller.

No changes under `ql/plan/`, `ql/eval/`, `ql/desugar/`, or `bridge/` — the planner-fix work happening on the same investigation worktree is not touched.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./cmd/... ./ql/... -race -count=1` passes
- [x] Manual smoke against `testdata/queries/v2/find_setstate_updater_calls_other_setstate.ql` on the `react-usestate` fixture — all three flags emit expected stderr; `tsq check --help` and `tsq check --bogus` both print the usage block