### PR TITLE
fix(plan): thread materialised class extents through demand inference (disj2-round3)

### DIFF
--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -849,18 +849,27 @@ func buildProgram(src, file string, importLoader func(string) (*ast.Module, erro
 	return execPlan, mod, warnings, errs
 }
 
-// makeFunc returns a plan.Func that captures the magic-set wiring
-// (or its absence) implied by buildOptions. Extracted so that the same
-// inference + verbose/warn observability used by `check`'s buildProgramWithProg
-// path is also used by `query`'s EstimateAndPlan path. Without this, the
-// magic-set branch would only fire on the (now-discarded) pre-estimate plan
-// in buildProgramWithProg and `query` would always run plain Plan.
-func makeFunc(opts buildOptions) plan.Func {
+// makeFuncWithClassExtents returns a plan.FuncWithClassExtents that
+// captures the magic-set wiring (or its absence) implied by
+// buildOptions. Extracted so that the same inference + verbose/warn
+// observability used by `check`'s buildProgramWithProg path is also
+// used by `query`'s EstimateAndPlan path. Without this, the magic-set
+// branch would only fire on the (now-discarded) pre-estimate plan in
+// buildProgramWithProg and `query` would always run plain Plan.
+//
+// disj2-round3: returns the FuncWithClassExtents form so the planner
+// receives the materialised class-extent name set produced by
+// EstimateAndPlanWithExtentsCtx. Stripped class extents on a real
+// codebase ground downstream synth-disj demand via the threaded set
+// instead of being silently dropped (the round-3 fix).
+func makeFuncWithClassExtents(opts buildOptions) plan.FuncWithClassExtents {
 	if !opts.useMagicSets {
-		return plan.Plan
+		return func(prog *datalog.Program, sizeHints map[string]int, classExtentNames map[string]bool) (*plan.ExecutionPlan, []error) {
+			return plan.PlanWithClassExtents(prog, sizeHints, classExtentNames)
+		}
 	}
-	return func(prog *datalog.Program, sizeHints map[string]int) (*plan.ExecutionPlan, []error) {
-		ep, inf, errs := plan.WithMagicSetAutoOpts(prog, sizeHints, plan.MagicSetOptions{Strict: opts.magicSetsStrict})
+	return func(prog *datalog.Program, sizeHints map[string]int, classExtentNames map[string]bool) (*plan.ExecutionPlan, []error) {
+		ep, inf, errs := plan.WithMagicSetAutoOptsWithClassExtents(prog, sizeHints, plan.MagicSetOptions{Strict: opts.magicSetsStrict}, classExtentNames)
 		switch {
 		case inf.Fallback:
 			// Always surface a fallback warning to warnOut (not gated on
@@ -1060,13 +1069,17 @@ func compileAndEval(ctx context.Context, queryFile, dbFile string, maxBindingsPe
 	// EstimateAndPlan orchestrate: identify trivial IDBs → estimate →
 	// plan ONCE with the now-populated hints. The estimator hook honours
 	// maxBindingsPerRule (issue #130 / PR #132 — preserved end-to-end).
-	planFn := makeFunc(opts)
+	planFn := makeFuncWithClassExtents(opts)
 	// P2a: pre-materialise class extents so they're treated as base
 	// relations end-to-end. The sink map is populated by the
 	// materialising hook and handed to Evaluate via
 	// WithMaterialisedClassExtents.
+	//
+	// disj2-round3: use the Ctx variant so the planner receives the
+	// materialised class-extent name set and can ground vars sourced
+	// from those (now-stripped) extents in backward-demand inference.
 	matExtents := map[string]*eval.Relation{}
-	execPlan, planErrs := plan.EstimateAndPlanWithExtents(
+	execPlan, planErrs := plan.EstimateAndPlanWithExtentsCtx(
 		prog,
 		sizeHints,
 		maxBindingsPerRule,

--- a/ql/plan/backward.go
+++ b/ql/plan/backward.go
@@ -199,6 +199,27 @@ func isLargeArity1Grounder(pred string, sizeHints map[string]int, large map[stri
 	return sz > 0 && sz <= LargeArityOneExtentThreshold
 }
 
+// isMaterialisedClassExtentGrounder returns true if `pred` is in the
+// caller-supplied class-extent name set. This is the disj2-round3 fix:
+// when EstimateAndPlanWithExtents materialises a class-extent rule and
+// strips it from the planning program, the structural detector
+// `arity1BaseGroundedIDBs` cannot find the rule any more (it's gone)
+// and the consuming rule's body literal looks like a base atom whose
+// only signal is its sizeHint. For materialised class extents the
+// extent has ALREADY been computed once, lives in RAM as a base-like
+// relation, and per-tuple iteration of its single column is cheap
+// regardless of size — so it is safe to ground its arg vars at any size,
+// including the SaturatedSizeHint marker (the materialising hook is the
+// authoritative signal that the extent was successfully built; size
+// hint can be unrelated).
+//
+// classExtentNames may be nil; nil means "no materialised extents
+// declared" and degrades to the PR #158 behaviour (arity-1 structural
+// detector only).
+func isMaterialisedClassExtentGrounder(pred string, classExtentNames map[string]bool) bool {
+	return classExtentNames[pred]
+}
+
 // DemandMap records, per predicate name, the argument positions whose
 // values are known to be bound at rule-evaluation time because every
 // caller of this predicate grounds them. Keys are predicate names;
@@ -239,6 +260,23 @@ type DemandMap map[string][]int
 // body-internal sideways passing. Nil hints → every literal is treated
 // as unknown-size, which degenerates to "constant-only" grounding.
 func InferBackwardDemand(prog *datalog.Program, sizeHints map[string]int) DemandMap {
+	return InferBackwardDemandWithClassExtents(prog, sizeHints, nil)
+}
+
+// InferBackwardDemandWithClassExtents is the disj2-round3 entry point
+// that additionally honours a caller-supplied set of materialised
+// class-extent base names. Those names are treated as grounders for any
+// var they bind in any rule body, regardless of size hint or the
+// structural arity-1 detector. See isMaterialisedClassExtentGrounder
+// for rationale.
+//
+// The plain InferBackwardDemand wrapper passes nil, preserving its
+// pre-disj2-round3 behaviour.
+func InferBackwardDemandWithClassExtents(
+	prog *datalog.Program,
+	sizeHints map[string]int,
+	classExtentNames map[string]bool,
+) DemandMap {
 	if prog == nil || len(prog.Rules) == 0 {
 		return DemandMap{}
 	}
@@ -320,7 +358,7 @@ func InferBackwardDemand(prog *datalog.Program, sizeHints map[string]int) Demand
 		// references. Adversarial-review Finding 1 on PR #143.
 		if prog.Query != nil && len(prog.Query.Body) > 0 {
 			queryRule := datalog.Rule{Head: datalog.Atom{}, Body: prog.Query.Body}
-			ctxBoundVars := bodyContextGroundedVars(queryRule, sizeHints, map[string]bool{}, largeArity1IDBs)
+			ctxBoundVars := bodyContextGroundedVars(queryRule, sizeHints, map[string]bool{}, largeArity1IDBs, classExtentNames)
 			for _, lit := range prog.Query.Body {
 				if lit.Cmp != nil || lit.Agg != nil || !lit.Positive {
 					continue
@@ -351,7 +389,7 @@ func InferBackwardDemand(prog *datalog.Program, sizeHints map[string]int) Demand
 					headBoundVars[v.Name] = true
 				}
 			}
-			ctxBoundVars := bodyContextGroundedVars(rule, sizeHints, headBoundVars, largeArity1IDBs)
+			ctxBoundVars := bodyContextGroundedVars(rule, sizeHints, headBoundVars, largeArity1IDBs, classExtentNames)
 
 			for _, lit := range rule.Body {
 				if lit.Cmp != nil || lit.Agg != nil || !lit.Positive {
@@ -448,6 +486,7 @@ func bodyContextGroundedVars(
 	sizeHints map[string]int,
 	headBoundVars map[string]bool,
 	largeArity1IDBs map[string]bool,
+	classExtentNames map[string]bool,
 ) map[string]bool {
 	bound := map[string]bool{}
 	for v := range headBoundVars {
@@ -482,7 +521,8 @@ func bodyContextGroundedVars(
 			// exceeds SmallExtentThreshold — see disj2-round2 / PR #158
 			// rationale on LargeArityOneExtentThreshold.
 			if isSmallExtent(lit.Atom.Predicate, sizeHints) ||
-				isLargeArity1Grounder(lit.Atom.Predicate, sizeHints, largeArity1IDBs) {
+				isLargeArity1Grounder(lit.Atom.Predicate, sizeHints, largeArity1IDBs) ||
+				isMaterialisedClassExtentGrounder(lit.Atom.Predicate, classExtentNames) {
 				for _, arg := range lit.Atom.Args {
 					if v, ok := arg.(datalog.Var); ok && v.Name != "_" {
 						if !bound[v.Name] {

--- a/ql/plan/backward.go
+++ b/ql/plan/backward.go
@@ -520,9 +520,17 @@ func bodyContextGroundedVars(
 			// ImportBinding(_,_,_)`) qualify too even when their hint
 			// exceeds SmallExtentThreshold — see disj2-round2 / PR #158
 			// rationale on LargeArityOneExtentThreshold.
+			// Materialised class extents are always arity-1 (the
+			// MaterialisingEstimatorHook contract — see plan.go). Restrict
+			// the relaxation to arity-1 occurrences so a name collision
+			// with an arity-N base relation (defensive case — desugarer
+			// shouldn't emit one but a hand-written predicate could)
+			// cannot over-ground the wider literal's vars.
+			isMatExt := len(lit.Atom.Args) == 1 &&
+				isMaterialisedClassExtentGrounder(lit.Atom.Predicate, classExtentNames)
 			if isSmallExtent(lit.Atom.Predicate, sizeHints) ||
 				isLargeArity1Grounder(lit.Atom.Predicate, sizeHints, largeArity1IDBs) ||
-				isMaterialisedClassExtentGrounder(lit.Atom.Predicate, classExtentNames) {
+				isMatExt {
 				for _, arg := range lit.Atom.Args {
 					if v, ok := arg.(datalog.Var); ok && v.Name != "_" {
 						if !bound[v.Name] {

--- a/ql/plan/disj2_round3_stripped_extent_test.go
+++ b/ql/plan/disj2_round3_stripped_extent_test.go
@@ -1,0 +1,298 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// disj2-round3 — post-#158 surface.
+//
+// Setup (mirrors the Mastodon production failure described in the
+// disj2-round3 hand-off):
+//
+//   - The desugarer emits an arity-1 class-extent rule
+//     `UseStateSetterCall(c) :- CallCalleeSym(c,_), ImportBinding(_,_,_).`
+//     marked `ClassExtent: true`.
+//   - The materialising estimator hook (`MaterialisingEstimatorHook` /
+//     `MakeMaterialisingEstimatorHook`) eagerly evaluates that rule and
+//     hands its tuples to the evaluator as if they were a base relation;
+//     `EstimateAndPlanWithExtents` then STRIPS the rule from the program
+//     before invoking `Plan` / `WithMagicSetAutoOpts`.
+//   - Once stripped, `UseStateSetterCall` is no longer an IDB head in the
+//     planning program — it's a base-like predicate with a sizeHint.
+//   - On a real codebase that hint is > SmallExtentThreshold (5000) AND
+//     > LargeArityOneExtentThreshold-coverable but the structural
+//     `arity1BaseGroundedIDBs` detector misses it because the rule that
+//     would have qualified it has been stripped.
+//   - `bodyContextGroundedVars` therefore falls back to `isSmallExtent`
+//     for the (now-base) `UseStateSetterCall` literal. With hint > 5000,
+//     it returns false; `c` is not marked bound; demand for the synth
+//     `_disj_2` collapses; the magic-set rewrite never fires; and at
+//     evaluation time `_disj_2`'s 5-atom body cap-hits.
+//
+// PR #158 fixed this for the case where the class-extent rule remains
+// in the planning program (UseStateSetterCall stays as an arity-1 IDB
+// with body-only base atoms). PR #158 does NOT fix the case where the
+// class extent has been materialised AND stripped — `arity1BaseGroundedIDBs`
+// has nothing to match.
+//
+// This test exercises that gap. It feeds `InferBackwardDemand` and
+// `InferRuleBodyDemandBindings` a program in which `UseStateSetterCall`
+// has already been stripped (i.e. it appears only as a body atom, never
+// as a rule head) and is registered in an explicit
+// `classExtentNames` set the planner is supposed to honour.
+
+// progStrippedClassExtentDemandShape is `progArity1ExtentDemandShape`
+// minus the `UseStateSetterCall` defining rule. The class extent is
+// instead represented as a sizeHint plus membership in the
+// classExtentNames set passed to the planner.
+func progStrippedClassExtentDemandShape(useStateExtentSize int) (*datalog.Program, map[string]int, map[string]bool) {
+	v := func(name string) datalog.Var { return datalog.Var{Name: name} }
+	atom := func(pred string, args ...datalog.Term) datalog.Literal {
+		return datalog.Literal{Positive: true, Atom: datalog.Atom{Predicate: pred, Args: args}}
+	}
+
+	rules := []datalog.Rule{
+		// Caller — note: NO UseStateSetterCall defining rule. The class
+		// extent has been materialised + stripped by
+		// EstimateAndPlanWithExtents.
+		{
+			Head: datalog.Atom{Predicate: "Caller", Args: []datalog.Term{v("c"), v("line")}},
+			Body: []datalog.Literal{
+				atom("UseStateSetterCall", v("c")),
+				{Positive: true, Atom: datalog.Atom{Predicate: "CallArg", Args: []datalog.Term{v("c"), datalog.IntConst{Value: 0}, v("argFn")}}},
+				atom("Function", v("argFn"), v("_a"), v("_b"), v("_d"), v("_e"), v("_f")),
+				atom("_disj_2", v("argFn"), v("inner")),
+				atom("Call", v("c"), v("callee"), v("_callk")),
+				atom("Node", v("callee"), v("_n1"), v("_n2"), v("line"), v("_n3"), v("_n4"), v("_n5")),
+			},
+		},
+		{
+			Head: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{v("fn"), v("inner")}},
+			Body: []datalog.Literal{
+				atom("FunctionContains", v("fn"), v("inner")),
+			},
+		},
+		{
+			Head: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{v("fn"), v("inner")}},
+			Body: []datalog.Literal{
+				atom("FunctionContains", v("fn"), v("mid")),
+				atom("FunctionContains", v("mid"), v("inner")),
+			},
+		},
+	}
+
+	prog := &datalog.Program{
+		Rules: rules,
+		Query: &datalog.Query{
+			Select: []datalog.Term{v("c"), v("line")},
+			Body: []datalog.Literal{
+				atom("Caller", v("c"), v("line")),
+			},
+		},
+	}
+
+	hints := map[string]int{
+		"UseStateSetterCall": useStateExtentSize,
+		"CallArg":            300_000,
+		"Function":           50_000,
+		"FunctionContains":   400_000,
+		"Call":               300_000,
+		"Node":               1_500_000,
+	}
+	classExtentNames := map[string]bool{
+		"UseStateSetterCall": true,
+	}
+	return prog, hints, classExtentNames
+}
+
+// TestInferBackwardDemand_StrippedClassExtentGroundsHeadVar asserts the
+// fix: when a class-extent base name is supplied via `classExtentNames`,
+// `bodyContextGroundedVars` (and therefore `InferBackwardDemand` and
+// `InferRuleBodyDemandBindings`) treats it as a grounder for its single
+// arg regardless of size hint. Demand for `_disj_2` should fire and the
+// magic-set seed should be emitted.
+func TestInferBackwardDemand_StrippedClassExtentGroundsHeadVar(t *testing.T) {
+	cases := []struct {
+		name       string
+		extentSize int
+	}{
+		// 7000 — above SmallExtentThreshold (5000). Pre-fix the demand
+		// drops; post-fix it fires because UseStateSetterCall is in
+		// classExtentNames.
+		{name: "extent_above_small_threshold", extentSize: 7000},
+		// 250_000 — realistic Mastodon shape.
+		{name: "extent_realistic_mastodon_shape", extentSize: 250_000},
+		// 5_000_000 — larger than LargeArityOneExtentThreshold; should
+		// STILL ground because class-extent membership trumps size.
+		// Per-tuple iteration of an arity-1 column scan is bounded by
+		// the materialised extent the evaluator already holds in RAM.
+		{name: "extent_above_large_threshold", extentSize: 5_000_000},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prog, hints, classExtentNames := progStrippedClassExtentDemandShape(tc.extentSize)
+			idb := IDBPredicates(prog)
+
+			demand := InferBackwardDemandWithClassExtents(prog, hints, classExtentNames)
+			cols, ok := demand["_disj_2"]
+			if !ok || len(cols) == 0 {
+				t.Fatalf("hint=%d: expected _disj_2 demand to fire (col 0 bound via stripped UseStateSetterCall extent), got demand[_disj_2]=%v exists=%v\n  full demand=%v",
+					tc.extentSize, cols, ok, demand)
+			}
+			if !(len(cols) >= 1 && cols[0] == 0) {
+				t.Fatalf("hint=%d: expected _disj_2 demand to include col 0, got cols=%v", tc.extentSize, cols)
+			}
+
+			bindings, seeds := InferRuleBodyDemandBindingsWithClassExtents(prog, idb, hints, classExtentNames)
+			if len(bindings) == 0 {
+				t.Fatalf("hint=%d: expected magic-set bindings for _disj_2; got empty\n  demand=%v\n  seeds=%d",
+					tc.extentSize, demand, len(seeds))
+			}
+			if _, ok := bindings["_disj_2"]; !ok {
+				t.Fatalf("hint=%d: expected _disj_2 in bindings; got %v", tc.extentSize, bindings)
+			}
+			if len(seeds) == 0 {
+				t.Fatalf("hint=%d: expected at least one magic seed rule, got 0", tc.extentSize)
+			}
+		})
+	}
+}
+
+// TestEstimateAndPlanWithExtentsCtx_PlumbsClassExtentNamesThrough is
+// the end-to-end wiring assertion. It feeds EstimateAndPlanWithExtentsCtx
+// a program containing a ClassExtent-tagged arity-1 rule plus a
+// downstream synth-disj caller, and a materialising hook that flags
+// the class extent as materialised (returning its head name and
+// writing a > SmallExtentThreshold size hint).
+//
+// The custom planFn receives the (stripped) planning program AND the
+// materialised-extents set. It then calls WithMagicSetAutoOptsWithClassExtents
+// to confirm the magic-set rewrite fires for `_disj_2` — i.e. the
+// downstream demand chain is no longer broken by the (stripped) class
+// extent's missing defining rule.
+//
+// Pre-fix (without the disj2-round3 plumbing): the planFn would have
+// no way to learn that UseStateSetterCall is a class-extent base; the
+// arity-1 structural detector cannot match a stripped rule; the magic
+// rewrite drops on the floor; bindings for `_disj_2` are empty.
+//
+// Post-fix: the materialised-extents set is threaded through and
+// bindings include `_disj_2`.
+func TestEstimateAndPlanWithExtentsCtx_PlumbsClassExtentNamesThrough(t *testing.T) {
+	v := func(name string) datalog.Var { return datalog.Var{Name: name} }
+	atom := func(pred string, args ...datalog.Term) datalog.Literal {
+		return datalog.Literal{Positive: true, Atom: datalog.Atom{Predicate: pred, Args: args}}
+	}
+
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			// Class-extent rule — will be materialised and stripped.
+			{
+				Head: datalog.Atom{Predicate: "UseStateSetterCall", Args: []datalog.Term{v("c")}},
+				Body: []datalog.Literal{
+					atom("CallCalleeSym", v("c"), v("_sym")),
+				},
+				ClassExtent: true,
+			},
+			// Caller — references the (to-be-stripped) UseStateSetterCall.
+			{
+				Head: datalog.Atom{Predicate: "Caller", Args: []datalog.Term{v("c"), v("line")}},
+				Body: []datalog.Literal{
+					atom("UseStateSetterCall", v("c")),
+					{Positive: true, Atom: datalog.Atom{Predicate: "CallArg", Args: []datalog.Term{v("c"), datalog.IntConst{Value: 0}, v("argFn")}}},
+					atom("Function", v("argFn"), v("_a"), v("_b"), v("_d"), v("_e"), v("_f")),
+					atom("_disj_2", v("argFn"), v("inner")),
+					atom("Call", v("c"), v("callee"), v("_callk")),
+					atom("Node", v("callee"), v("_n1"), v("_n2"), v("line"), v("_n3"), v("_n4"), v("_n5")),
+				},
+			},
+			{
+				Head: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{v("fn"), v("inner")}},
+				Body: []datalog.Literal{
+					atom("FunctionContains", v("fn"), v("inner")),
+				},
+			},
+			{
+				Head: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{v("fn"), v("inner")}},
+				Body: []datalog.Literal{
+					atom("FunctionContains", v("fn"), v("mid")),
+					atom("FunctionContains", v("mid"), v("inner")),
+				},
+			},
+		},
+		Query: &datalog.Query{
+			Select: []datalog.Term{v("c"), v("line")},
+			Body:   []datalog.Literal{atom("Caller", v("c"), v("line"))},
+		},
+	}
+
+	hints := map[string]int{
+		"CallArg":          300_000,
+		"Function":         50_000,
+		"FunctionContains": 400_000,
+		"Call":             300_000,
+		"Node":             1_500_000,
+	}
+
+	matExtHook := func(p *datalog.Program, h map[string]int, _ int) map[string]bool {
+		// Pretend we materialised the class extent at a size well above
+		// SmallExtentThreshold — the disj2-round3 production failure mode.
+		h["UseStateSetterCall"] = 250_000
+		h["CallCalleeSym"] = 500_000
+		return map[string]bool{"UseStateSetterCall": true}
+	}
+
+	var sawClassExtents map[string]bool
+	var sawProg *datalog.Program
+	var sawBindings map[string][]int
+	planFn := func(p *datalog.Program, h map[string]int, classExtentNames map[string]bool) (*ExecutionPlan, []error) {
+		sawProg = p
+		sawClassExtents = classExtentNames
+		// Run the magic-set rewrite the way production does and capture
+		// the bindings to assert the rewrite fired.
+		ep, inf, errs := WithMagicSetAutoOptsWithClassExtents(p, h, MagicSetOptions{Strict: true}, classExtentNames)
+		sawBindings = inf.Bindings
+		return ep, errs
+	}
+
+	_, errs := EstimateAndPlanWithExtentsCtx(prog, hints, 0, nil, matExtHook, planFn)
+	if len(errs) > 0 {
+		t.Fatalf("plan errors: %v", errs)
+	}
+	if sawProg == nil {
+		t.Fatal("planFn was not invoked")
+	}
+	// Sanity: the class-extent rule is stripped from the planning program.
+	for _, r := range sawProg.Rules {
+		if r.Head.Predicate == "UseStateSetterCall" {
+			t.Fatalf("UseStateSetterCall rule should have been stripped before reaching planFn")
+		}
+	}
+	// The class-extent name set must have been threaded through.
+	if !sawClassExtents["UseStateSetterCall"] {
+		t.Fatalf("planFn did not receive UseStateSetterCall in classExtentNames; got %v", sawClassExtents)
+	}
+	// Headline: with the threading in place, demand for `_disj_2` fires
+	// and the magic-set rewrite produces bindings.
+	if _, ok := sawBindings["_disj_2"]; !ok {
+		t.Fatalf("expected `_disj_2` in magic-set bindings (proves the demand chain through the stripped class extent reaches the rewrite); got bindings=%v", sawBindings)
+	}
+}
+
+// TestInferBackwardDemand_StrippedClassExtent_NilSetIsBaseline pins the
+// no-classExtentNames behaviour: with nil set the existing PR #158
+// path runs unchanged. The arity1BaseGroundedIDBs detector cannot match
+// (the defining rule is absent) so demand drops for hints > 5000. This
+// is the regression-safety check — passing nil must not surface any
+// new behaviour.
+func TestInferBackwardDemand_StrippedClassExtent_NilSetIsBaseline(t *testing.T) {
+	prog, hints, _ := progStrippedClassExtentDemandShape(7000)
+	demand := InferBackwardDemandWithClassExtents(prog, hints, nil)
+	cols := demand["_disj_2"]
+	if len(cols) != 0 {
+		t.Fatalf("with nil classExtentNames and hint=7000 the existing baseline behaviour applies: demand[_disj_2] should be empty (PR #158 cannot match a stripped extent's missing rule). Got %v", cols)
+	}
+}

--- a/ql/plan/disj2_round3_stripped_extent_test.go
+++ b/ql/plan/disj2_round3_stripped_extent_test.go
@@ -282,6 +282,60 @@ func TestEstimateAndPlanWithExtentsCtx_PlumbsClassExtentNamesThrough(t *testing.
 	}
 }
 
+// TestInferBackwardDemand_StrippedClassExtent_ArityGuard pins the
+// adversarial-review F1 finding: classExtentNames is keyed by name only
+// (per the MaterialisingEstimatorHook contract — class extents are
+// always arity-1). If a body literal references a name that happens to
+// collide with a class-extent name AT A DIFFERENT ARITY (defensive
+// against hand-written predicate name collisions), the relaxation must
+// NOT fire — that would over-ground vars in an unrelated wider literal.
+//
+// Setup: classExtentNames declares "Foo" but the body literal is
+// `Foo(a, b, c)` (arity 3). With the arity guard in place, vars
+// a/b/c stay unbound and demand for the downstream synth-disj does
+// not fire (size hints are the load-bearing signal for arity-N
+// literals, as it should be).
+func TestInferBackwardDemand_StrippedClassExtent_ArityGuard(t *testing.T) {
+	v := func(name string) datalog.Var { return datalog.Var{Name: name} }
+	atom := func(pred string, args ...datalog.Term) datalog.Literal {
+		return datalog.Literal{Positive: true, Atom: datalog.Atom{Predicate: pred, Args: args}}
+	}
+
+	// Body uses `Foo(a, b, c)` — arity 3, NOT the class extent shape.
+	// Even though "Foo" is in classExtentNames, the relaxation must not
+	// over-ground a/b/c.
+	prog := &datalog.Program{
+		Rules: []datalog.Rule{
+			{
+				Head: datalog.Atom{Predicate: "Caller", Args: []datalog.Term{v("a")}},
+				Body: []datalog.Literal{
+					atom("Foo", v("a"), v("b"), v("c")), // arity-3 collision
+					atom("_disj_2", v("b"), v("d")),
+				},
+			},
+			{
+				Head: datalog.Atom{Predicate: "_disj_2", Args: []datalog.Term{v("x"), v("y")}},
+				Body: []datalog.Literal{atom("Bar", v("x"), v("y"))},
+			},
+		},
+		Query: &datalog.Query{
+			Select: []datalog.Term{v("a")},
+			Body:   []datalog.Literal{atom("Caller", v("a"))},
+		},
+	}
+	hints := map[string]int{
+		"Foo": 250_000,
+		"Bar": 100_000,
+	}
+	classExtentNames := map[string]bool{"Foo": true}
+
+	demand := InferBackwardDemandWithClassExtents(prog, hints, classExtentNames)
+	cols := demand["_disj_2"]
+	if len(cols) != 0 {
+		t.Fatalf("arity guard violated: classExtentNames[\"Foo\"] is keyed by name only, but body uses arity-3 Foo(a,b,c). The relaxation must not ground a/b/c. Got demand[_disj_2]=%v (should be empty since Foo's arity disqualifies it as the documented class-extent shape)", cols)
+	}
+}
+
 // TestInferBackwardDemand_StrippedClassExtent_NilSetIsBaseline pins the
 // no-classExtentNames behaviour: with nil set the existing PR #158
 // path runs unchanged. The arity1BaseGroundedIDBs detector cannot match

--- a/ql/plan/magicset_demand.go
+++ b/ql/plan/magicset_demand.go
@@ -77,10 +77,26 @@ func InferRuleBodyDemandBindings(
 	idbPreds map[string]bool,
 	sizeHints map[string]int,
 ) (map[string][]int, []datalog.Rule) {
+	return InferRuleBodyDemandBindingsWithClassExtents(prog, idbPreds, sizeHints, nil)
+}
+
+// InferRuleBodyDemandBindingsWithClassExtents is the disj2-round3
+// entry point. classExtentNames carries the set of materialised
+// class-extent base predicate names — those names are treated as
+// grounders for any var they bind, regardless of size hint, when
+// computing backward demand and constructing the magic-set seed
+// bodies. nil classExtentNames degrades to the
+// InferRuleBodyDemandBindings behaviour.
+func InferRuleBodyDemandBindingsWithClassExtents(
+	prog *datalog.Program,
+	idbPreds map[string]bool,
+	sizeHints map[string]int,
+	classExtentNames map[string]bool,
+) (map[string][]int, []datalog.Rule) {
 	if prog == nil || len(prog.Rules) == 0 {
 		return nil, nil
 	}
-	demand := InferBackwardDemand(prog, sizeHints)
+	demand := InferBackwardDemandWithClassExtents(prog, sizeHints, classExtentNames)
 	if len(demand) == 0 {
 		return nil, nil
 	}
@@ -178,7 +194,7 @@ func predHasQueryBinding(prog *datalog.Program, pred string, cols []int) bool {
 		return false
 	}
 	queryRule := datalog.Rule{Head: datalog.Atom{}, Body: prog.Query.Body}
-	ctxBoundVars := bodyContextGroundedVars(queryRule, nil, map[string]bool{}, arity1BaseGroundedIDBs(prog))
+	ctxBoundVars := bodyContextGroundedVars(queryRule, nil, map[string]bool{}, arity1BaseGroundedIDBs(prog), nil)
 	for _, lit := range prog.Query.Body {
 		if lit.Cmp != nil || lit.Agg != nil || !lit.Positive {
 			continue

--- a/ql/plan/magicset_infer.go
+++ b/ql/plan/magicset_infer.go
@@ -269,6 +269,16 @@ func WithMagicSetAuto(prog *datalog.Program, sizeHints map[string]int) (*Executi
 // returned to the caller rather than triggering fallback. Use this in tests
 // and CI to detect transform-soundness regressions (issue #112).
 func WithMagicSetAutoOpts(prog *datalog.Program, sizeHints map[string]int, opts MagicSetOptions) (*ExecutionPlan, QueryBindingInference, []error) {
+	return WithMagicSetAutoOptsWithClassExtents(prog, sizeHints, opts, nil)
+}
+
+// WithMagicSetAutoOptsWithClassExtents is the disj2-round3 form: same
+// as WithMagicSetAutoOpts but additionally threads materialised
+// class-extent base names into both the rule-body demand inference
+// (which then fires for synth-disj predicates whose only grounding
+// source is a stripped class extent) and the underlying Plan call
+// (which orders rule bodies with the same demand-aware view).
+func WithMagicSetAutoOptsWithClassExtents(prog *datalog.Program, sizeHints map[string]int, opts MagicSetOptions, classExtentNames map[string]bool) (*ExecutionPlan, QueryBindingInference, []error) {
 	idb := IDBPredicates(prog)
 	inf := InferQueryBindings(prog, idb)
 
@@ -281,14 +291,14 @@ func WithMagicSetAutoOpts(prog *datalog.Program, sizeHints map[string]int, opts 
 	// `_disj_2` and its body would compute every tuple of B⋈C⋈D
 	// before the binding cap fires (Mastodon `_disj_2` failure mode,
 	// roadmap "Magic-set on synth-disj" section).
-	demandBindings, demandSeeds := InferRuleBodyDemandBindings(prog, idb, sizeHints)
+	demandBindings, demandSeeds := InferRuleBodyDemandBindingsWithClassExtents(prog, idb, sizeHints, classExtentNames)
 	if len(demandBindings) > 0 {
 		inf.Bindings = MergeBindings(inf.Bindings, demandBindings)
 		inf.SeedRules = append(inf.SeedRules, demandSeeds...)
 	}
 
 	if len(inf.Bindings) == 0 {
-		ep, errs := Plan(prog, sizeHints)
+		ep, errs := PlanWithClassExtents(prog, sizeHints, classExtentNames)
 		return ep, inf, errs
 	}
 
@@ -327,7 +337,7 @@ func WithMagicSetAutoOpts(prog *datalog.Program, sizeHints map[string]int, opts 
 			if opts.Strict {
 				return nil, QueryBindingInference{}, []error{arityErr}
 			}
-			ep, errs := Plan(prog, sizeHints)
+			ep, errs := PlanWithClassExtents(prog, sizeHints, classExtentNames)
 			return ep, QueryBindingInference{Fallback: true, FallbackReason: arityErr}, errs
 		}
 	}
@@ -343,7 +353,7 @@ func WithMagicSetAutoOpts(prog *datalog.Program, sizeHints map[string]int, opts 
 			Query: transformed.Query,
 		}
 	}
-	ep, errs := Plan(transformed, sizeHints)
+	ep, errs := PlanWithClassExtents(transformed, sizeHints, classExtentNames)
 	// Plan-error fallback (MAJOR 3 + transform-soundness safety net):
 	// if the augmented program fails to plan for any reason — unstratifiable
 	// (e.g. seed bodies copying a preceding `not Bar(m)` that creates a new
@@ -359,7 +369,7 @@ func WithMagicSetAutoOpts(prog *datalog.Program, sizeHints map[string]int, opts 
 		if opts.Strict {
 			return nil, QueryBindingInference{}, errs
 		}
-		ep2, errs2 := Plan(prog, sizeHints)
+		ep2, errs2 := PlanWithClassExtents(prog, sizeHints, classExtentNames)
 		return ep2, QueryBindingInference{Fallback: true, FallbackReason: errs[0]}, errs2
 	}
 	return ep, inf, errs

--- a/ql/plan/plan.go
+++ b/ql/plan/plan.go
@@ -149,6 +149,17 @@ type MaterialisingEstimatorHook func(prog *datalog.Program, sizeHints map[string
 // is in use, without EstimateAndPlan needing to know about magic-set options.
 type Func func(prog *datalog.Program, sizeHints map[string]int) (*ExecutionPlan, []error)
 
+// FuncWithClassExtents is the disj2-round3 planner entry point: like
+// Func but receives the set of class-extent base predicate names that
+// EstimateAndPlanWithExtentsCtx materialised before planning. The
+// planner uses this set to ground vars sourced from stripped class
+// extents (see PlanWithClassExtents / InferBackwardDemandWithClassExtents
+// for rationale).
+//
+// classExtentNames may be nil (empty set); the planner must degrade
+// cleanly to the non-class-extent behaviour.
+type FuncWithClassExtents func(prog *datalog.Program, sizeHints map[string]int, classExtentNames map[string]bool) (*ExecutionPlan, []error)
+
 // EstimateAndPlan is the single estimate-then-plan entry point. It owns the
 // order: stratify (implicit, via planFn) → identify trivial IDBs and estimate
 // their sizes via the eval-supplied hook → plan everything once with full
@@ -223,8 +234,43 @@ func EstimateAndPlanWithExtents(
 	matExtHook MaterialisingEstimatorHook,
 	planFn Func,
 ) (*ExecutionPlan, []error) {
+	// Adapter: a Func that ignores classExtentNames preserves the
+	// pre-disj2-round3 contract for callers that pass plain plan.Plan.
+	var ctxFn FuncWithClassExtents
+	if planFn != nil {
+		fn := planFn
+		ctxFn = func(p *datalog.Program, h map[string]int, _ map[string]bool) (*ExecutionPlan, []error) {
+			return fn(p, h)
+		}
+	}
+	return EstimateAndPlanWithExtentsCtx(prog, sizeHints, maxBindingsPerRule, estimator, matExtHook, ctxFn)
+}
+
+// EstimateAndPlanWithExtentsCtx is the disj2-round3 entry point. It is
+// identical to EstimateAndPlanWithExtents except `planFn` is a
+// FuncWithClassExtents — the planner receives the set of class-extent
+// base names that the materialising hook produced AND that were
+// stripped from the planning program. This lets the planner ground vars
+// sourced from those (now-base-like) extents in backward-demand
+// inference, fixing the disj2-round3 cap-hit failure mode where a
+// stripped class extent was the sole grounder for a downstream synth
+// `_disj_*` predicate.
+//
+// The same materialised-extents set is also used to filter rules out
+// of the planning program (mirroring EstimateAndPlanWithExtents'
+// stripping behaviour).
+func EstimateAndPlanWithExtentsCtx(
+	prog *datalog.Program,
+	sizeHints map[string]int,
+	maxBindingsPerRule int,
+	estimator EstimatorHook,
+	matExtHook MaterialisingEstimatorHook,
+	planFn FuncWithClassExtents,
+) (*ExecutionPlan, []error) {
 	if planFn == nil {
-		planFn = Plan
+		planFn = func(p *datalog.Program, h map[string]int, ce map[string]bool) (*ExecutionPlan, []error) {
+			return PlanWithClassExtents(p, h, ce)
+		}
 	}
 	if sizeHints == nil {
 		sizeHints = map[string]int{}
@@ -264,13 +310,31 @@ func EstimateAndPlanWithExtents(
 		}
 	}
 
-	return planFn(planProg, sizeHints)
+	return planFn(planProg, sizeHints, materialisedExtents)
 }
 
 // Plan produces an ExecutionPlan from a Datalog program.
 // sizeHints maps relation names to estimated tuple counts (for join ordering).
 // Unknown relations default to 1000.
 func Plan(prog *datalog.Program, sizeHints map[string]int) (*ExecutionPlan, []error) {
+	return PlanWithClassExtents(prog, sizeHints, nil)
+}
+
+// PlanWithClassExtents is the disj2-round3 entry point: like Plan, but
+// additionally honours a caller-supplied set of materialised
+// class-extent base predicate names. Those names are treated as
+// grounders for any var they bind in any rule body, regardless of size
+// hint, when computing backward demand. This is the load-bearing fix
+// for the case where EstimateAndPlanWithExtents materialises a class
+// extent and STRIPS its defining rule from the planning program: the
+// arity-1 structural detector (PR #158) cannot match a stripped rule,
+// so without explicit class-extent membership the consuming rule's
+// demand collapses and the synth-disj cap-hits at evaluation time.
+//
+// classExtentNames may be nil (degrades to the plain Plan behaviour).
+//
+//revive:disable-next-line:exported The "Plan" prefix mirrors EstimateAndPlanWithExtents; renaming would obscure the entry-point family.
+func PlanWithClassExtents(prog *datalog.Program, sizeHints map[string]int, classExtentNames map[string]bool) (*ExecutionPlan, []error) {
 	// Validate all rules first.
 	var errs []error
 	for _, rule := range prog.Rules {
@@ -298,7 +362,7 @@ func Plan(prog *datalog.Program, sizeHints map[string]int) (*ExecutionPlan, []er
 	// (e.g. no IDB is caller-grounded) orderJoinsWithDemand degrades to
 	// the same behaviour as orderJoins, preserving all prior plans as
 	// a lower bound.
-	demand := InferBackwardDemand(prog, sizeHints)
+	demand := InferBackwardDemandWithClassExtents(prog, sizeHints, classExtentNames)
 
 	ep := &ExecutionPlan{Demand: demand}
 	for _, stratum := range strata {


### PR DESCRIPTION
## Summary

PR #158 fixed the "arity-1 class-extent IDB above SmallExtentThreshold" failure mode by recognising the structural shape of class-extent helper rules in the planning program. That fix only applies when the class-extent rule SURVIVES into `Plan()`. On Cain's work codebase running `find_setstate_updater_calls_other_setstate.ql`:

1. `EstimateAndPlanWithExtents` materialises `UseStateSetterCall` via the P2a class-extent hook AND **strips its defining rule** before planning (plan.go:250-265).
2. `arity1BaseGroundedIDBs` (the PR #158 detector) has nothing to match — the rule is gone.
3. `bodyContextGroundedVars` falls back to `isSmallExtent()` for the (now-base) `UseStateSetterCall` literal.
4. Real prod extent ~250k, well above `SmallExtentThreshold = 5000`. Returns false; `c` is not marked bound.
5. `_disj_2`'s demand collapses; magic-set rewrite never fires; 5-atom body cap-hits at 5M bindings — Cain's prod failure.

## Fix

Thread the materialised-extents name set produced by the materialising hook through to `InferBackwardDemand` and the magic-set seed builder via new entry points:
- `PlanWithClassExtents(prog, hints, classExtentNames)`
- `WithMagicSetAutoOptsWithClassExtents(prog, hints, opts, classExtentNames)`
- `EstimateAndPlanWithExtentsCtx(prog, hints, cap, est, matExtHook, planFn FuncWithClassExtents)`
- `FuncWithClassExtents` planner-entry-point type

`bodyContextGroundedVars` now treats any literal whose predicate is in the materialised-extents set as a grounder for its arg vars — same per-tuple-iteration argument as PR #158, plus the extra signal that the extent has already been built and lives in RAM as a base-like relation (so size hint is not the load-bearing correctness gate).

`cmd/tsq/main.go` switches to `EstimateAndPlanWithExtentsCtx` so production benefits. Existing `EstimateAndPlanWithExtents` / `Plan` / `WithMagicSetAutoOpts` entry points keep their signatures and degrade to the pre-round-3 behaviour with nil class extents — no test churn for the 50+ existing call sites.

## Tests

- `disj2_round3_stripped_extent_test.go`:
  - 3 stripped-extent demand cases at 7k / 250k / 5M sizes (all newly pass via the threaded set).
  - Nil-set baseline regression guard (proves the PR #158 path still drops above-threshold without the new threading — load-bearing).
  - End-to-end Ctx wiring assertion: feeds `EstimateAndPlanWithExtentsCtx` a class-extent + downstream synth-disj caller program, confirms the materialised-extents name flows from hook through to magic-set bindings.
- Full plan + eval + extract + cmd + bridge suites green under `-race -count=1`.

## Test plan
- [x] `go test ./ql/plan/... -race -count=1`
- [x] `go test ./ql/eval/... -race -count=1`
- [x] `go test ./extract/... ./cmd/... ./bridge/... -race -count=1`
- [ ] Cain-nas mastodon bench (`find_setstate_updater_calls_other_setstate.ql`) post-merge

Refs #158