### PR TITLE
fix(plan): bypass extent-size gate for arity-1 class-extent grounders

### DIFF
--- a/ql/plan/backward.go
+++ b/ql/plan/backward.go
@@ -73,6 +73,132 @@ import (
 //     backward_test.go.
 const SmallExtentThreshold = 5000
 
+// LargeArityOneExtentThreshold is the upper bound on a predicate's
+// sizeHint for an arity-1 IDB literal to count as a grounder for its
+// single var.
+//
+// Rationale (disj2-round2 / PR #158): per-tuple iteration of an
+// arity-1 IDB extent is cheap regardless of size — it's a single-column
+// scan. An arity-1 literal whose hint sits in the 5k–500k range (real
+// class extents like UseStateSetterCall on mastodon-shape corpora) is
+// the SOLE source of demand for downstream synth `_disj_*` predicates
+// in setStateUpdater-style queries. Refusing to ground at 5001 because
+// the generic SmallExtentThreshold caps at 5000 leaves the synth-disj
+// with empty demand and forces the planner into a 5-atom cross-product
+// cap-hit. Allowing arity-1 grounding up to a much higher ceiling
+// avoids that failure mode without touching the multi-arity case
+// (where wider tuples make per-tuple scoring matter).
+//
+// Saturated hints (eval.SaturatedSizeHint = 1<<30 → genuinely huge or
+// MaterialiseClassExtents-failed) deliberately stay above this ceiling
+// and continue to drop demand. The fix targets known-mid-sized arity-1
+// extents only; unknowable-size literals remain untreated.
+const LargeArityOneExtentThreshold = 1_000_000
+
+// arity1BaseGroundedIDBs returns the set of IDB predicate names whose
+// every defining rule has a single head var (arity 1) and a body
+// composed entirely of non-IDB (base/extensional) positive atoms or
+// comparisons — i.e. the structural shape of a class-extent helper
+// (concrete-charPred-style: `Pred(this) :- Base1(this,_), Base2(_,_)`).
+//
+// Such predicates are safe to treat as grounders for their single
+// column at any size up to LargeArityOneExtentThreshold: per-tuple
+// iteration is a single-column scan and the body is non-recursive so
+// the tuple count is bounded by the underlying base relations.
+//
+// This is the gating set for the disj2-round2 fix in
+// bodyContextGroundedVars. Conservative on purpose:
+//   - mixed-arity heads → excluded (mirror of mixedArity skip in
+//     InferBackwardDemand, prevents the audit-#3 name/arity hazard)
+//   - any IDB-on-IDB body atom → excluded (recursion or IDB-stacking
+//     means the size hint is the load-bearing signal we should not
+//     bypass)
+//   - aggregates / negation / empty body → excluded
+func arity1BaseGroundedIDBs(prog *datalog.Program) map[string]bool {
+	out := map[string]bool{}
+	if prog == nil || len(prog.Rules) == 0 {
+		return out
+	}
+	// First pass: collect IDB names so we can check body atoms.
+	idb := map[string]bool{}
+	for _, r := range prog.Rules {
+		idb[r.Head.Predicate] = true
+	}
+	// Group rules by head and arity-check.
+	type ruleSet struct {
+		ok    bool
+		rules []datalog.Rule
+	}
+	heads := map[string]*ruleSet{}
+	for _, r := range prog.Rules {
+		rs, ok := heads[r.Head.Predicate]
+		if !ok {
+			rs = &ruleSet{ok: true}
+			heads[r.Head.Predicate] = rs
+		}
+		if len(r.Head.Args) != 1 {
+			rs.ok = false
+		}
+		rs.rules = append(rs.rules, r)
+	}
+	for name, rs := range heads {
+		if !rs.ok {
+			continue
+		}
+		allOK := true
+		for _, r := range rs.rules {
+			if len(r.Body) == 0 {
+				allOK = false
+				break
+			}
+			for _, lit := range r.Body {
+				if lit.Cmp != nil {
+					continue
+				}
+				if lit.Agg != nil || !lit.Positive {
+					allOK = false
+					break
+				}
+				if idb[lit.Atom.Predicate] {
+					allOK = false
+					break
+				}
+			}
+			if !allOK {
+				break
+			}
+		}
+		if allOK {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+// isLargeArity1Grounder returns true if `pred` is an arity-1 base-grounded
+// IDB AND its size hint is within LargeArityOneExtentThreshold (or
+// unknown — treat as plausibly small for grounding purposes since the
+// alternative is dropping demand and producing a cross-product plan).
+// Saturated hints (>= LargeArityOneExtentThreshold, in practice 1<<30)
+// deliberately do NOT qualify; we only relax the gate for mid-sized
+// extents.
+func isLargeArity1Grounder(pred string, sizeHints map[string]int, large map[string]bool) bool {
+	if !large[pred] {
+		return false
+	}
+	sz, ok := sizeHints[pred]
+	if !ok {
+		// No hint: treat as eligible — refusing to ground here is what
+		// triggers the disj2-round2 cap-hit in the SaturatedSizeHint
+		// sibling case where the pre-pass overwrote the hint with the
+		// saturated marker. Caller bears responsibility for not over-
+		// committing on truly-huge extents (the threshold above guards
+		// the saturated marker explicitly).
+		return true
+	}
+	return sz > 0 && sz <= LargeArityOneExtentThreshold
+}
+
 // DemandMap records, per predicate name, the argument positions whose
 // values are known to be bound at rule-evaluation time because every
 // caller of this predicate grounds them. Keys are predicate names;
@@ -124,6 +250,8 @@ func InferBackwardDemand(prog *datalog.Program, sizeHints map[string]int) Demand
 	// arities (shouldn't happen after desugar, but be defensive), we
 	// skip backward inference for it — the name/arity ambiguity from
 	// the roadmap's audit-#3 finding would give unsafe results.
+	largeArity1IDBs := arity1BaseGroundedIDBs(prog)
+
 	idbArity := map[string]int{}
 	mixedArity := map[string]bool{}
 	for _, r := range prog.Rules {
@@ -192,7 +320,7 @@ func InferBackwardDemand(prog *datalog.Program, sizeHints map[string]int) Demand
 		// references. Adversarial-review Finding 1 on PR #143.
 		if prog.Query != nil && len(prog.Query.Body) > 0 {
 			queryRule := datalog.Rule{Head: datalog.Atom{}, Body: prog.Query.Body}
-			ctxBoundVars := bodyContextGroundedVars(queryRule, sizeHints, map[string]bool{})
+			ctxBoundVars := bodyContextGroundedVars(queryRule, sizeHints, map[string]bool{}, largeArity1IDBs)
 			for _, lit := range prog.Query.Body {
 				if lit.Cmp != nil || lit.Agg != nil || !lit.Positive {
 					continue
@@ -223,7 +351,7 @@ func InferBackwardDemand(prog *datalog.Program, sizeHints map[string]int) Demand
 					headBoundVars[v.Name] = true
 				}
 			}
-			ctxBoundVars := bodyContextGroundedVars(rule, sizeHints, headBoundVars)
+			ctxBoundVars := bodyContextGroundedVars(rule, sizeHints, headBoundVars, largeArity1IDBs)
 
 			for _, lit := range rule.Body {
 				if lit.Cmp != nil || lit.Agg != nil || !lit.Positive {
@@ -319,6 +447,7 @@ func bodyContextGroundedVars(
 	rule datalog.Rule,
 	sizeHints map[string]int,
 	headBoundVars map[string]bool,
+	largeArity1IDBs map[string]bool,
 ) map[string]bool {
 	bound := map[string]bool{}
 	for v := range headBoundVars {
@@ -347,8 +476,13 @@ func bodyContextGroundedVars(
 				continue
 			}
 			// Small extent: every var in the atom becomes bound after
-			// seeding.
-			if isSmallExtent(lit.Atom.Predicate, sizeHints) {
+			// seeding. Arity-1 base-grounded IDB extents (class-extent
+			// helpers like `UseStateSetterCall(c) :- CallCalleeSym(c,_),
+			// ImportBinding(_,_,_)`) qualify too even when their hint
+			// exceeds SmallExtentThreshold — see disj2-round2 / PR #158
+			// rationale on LargeArityOneExtentThreshold.
+			if isSmallExtent(lit.Atom.Predicate, sizeHints) ||
+				isLargeArity1Grounder(lit.Atom.Predicate, sizeHints, largeArity1IDBs) {
 				for _, arg := range lit.Atom.Args {
 					if v, ok := arg.(datalog.Var); ok && v.Name != "_" {
 						if !bound[v.Name] {

--- a/ql/plan/disj2_round2_arity1_extent_test.go
+++ b/ql/plan/disj2_round2_arity1_extent_test.go
@@ -181,10 +181,10 @@ func TestInferRuleBodyDemandBindings_Arity1ExtentAboveThresholdBreaksDemand(t *t
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.expectedPostFix {
-				t.Skip("XFAIL today — bug documented; requires arity-1 grounding-threshold fix to pass. " +
-					"Note: " + tc.expectFiringNote)
-			}
+			// XFAIL→PASS conversion: post-fix (PR #158), the previously
+			// skipped expectedPostFix cases must now pass. Removing the
+			// t.Skip is the load-bearing regression guard.
+			_ = tc.expectedPostFix
 			prog, hints := progArity1ExtentDemandShape(tc.extentSize)
 			idb := IDBPredicates(prog)
 

--- a/ql/plan/disj2_round2_arity1_extent_test.go
+++ b/ql/plan/disj2_round2_arity1_extent_test.go
@@ -1,0 +1,218 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// disj2-round2 unit-level regression — see HANDOVER notes in PR.
+//
+// Hypothesis (verified by static read of backward.go:351, :424-430 and
+// the eval.SaturatedSizeHint write in ql/eval/estimate.go:491-494):
+//
+//   When a class-extent IDB literal that is the SOLE grounding source
+//   for a downstream synthesised disjunction's bound var has a size
+//   hint above SmallExtentThreshold (5000) — whether because the real
+//   extent is in the 5k–500k range OR because MaterialiseClassExtents
+//   failed and the trivial-IDB pre-pass wrote SaturatedSizeHint —
+//   bodyContextGroundedVars treats it as non-grounding. The all-callers
+//   intersect in InferBackwardDemand records cols=[] for the synth
+//   `_disj_*` predicate, InferRuleBodyDemandBindings emits no seed,
+//   and the magic-set rewrite never fires. The planner then orders
+//   the synth-disj's multi-atom body as a free-for-all and cap-hits.
+//
+// Repro at unit level: progArity1ExtentDemandShape constructs a 3-rule
+// program structurally identical to the post-#156 setStateUpdater
+// query plan: an arity-1 class-extent IDB head sized just above
+// SmallExtentThreshold, a multi-base-atom IDB caller that probes it
+// AND `_disj_2`, and `_disj_2` defined as a wide cross-product. With
+// the size hint at 5001, the demand chain breaks identically to the
+// SaturatedSizeHint=1<<30 case — proof that the bug is gated purely on
+// the threshold check, not on saturation per se.
+
+// progArity1ExtentDemandShape models setStateUpdaterCallsOtherSetState
+// after PR #156's name-arity shadow fix:
+//
+//	UseStateSetterCall(c) :- CallCalleeSym(c,_), ImportBinding(_,_,_).  // size > 5000
+//	Caller(c, line) :-
+//	    UseStateSetterCall(c),                  // <-- only c-grounder
+//	    CallArg(c, 0, argFn),                   // base, arity-3 — needs c bound
+//	    Function(argFn, _, _, _, _, _),         // base, arity-6
+//	    _disj_2(argFn, inner),                  // synth disj
+//	    Call(c, callee, _),
+//	    Node(callee, _, _, line, _, _, _).
+//	_disj_2(fn, inner) :- FunctionContains(fn, inner).
+//	_disj_2(fn, inner) :- FunctionContains(fn, mid), FunctionContains(mid, inner).
+func progArity1ExtentDemandShape(useStateExtentSize int) (*datalog.Program, map[string]int) {
+	v := func(name string) datalog.Var { return datalog.Var{Name: name} }
+	atom := func(pred string, args ...datalog.Term) datalog.Literal {
+		return datalog.Literal{Positive: true, Atom: datalog.Atom{Predicate: pred, Args: args}}
+	}
+
+	rules := []datalog.Rule{
+		// Class-extent IDB. Body is base-only so the trivial-IDB
+		// pre-pass would attempt it; in real prod runs the pre-pass
+		// either materialises it (size ~7k) or hits the cap and writes
+		// SaturatedSizeHint. We model the post-pre-pass state by
+		// passing the hint directly.
+		{
+			Head: datalog.Atom{Predicate: "UseStateSetterCall", Args: []datalog.Term{v("c")}},
+			Body: []datalog.Literal{
+				atom("CallCalleeSym", v("c"), v("_sym")),
+				atom("ImportBinding", v("_sym"), v("_mod"), v("_nm")),
+			},
+		},
+		// Caller = setStateUpdaterCallsOtherSetState.
+		{
+			Head: datalog.Atom{Predicate: "Caller", Args: []datalog.Term{v("c"), v("line")}},
+			Body: []datalog.Literal{
+				atom("UseStateSetterCall", v("c")),
+				// CallArg(c, 0, argFn): the integer-const col 1 means
+				// hasConstTerm fires once `c` is bound, grounding argFn.
+				{Positive: true, Atom: datalog.Atom{Predicate: "CallArg", Args: []datalog.Term{v("c"), datalog.IntConst{Value: 0}, v("argFn")}}},
+				atom("Function", v("argFn"), v("_a"), v("_b"), v("_d"), v("_e"), v("_f")),
+				atom("_disj_2", v("argFn"), v("inner")),
+				atom("Call", v("c"), v("callee"), v("_callk")),
+				atom("Node", v("callee"), v("_n1"), v("_n2"), v("line"), v("_n3"), v("_n4"), v("_n5")),
+			},
+		},
+		// _disj_2 — desugarer-emitted multi-branch synthetic IDB.
+		// Branch A: trivial direct-contains.
+		{
+			Head: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{v("fn"), v("inner")}},
+			Body: []datalog.Literal{
+				atom("FunctionContains", v("fn"), v("inner")),
+			},
+		},
+		// Branch B: 2-hop, the cross-product candidate.
+		{
+			Head: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{v("fn"), v("inner")}},
+			Body: []datalog.Literal{
+				atom("FunctionContains", v("fn"), v("mid")),
+				atom("FunctionContains", v("mid"), v("inner")),
+			},
+		},
+	}
+
+	prog := &datalog.Program{
+		Rules: rules,
+		Query: &datalog.Query{
+			Select: []datalog.Term{v("c"), v("line")},
+			Body: []datalog.Literal{
+				atom("Caller", v("c"), v("line")),
+			},
+		},
+	}
+
+	hints := map[string]int{
+		"UseStateSetterCall": useStateExtentSize, // tunable across the test cases
+		"CallCalleeSym":      200_000,
+		"ImportBinding":      500,
+		"CallArg":            300_000,
+		"Function":           50_000,
+		"FunctionContains":   400_000,
+		"Call":               300_000,
+		"Node":               1_500_000,
+	}
+	return prog, hints
+}
+
+// TestInferRuleBodyDemandBindings_Arity1ExtentAboveThresholdBreaksDemand
+// is the headline disj2-round2 regression. Three sizings of the SOLE
+// demand-grounder (UseStateSetterCall) bracket the SmallExtentThreshold:
+//
+//	  4_999  →  small → demand fires → bindings non-empty (control: passes today)
+//	  5_001  →  above → demand silent → bindings empty (POST-#156 BUG)
+//	1<<30   →  saturated → demand silent → bindings empty (same path)
+//
+// The 5001 case is the proof that the bug is purely a threshold issue,
+// independent of MaterialiseClassExtents failure. Saturated cap-hit is
+// a sufficient trigger but not a necessary one — any mid-sized class
+// extent (5k–50k) reproduces the same outcome on real corpora.
+//
+// Expected outcome on current main: the >5000 cases FAIL (bug present).
+// Expected outcome post-fix: the saturated case still drops (genuine
+// huge), but mid-sized arity-1 class extents (e.g. 7k, 50k) should
+// continue to ground their head var — the fix is to treat arity-1 IDB
+// literals as grounders up to a higher ceiling than the generic
+// SmallExtentThreshold, since per-tuple iteration of an arity-1 set is
+// cheap regardless.
+func TestInferRuleBodyDemandBindings_Arity1ExtentAboveThresholdBreaksDemand(t *testing.T) {
+	// Cases marked `expectedPostFix: true` are XFAIL today (skipped via
+	// t.Skip with a clear reason) and will become required guards once
+	// the planner-policy fix lands. The 4999 control case must always
+	// pass — if it ever fails, demand inference broke for the in-spec
+	// shape and the regression guard catches it independent of the fix.
+	cases := []struct {
+		name             string
+		extentSize       int
+		expectBindings   bool
+		expectedPostFix  bool // true → currently failing, intentionally documents the bug
+		expectFiringNote string
+	}{
+		{
+			name:             "extent_4999_under_threshold_demand_fires",
+			extentSize:       4999,
+			expectBindings:   true,
+			expectFiringNote: "below SmallExtentThreshold — bodyContextGroundedVars marks c bound, demand cols=[0]",
+		},
+		{
+			name:             "extent_5001_above_threshold_demand_should_fire_post_fix",
+			extentSize:       5001,
+			expectBindings:   true,
+			expectedPostFix:  true,
+			expectFiringNote: "1 tuple over threshold should still ground via arity-1 extent (cheap iteration). Currently broken — same demand-empty bug as the saturated case.",
+		},
+		{
+			name:             "extent_50000_realistic_above_threshold_should_fire_post_fix",
+			extentSize:       50_000,
+			expectBindings:   true,
+			expectedPostFix:  true,
+			expectFiringNote: "realistic mastodon-shape extent — prod failure mode for setStateUpdater queries. Post-fix should still ground.",
+		},
+		{
+			name:             "extent_saturated_cap_hit_demand_drops_genuine_huge",
+			extentSize:       1 << 30, // eval.SaturatedSizeHint
+			expectBindings:   false,
+			expectFiringNote: "saturated hint = genuinely huge or unmeasurable; correct to drop demand here.",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expectedPostFix {
+				t.Skip("XFAIL today — bug documented; requires arity-1 grounding-threshold fix to pass. " +
+					"Note: " + tc.expectFiringNote)
+			}
+			prog, hints := progArity1ExtentDemandShape(tc.extentSize)
+			idb := IDBPredicates(prog)
+
+			bindings, seeds := InferRuleBodyDemandBindings(prog, idb, hints)
+			gotFired := len(bindings) > 0
+
+			if gotFired != tc.expectBindings {
+				t.Fatalf("UseStateSetterCall hint=%d (threshold=%d): demand bindings fired=%v want=%v\n"+
+					"  bindings=%v\n  seeds=%d\n  note: %s\n"+
+					"  Failure mechanism: bodyContextGroundedVars (backward.go:351) calls\n"+
+					"  isSmallExtent which returns false for sz>SmallExtentThreshold;\n"+
+					"  c is therefore not marked bound at the _disj_2(argFn,inner) call site,\n"+
+					"  so all-callers intersect collapses to cols=[] for _disj_2.",
+					tc.extentSize, SmallExtentThreshold,
+					gotFired, tc.expectBindings,
+					bindings, len(seeds), tc.expectFiringNote)
+			}
+
+			if tc.expectBindings {
+				cols, ok := bindings["_disj_2"]
+				if !ok {
+					t.Fatalf("expected _disj_2 in bindings (control case); got %v", bindings)
+				}
+				// argFn is at col 0 of _disj_2 — that's what should be demanded.
+				if len(cols) == 0 {
+					t.Fatalf("expected non-empty cols for _disj_2; got %v", cols)
+				}
+			}
+		})
+	}
+}

--- a/ql/plan/magicset_demand.go
+++ b/ql/plan/magicset_demand.go
@@ -178,7 +178,7 @@ func predHasQueryBinding(prog *datalog.Program, pred string, cols []int) bool {
 		return false
 	}
 	queryRule := datalog.Rule{Head: datalog.Atom{}, Body: prog.Query.Body}
-	ctxBoundVars := bodyContextGroundedVars(queryRule, nil, map[string]bool{})
+	ctxBoundVars := bodyContextGroundedVars(queryRule, nil, map[string]bool{}, arity1BaseGroundedIDBs(prog))
 	for _, lit := range prog.Query.Body {
 		if lit.Cmp != nil || lit.Agg != nil || !lit.Positive {
 			continue


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Summary

Fix for the post-#156 `_disj_2` cap-hit on `find_setstate_updater_calls_other_setstate.ql`.

`bodyContextGroundedVars` was rejecting any grounding literal whose `sizeHint` exceeded `SmallExtentThreshold = 5000`. Arity-1 class-extent IDBs (e.g. `UseStateSetterCall(c) :- CallCalleeSym(c,_), ImportBinding(_,_,_)`) hinted in the 5k–500k range — or with `SaturatedSizeHint = 1<<30` after a `MaterialiseClassExtents` cap-hit — therefore never grounded `c`, collapsing the all-callers intersect for downstream `_disj_2` to `cols=[]` and forcing the planner into a 5-atom cross-product cap-hit.

## Fix (this PR)

- New helper `arity1BaseGroundedIDBs(prog)` in `ql/plan/backward.go`: returns the set of IDB predicates whose every defining rule is structurally arity-1 with a non-recursive base-only body (the canonical class-extent helper shape).
- New const `LargeArityOneExtentThreshold = 1_000_000` and helper `isLargeArity1Grounder(pred, sizeHints, large)`.
- `bodyContextGroundedVars` now treats a literal as grounding if EITHER `isSmallExtent` OR `isLargeArity1Grounder` returns true.
- Saturated hints (`1<<30`, deliberately above the 1M ceiling) continue to drop demand — preserves the genuinely-huge case.
- Plumbed through three call sites (`backward.go` ×2, `magicset_demand.go` ×1).

Diff: **143 insertions / 9 deletions** across 3 files.

## Root cause (verified)

Even after #156's `(name,arity)` shadow fix, the chain:

1. `MaterialiseClassExtents` may fail to materialise `UseStateSetterCall` (silent at `:261-263`).
2. `EstimateNonRecursiveIDBSizes` then either samples >5000 or writes `SaturatedSizeHint = 1<<30`.
3. `bodyContextGroundedVars` calls `isSmallExtent` which returns `false` for `sz > 5000` → `c` not bound.
4. `c` unbound → `CallArg(c, 0, argFn)` doesn't ground `argFn` → `_disj_2` demand cols collapse → magic-set rewrite skipped → planner cap-hits.

The bug is gated purely on the threshold check; the unit test demonstrates it reproduces identically at a hint of 5001 (independent of saturation). Any real mid-sized class extent triggers it.

## Tests

`ql/plan/disj2_round2_arity1_extent_test.go` — four cases bracketing `SmallExtentThreshold`:

| extent hint | demand fires? | status |
|-------------|---------------|--------|
| 4_999       | yes           | PASS (control, unchanged) |
| 5_001       | yes           | PASS (was XFAIL pre-fix) |
| 50_000      | yes           | PASS (was XFAIL, mastodon-realistic) |
| 1<<30       | no            | PASS (correct: genuine huge) |

XFAIL→PASS conversion confirmed via `-v` run; both previously-skipped cases now execute and pass. Saturated case continues to (correctly) drop demand.

`go test ./ql/plan/... -race -count=1` → `ok ... 1.058s`.

## Bench validation

**Skipped this iteration per Cain's directive (prioritize landing the fix).** Unit-level XFAIL→PASS conversion is the regression guard; cain-nas mastodon/jitsi bench can be run post-merge if anything regresses.

## Constraints honoured

- No `--max-bindings-per-rule` widening.
- No `--no-verify`.
- No `go test ./...` or heavy local repro (OOM-safe).
- Diff under 150 LOC ceiling.
- Pre-commit hooks ran clean (gofmt + golangci-lint).

## Test plan

- [x] `go test ./ql/plan/... -race -count=1` — green
- [x] XFAIL cases at hints 5001 and 50000 converted to passing assertions
- [x] Saturated 1<<30 case still drops demand (correct)
- [ ] cain-nas mastodon + jitsi bench — deferred to post-merge