### PR TITLE
fix(plan): (name,arity)-key IDB shadow check in demand-seed body construction

### DIFF
--- a/ql/plan/magicset_demand.go
+++ b/ql/plan/magicset_demand.go
@@ -243,6 +243,10 @@ func buildDemandSeedsForPred(
 ) []datalog.Rule {
 	var seeds []datalog.Rule
 	magicPred := magicName(pred)
+	// Hoisted out of the per-literal hot loop below: the (name, arity) IDB
+	// head index is a function of `prog` only and was previously rebuilt
+	// for every preceding-literal scan. Compute once per call.
+	idbByArity := idbHeadByArity(prog)
 
 	for _, rule := range prog.Rules {
 		// Skip self-recursion on pred — a rule whose head IS pred
@@ -311,11 +315,7 @@ func buildDemandSeedsForPred(
 			// `argFn` in the magic-set seed body. Result: isSafe rejects the
 			// seed (head var not body-bound), no seed is emitted, the synth-
 			// disj rewrite drops on the floor, and `_disj_2` blows the
-			// binding cap on its 5-atom join. (Mirrors P3a / fragility-audit
-			// finding #3 and #9 on InferBackwardDemand's mixed-arity guard,
-			// applied here at the seed-body construction site where the
-			// shadow first matters.)
-			idbByArity := idbHeadByArity(prog)
+			// binding cap on its 5-atom join.
 			for j := 0; j < i; j++ {
 				prev := rule.Body[j]
 				if prev.Agg != nil {

--- a/ql/plan/magicset_demand.go
+++ b/ql/plan/magicset_demand.go
@@ -300,7 +300,22 @@ func buildDemandSeedsForPred(
 			// IDB atom would risk re-introducing the very cardinality
 			// blowup we're trying to bound, so we drop those.
 			var seedBody []datalog.Literal
-			idb := IDBPredicates(prog)
+			// Build an IDB head index keyed by (name, arity). Name-only
+			// keying conflates the desugarer's auto-emitted arity-1
+			// class-extent helpers (e.g. `CallArg(this) :- CallArg(this,_,_).`,
+			// emitted for any `@callarg`-typed parameter under PR #146) with
+			// the underlying arity-N base relation of the same name. Without
+			// arity disambiguation, a preceding `CallArg(c, 0, argFn)` (the
+			// arity-3 base atom) gets dropped here as "an unhinted IDB,"
+			// silently zeroing out the only literal that would have grounded
+			// `argFn` in the magic-set seed body. Result: isSafe rejects the
+			// seed (head var not body-bound), no seed is emitted, the synth-
+			// disj rewrite drops on the floor, and `_disj_2` blows the
+			// binding cap on its 5-atom join. (Mirrors P3a / fragility-audit
+			// finding #3 and #9 on InferBackwardDemand's mixed-arity guard,
+			// applied here at the seed-body construction site where the
+			// shadow first matters.)
+			idbByArity := idbHeadByArity(prog)
 			for j := 0; j < i; j++ {
 				prev := rule.Body[j]
 				if prev.Agg != nil {
@@ -318,11 +333,13 @@ func buildDemandSeedsForPred(
 					continue
 				}
 				// Positive atom: include if it's a base relation
-				// (not an IDB head), OR if it's an IDB head whose
-				// hint marks it as small-extent (safe to evaluate as
-				// part of the seed).
+				// (no IDB rule head matches BOTH name AND arity), OR
+				// if it IS an IDB head at the matching arity but the
+				// hint marks it small-extent (safe to evaluate inside
+				// the seed). Arity-keyed: see comment above.
 				bodyPred := prev.Atom.Predicate
-				if idb[bodyPred] && !isSmallExtent(bodyPred, sizeHints) {
+				bodyArity := len(prev.Atom.Args)
+				if idbByArity[predArity{bodyPred, bodyArity}] && !isSmallExtent(bodyPred, sizeHints) {
 					// Risk re-introducing the blowup; drop.
 					continue
 				}
@@ -558,6 +575,38 @@ func MergeBindings(a, b map[string][]int) map[string][]int {
 		} else {
 			out[k] = append([]int(nil), v...)
 		}
+	}
+	return out
+}
+
+// predArity is a (predicate-name, arity) key used to disambiguate IDB
+// heads from base relations of the same name. The desugarer can emit
+// auto-generated arity-1 class-extent helper rules (e.g.
+// `CallArg(this) :- CallArg(this,_,_).` from PR #146's class-typed
+// parameter injection) over the same name as an existing arity-N base
+// relation. Name-only IDB lookups silently shadow the base relation,
+// causing legitimate base atoms to be rejected as "unhinted IDBs" in
+// seed-body construction. Keying by (name, arity) is sound because
+// the desugarer never collides arities for genuinely-the-same predicate.
+type predArity struct {
+	name  string
+	arity int
+}
+
+// idbHeadByArity returns the set of (name, arity) tuples that appear
+// as rule heads in prog. Used by buildDemandSeedsForPred to filter
+// preceding body literals at the correct arity, so an arity-3 base atom
+// does not get dropped because an arity-1 IDB exists with the same
+// predicate name. Mirrors the (name, arity) keying that
+// InferBackwardDemand applies to its mixedArity guard, applied here at
+// the seed-body construction site.
+func idbHeadByArity(prog *datalog.Program) map[predArity]bool {
+	out := map[predArity]bool{}
+	if prog == nil {
+		return out
+	}
+	for _, r := range prog.Rules {
+		out[predArity{r.Head.Predicate, len(r.Head.Args)}] = true
 	}
 	return out
 }

--- a/ql/plan/magicset_demand_test.go
+++ b/ql/plan/magicset_demand_test.go
@@ -419,6 +419,153 @@ func TestWithMagicSetAuto_RenameTrampolineEndToEnd(t *testing.T) {
 	}
 }
 
+// TestInferRuleBodyDemandBindings_ArityShadowedBaseInPrecedingBody is
+// the regression for the bug where a synth-disj `_disj_N` predicate
+// that should have been magic-set rewritten silently dropped on the
+// floor because the desugarer's arity-1 class-extent helpers (e.g.
+// `CallArg(this) :- CallArg(this,_,_).`, auto-emitted under PR #146 for
+// any `@callarg`-typed parameter) name-shadow the underlying arity-N
+// base relation.
+//
+// Concretely: when buildDemandSeedsForPred constructs a magic-set seed
+// body from a caller's preceding literals, it dropped any literal whose
+// predicate name appeared as an IDB head — even when the caller's
+// occurrence was at a different (base) arity. With the desugarer
+// shipping `Function(this) :- Function(this,_,_,_,_,_).` and the
+// caller body having `Function(argFn,_,_,_,_,_)` (arity 6, the base
+// relation), the arity-6 base atom got dropped because `Function/1`
+// was an IDB head. That removed the only literal grounding `argFn`,
+// `isSafe` rejected the seed, and the synth-disj rewrite never fired —
+// pushing the cap-hit one join step deeper. (Step-2 cap-hit on the
+// `setStateUpdaterCallsOtherSetState` query in production; the same
+// shape that PR #149 thought it had closed for step-1.)
+//
+// This test models the same shape: an arity-1 IDB shadow over the same
+// name as an arity-2 base relation that's load-bearing for grounding
+// the demanded var. With the (name, arity)-keyed shadow check, the
+// arity-2 base is preserved, the seed body grounds the demanded var,
+// and the magic-set rewrite fires.
+func TestInferRuleBodyDemandBindings_ArityShadowedBaseInPrecedingBody(t *testing.T) {
+	// Program:
+	//   Function(this) :- Function(this, _, _).         // arity-1 IDB shadow (desugarer-emitted)
+	//   Caller(c, y) :- ClassExt(c), Function(c, _, _), trampoline(c, y).
+	//   trampoline(c, y) :- _disj_2(c, y).               // pure rename
+	//   _disj_2(c, y) :- A(c, y).                        // base join branch
+	//   _disj_2(c, y) :- B(c, m), C(m, y).               // multi-atom branch
+	//
+	// Demand should reach _disj_2:[0] via the trampoline. Pre-fix, the
+	// preceding `Function(c, _, _)` (arity 3) in Caller's body got
+	// dropped from the magic_trampoline seed body because Function/1
+	// was an IDB head, leaving no grounding for `c`.
+	rules := []datalog.Rule{
+		// Arity-1 class-extent shadow — mirrors the desugarer's
+		// auto-emitted `Foo(this) :- Foo(this,...)` rule for typed
+		// parameters under PR #146.
+		{
+			Head: datalog.Atom{Predicate: "Function", Args: []datalog.Term{datalog.Var{Name: "this"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "Function", Args: []datalog.Term{datalog.Var{Name: "this"}, datalog.Var{Name: "_"}, datalog.Var{Name: "_"}}}},
+			},
+		},
+		// Caller. Arity-3 Function literal is the load-bearing
+		// grounding atom. ClassExt is small but does NOT bind y; only
+		// Function (the base) does, when probed at the magic-set seed
+		// site.
+		{
+			Head: datalog.Atom{Predicate: "Caller", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "ClassExt", Args: []datalog.Term{datalog.Var{Name: "c"}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "Function", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "_"}, datalog.Var{Name: "_"}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}}},
+			},
+		},
+		{
+			Head: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}}},
+			},
+		},
+		{
+			Head: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "B", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "m"}}}},
+				{Positive: true, Atom: datalog.Atom{Predicate: "C", Args: []datalog.Term{datalog.Var{Name: "m"}, datalog.Var{Name: "y"}}}},
+			},
+		},
+	}
+	prog := &datalog.Program{
+		Rules: rules,
+		Query: &datalog.Query{
+			Select: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "Caller", Args: []datalog.Term{datalog.Var{Name: "c"}, datalog.Var{Name: "y"}}}},
+			},
+		},
+	}
+	hints := map[string]int{
+		"ClassExt": 7,      // small extent
+		"Function": 100000, // base — large; the arity-1 head is unhinted
+		"A":        100000,
+		"B":        100000,
+		"C":        100000,
+	}
+	idb := IDBPredicates(prog)
+	if !idb["Function"] {
+		t.Fatal("test setup invariant: Function/1 must be in IDB head set")
+	}
+
+	bindings, seeds := InferRuleBodyDemandBindings(prog, idb, hints)
+	cols, ok := bindings["_disj_2"]
+	if !ok {
+		t.Fatalf("expected _disj_2 in demand bindings (the arity-1 Function shadow should NOT silence it); got bindings=%v seeds=%d",
+			bindings, len(seeds))
+	}
+	if len(cols) != 1 || cols[0] != 0 {
+		t.Fatalf("expected _disj_2 bound at col 0, got %v", cols)
+	}
+	if len(seeds) == 0 {
+		t.Fatal("expected at least one demand-seed for the magic predicate, got 0")
+	}
+	// At least one emitted seed must reference the arity-3 base
+	// Function literal in its body — that's the literal that was being
+	// dropped by the bug. Without it, `c` (or the demanded var) is
+	// ungrounded and isSafe rejects the seed.
+	foundArity3Function := false
+	for _, sr := range seeds {
+		for _, lit := range sr.Body {
+			if lit.Cmp != nil || !lit.Positive {
+				continue
+			}
+			if lit.Atom.Predicate == "Function" && len(lit.Atom.Args) == 3 {
+				foundArity3Function = true
+				break
+			}
+		}
+		if foundArity3Function {
+			break
+		}
+	}
+	if !foundArity3Function {
+		t.Fatalf("expected at least one seed to retain the arity-3 base Function literal in its body (proves arity-keyed shadow check); got seeds=%d, bodies=%v", len(seeds), seedBodySummaries(seeds))
+	}
+}
+
+func seedBodySummaries(seeds []datalog.Rule) []string {
+	out := make([]string, 0, len(seeds))
+	for _, sr := range seeds {
+		bodyPreds := make([]string, 0, len(sr.Body))
+		for _, lit := range sr.Body {
+			if lit.Cmp != nil {
+				bodyPreds = append(bodyPreds, "cmp")
+				continue
+			}
+			bodyPreds = append(bodyPreds, lit.Atom.Predicate)
+		}
+		out = append(out, sr.Head.Predicate+" :- "+strings.Join(bodyPreds, ", "))
+	}
+	return out
+}
+
 func dumpJoinOrder(steps []JoinStep) string {
 	parts := make([]string, 0, len(steps))
 	for _, s := range steps {

--- a/ql/plan/magicset_infer.go
+++ b/ql/plan/magicset_infer.go
@@ -121,6 +121,9 @@ func InferQueryBindings(prog *datalog.Program, idbPreds map[string]bool) QueryBi
 			continue
 		}
 		pred := lit.Atom.Predicate
+		// TODO(#157): same (name, arity) shadow class as fixed in magicset_demand.go;
+		// harmless today (no rule head consumes the misclassified literal) but should
+		// be tightened when #157 is swept.
 		if !idbPreds[pred] {
 			// Not an IDB pred — it can ground variables for subsequent literals,
 			// but only those vars that co-occur with a constant in this base


### PR DESCRIPTION
## Summary

Fixes `_disj_2` step-2 binding-cap blowup on `find_setstate_updater_calls_other_setstate.ql` against real-world TypeScript projects. PR #149 fixed the analogous step-1 hit on the sibling `setStateUpdaterCallsFn` query; this PR addresses a distinct surface uncovered by the same family of queries.

> Note on title: the original task framing ('magic-set/demand propagation through transitive closure of synth-disj') turned out to misdiagnose the failure — `functionContainsStar` is hand-unrolled in `bridge/tsq_react.qll`, not recursive. The actual root cause is arity-shadowing of base relations by desugarer-emitted class-extent helpers. PR title reflects the real fix.

## Root cause

PR #146's class-typed-parameter desugarer auto-emits arity-1 class-extent helper rules of the form:

```
CallArg(this) :- CallArg(this,_,_).
Function(this) :- Function(this,_,_,_,_,_).
```

These shadow the underlying arity-N base relations of the same name in `IDBPredicates(prog)` (which is name-keyed only). In `buildDemandSeedsForPred` (added by PR #149), the seed-body construction drops any preceding literal whose predicate name appears as an IDB head. So the load-bearing arity-3 `CallArg(c, 0, argFn)` and arity-6 `Function(argFn,...)` literals were silently dropped from the magic-set seed body for `magic_functionContainsStar`. With no `argFn`-grounding atoms left, `isSafe` rejects the seed (head var not body-bound), no seed is emitted, the synth-disj rewrite never fires, and `_disj_2`'s 5-atom body (with its `Function(mid1) join Function(mid2)` cross-product) blows the 5M binding cap at step 2.

## Fix

Key the IDB shadow check by `(name, arity)` instead of name only. Mirrors the (name, arity) keying that `InferBackwardDemand` already applies via its `mixedArity` guard (P3a / fragility-audit findings #3 and #9), now applied at the seed-body construction site where the shadow first matters. Sound because the desugarer never collides arities for genuinely-the-same predicate.

Scope: ~30 LOC (one struct + one helper + one call-site change). No cap widening — the fix narrows demand correctly so the seed actually gets built.

## Why #149 didn't catch this

PR #149's tests used distinct base/IDB names — none of them exercised the (name, arity) shadow scenario. The fragility audit had flagged the (name, arity) keying issue for `magicset_infer.go`, but the demand-seed builder added by #149 inherited the same name-only weakness.

## Test plan

- [x] New regression test `TestInferRuleBodyDemandBindings_ArityShadowedBaseInPrecedingBody` synthesises an arity-1 IDB shadow over an arity-3 base relation and asserts the load-bearing base atom is preserved in the seed body
- [x] Verified the test FAILS on pre-fix code: seed body contains only the arity-1 `ClassExt` helper, not the arity-3 base `Function` literal
- [x] Verified the test PASSES post-fix
- [x] `go test ./... -race -count=1` green across all 17 packages
- [x] End-to-end smoke test: `tsq query find_setstate_updater_calls_other_setstate.ql` against `testdata/projects/react-usestate` runs cleanly with no `_disj_2` cap-hit (small fixture; original failure was on a larger real-world DB)