### PR TITLE
fix(plan): defer IDB calls until demand-bound positions are satisfied (disj2-round4)

### DIFF
--- a/ql/plan/backward.go
+++ b/ql/plan/backward.go
@@ -696,6 +696,40 @@ func orderJoinsWithDemand(
 	sizeHints map[string]int,
 	headDemand []int,
 ) []JoinStep {
+	return orderJoinsWithDemandAndIDB(head, body, sizeHints, headDemand, nil)
+}
+
+// orderJoinsWithDemandAndIDB extends orderJoinsWithDemand with awareness
+// of per-IDB demand bindings: for any positive body literal that calls
+// an IDB whose demand map names bound positions, the planner penalises
+// scheduling that literal until the corresponding variables are
+// runtime-bound. This is the disj2-round4 fix.
+//
+// Concretely, after magic-set rewriting an IDB call P(x,y) with
+// demand[P]=[0] will be evaluated as `magic_P(x), P(x,y)` — i.e. the
+// magic seed prefilters x. If we schedule P(x,y) before x is bound by
+// some grounder in the body, we lose that benefit and the underlying
+// recursive evaluation iterates the entire predicate. The fix tells
+// the greedy scorer "defer this literal until x is runtime-bound" by
+// inflating its effective size hint to SaturatedSizeHint when the
+// precondition is unmet. Once a later step grounds x, the literal
+// becomes attractively-cheap again at its real size.
+//
+// Only POSITIVE atom literals on IDBs with non-empty demand are
+// affected. Comparisons, negatives, aggregates, base relations, and
+// IDBs with empty demand keep their current scoring. The penalty does
+// NOT apply to the rule's OWN head predicate (that would forbid
+// recursive self-calls from being scheduled at all).
+//
+// idbDemand may be nil; nil degrades exactly to orderJoinsWithDemand's
+// pre-round4 behaviour.
+func orderJoinsWithDemandAndIDB(
+	head datalog.Atom,
+	body []datalog.Literal,
+	sizeHints map[string]int,
+	headDemand []int,
+	idbDemand DemandMap,
+) []JoinStep {
 	if len(body) == 0 {
 		return nil
 	}
@@ -745,7 +779,28 @@ func orderJoinsWithDemand(
 		// review Finding 2 on PR #143. The "head-demand biases scoring"
 		// promise is preserved at scoreLiteral below (which keeps
 		// plannerBound).
-		tinyIdx := pickTinySeed(body, placed, runtimeBound, sizeHints, defaultSizeHint)
+		// Tiny-seed override is suppressed for IDB literals whose demand
+		// preconditions aren't met yet — a pickTinySeed promotion via the
+		// shared-bound-var branch would otherwise schedule a demand-IDB
+		// before its bound vars are grounded, defeating the round4 fix.
+		// We pass placedView equal to placed but block IDB-demand-deferred
+		// candidates by marking them temporarily placed for this lookup.
+		var tinyMask []bool
+		if hasIDBDemand(body, idbDemand) {
+			tinyMask = make([]bool, len(body))
+			copy(tinyMask, placed)
+			for i, lit := range body {
+				if tinyMask[i] {
+					continue
+				}
+				if isIDBCallDeferred(lit, head.Predicate, idbDemand, runtimeBound, sizeHints) {
+					tinyMask[i] = true
+				}
+			}
+		} else {
+			tinyMask = placed
+		}
+		tinyIdx := pickTinySeed(body, tinyMask, runtimeBound, sizeHints, defaultSizeHint)
 		if tinyIdx != -1 && isEligible(body[tinyIdx], runtimeBound) {
 			bestIdx = tinyIdx
 		} else {
@@ -757,6 +812,14 @@ func orderJoinsWithDemand(
 					continue
 				}
 				negBound, size := scoreLiteral(lit, plannerBound, sizeHints)
+				// Round4: defer IDB literals whose demand requires
+				// positions not yet runtime-bound. Inflate their size to
+				// SaturatedSizeHint so any other eligible candidate wins;
+				// when a later step binds the required vars they regain
+				// their true cost and become competitive again.
+				if isIDBCallDeferred(lit, head.Predicate, idbDemand, runtimeBound, sizeHints) {
+					size = idbDeferredPenalty
+				}
 				if bestIdx == -1 || negBound < bestNegBound || (negBound == bestNegBound && size < bestSize) {
 					bestIdx = i
 					bestNegBound = negBound
@@ -796,4 +859,93 @@ func orderJoinsWithDemand(
 		steps = append(steps, step)
 	}
 	return steps
+}
+
+// idbDeferredPenalty is the cost-model penalty assigned to an IDB
+// literal whose demand bindings are not yet runtime-bound. It must
+// dominate any plausible real size hint while staying below int
+// overflow; aligning with eval.SaturatedSizeHint (1<<30) is the
+// natural choice — both signal "treat as effectively unbounded".
+const idbDeferredPenalty = 1 << 30
+
+// hasIDBDemand returns true if any literal in body refers to a
+// predicate present in idbDemand with a non-empty bound-position list.
+// Used as a cheap pre-check to skip the per-step deferral computation
+// when no demand applies (the common case).
+func hasIDBDemand(body []datalog.Literal, idbDemand DemandMap) bool {
+	if len(idbDemand) == 0 {
+		return false
+	}
+	for _, lit := range body {
+		if !lit.Positive || lit.Cmp != nil || lit.Agg != nil {
+			continue
+		}
+		if cols, ok := idbDemand[lit.Atom.Predicate]; ok && len(cols) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// isIDBCallDeferred reports whether lit is a positive call to an IDB
+// whose demand map names argument positions that are NOT yet bound in
+// runtimeBound. Such a call should be deferred until a later step
+// grounds the required vars — but only when:
+//
+//   - The literal's size hint is "large" (≥ SmallExtentThreshold) or
+//     unhinted (defaultSizeHint). A genuinely small IDB call (e.g.
+//     a tiny class extent like TaintSink at size 7) is cheap to
+//     schedule even with free args; deferring it would suppress the
+//     existing tiny-seed heuristic that depends on small-hinted IDBs
+//     winning slot 0. Round4's target is the recursive / big-IDB
+//     shape (functionContainsStar), not small lookup helpers.
+//
+//   - The predicate is NOT the rule's own head (recursive self-call).
+//     A literal that is a recursive self-call (e.g. `Path :- Path,
+//     Edge`) is NEVER deferred — that would forbid scheduling the
+//     recursive case at all, breaking fixpoint convergence.
+//
+// Comparisons, negatives, aggregates, and base relations always return
+// false (idbDemand has no entry, or is gated out above).
+func isIDBCallDeferred(
+	lit datalog.Literal,
+	selfHead string,
+	idbDemand DemandMap,
+	runtimeBound map[string]bool,
+	sizeHints map[string]int,
+) bool {
+	if !lit.Positive || lit.Cmp != nil || lit.Agg != nil {
+		return false
+	}
+	pred := lit.Atom.Predicate
+	if pred == "" || pred == selfHead {
+		return false
+	}
+	cols, ok := idbDemand[pred]
+	if !ok || len(cols) == 0 {
+		return false
+	}
+	// Size-gate: only defer literals that would be expensive to
+	// scan unbound. A known-small IDB hint exempts the literal from
+	// deferral — its full scan is cheap.
+	if sz, hinted := sizeHints[pred]; hinted && sz > 0 && sz <= SmallExtentThreshold {
+		return false
+	}
+	for _, col := range cols {
+		if col < 0 || col >= len(lit.Atom.Args) {
+			// Arity mismatch — treat as not-deferred to avoid
+			// silently breaking malformed but otherwise-eligible plans.
+			return false
+		}
+		v, isVar := lit.Atom.Args[col].(datalog.Var)
+		if !isVar || v.Name == "" || v.Name == "_" {
+			// Constant or wildcard at the demand position satisfies
+			// the magic-set seed without runtime binding.
+			continue
+		}
+		if !runtimeBound[v.Name] {
+			return true
+		}
+	}
+	return false
 }

--- a/ql/plan/disj2_round4_idb_demand_defer_test.go
+++ b/ql/plan/disj2_round4_idb_demand_defer_test.go
@@ -1,0 +1,193 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// disj2-round4 — defer IDB calls until their demand-bound positions are
+// runtime-bound.
+//
+// Surface: PR #161 fixed the inner `_disj_2` cap-hit on
+// find_setstate_updater_calls_other_setstate.ql by threading
+// materialised class extents through demand inference. Magic-set now
+// correctly infers `bindings=map[_disj_2:[0]]`. But the OUTER rule
+// `setStateUpdaterCallsOtherSetState` still cap-hits at 20M.
+//
+// Root cause: even with demand[_disj_2] = [0] correctly inferred, the
+// planner still considers the recursive _disj_2 literal as cheap at slot
+// 0 (small / default size hint), placing it BEFORE the small grounder
+// chain (`UseStateSetterCall(c) → CallArg(c,0,argFn) → _disj_2(argFn,
+// inner)`). Without bound `argFn` the recursive call iterates the entire
+// star and blows the binding cap at step 2.
+//
+// Fix: orderJoinsWithDemandAndIDB consults the per-IDB DemandMap when
+// scoring each candidate. A positive IDB call whose demand bindings are
+// not yet runtime-bound (and whose hint isn't tiny) is penalised with
+// SaturatedSizeHint so the planner picks any other reasonable
+// alternative first. As soon as a later step grounds the required vars
+// the literal regains its true cost and is scheduled in its proper
+// place.
+//
+// This test reproduces the structural shape of the production failure
+// and asserts the corrected ordering.
+func TestPlan_Disj2Round4_DefersDemandIDBUntilBound(t *testing.T) {
+	v := func(name string) datalog.Var { return datalog.Var{Name: name} }
+	pos := func(pred string, args ...datalog.Term) datalog.Literal {
+		return datalog.Literal{Positive: true, Atom: datalog.Atom{Predicate: pred, Args: args}}
+	}
+
+	// Simulate the post-magic-set body of
+	// setStateUpdaterCallsOtherSetState. The planner sees:
+	//   UseStateSetterCall(c)        — small grounder, hint 7
+	//   CallArg(c, 0, argFn)         — point-keyed lookup binding argFn
+	//   functionContainsStar(argFn, inner) — recursive IDB,
+	//                                  demand[func...Star] = [0]
+	//   UseStateSetterCall(inner)    — small grounder, hint 7
+	//   Other(c, callee)             — base, large
+	body := []datalog.Literal{
+		pos("functionContainsStar", v("argFn"), v("inner")),
+		pos("UseStateSetterCall", v("inner")),
+		pos("UseStateSetterCall", v("c")),
+		pos("CallArg", v("c"), datalog.IntConst{Value: 0}, v("argFn")),
+		pos("Other", v("c"), v("callee")),
+	}
+	head := datalog.Atom{
+		Predicate: "setStateUpdaterCallsOtherSetState",
+		Args:      []datalog.Term{v("c"), v("callee")},
+	}
+
+	hints := map[string]int{
+		"UseStateSetterCall":   7,
+		"CallArg":              50000, // base, but constant arg keeps it cheap per-probe
+		"functionContainsStar": 50000, // > SmallExtentThreshold so deferral applies
+		"Other":                500000,
+	}
+	// demand[functionContainsStar] = [0] — col 0 must be bound
+	// before scheduling.
+	demand := DemandMap{
+		"functionContainsStar": {0},
+	}
+
+	steps := orderJoinsWithDemandAndIDB(head, body, hints, nil, demand)
+
+	if len(steps) == 0 {
+		t.Fatal("no steps produced")
+	}
+	first := steps[0].Literal.Atom.Predicate
+	if first == "functionContainsStar" {
+		t.Fatalf("functionContainsStar must NOT be the seed (its demand col 0 / argFn is unbound at slot 0); full order: %v", predicateOrder(steps))
+	}
+	// The recursive IDB must be scheduled AFTER argFn is bound. argFn
+	// is introduced by CallArg(c, 0, argFn) which itself requires c
+	// (introduced by UseStateSetterCall(c)). Find positions:
+	posOf := func(pred string) int {
+		for i, s := range steps {
+			if s.Literal.Atom.Predicate == pred {
+				return i
+			}
+		}
+		return -1
+	}
+	pStar := posOf("functionContainsStar")
+	pCallArg := posOf("CallArg")
+	if pStar == -1 || pCallArg == -1 {
+		t.Fatalf("missing expected literals; full order: %v", predicateOrder(steps))
+	}
+	if pStar < pCallArg {
+		t.Fatalf("functionContainsStar at %d must come AFTER CallArg at %d (argFn must be bound first); full order: %v",
+			pStar, pCallArg, predicateOrder(steps))
+	}
+}
+
+// Companion test: when the demand map is empty (or nil), the planner
+// preserves its pre-round4 behaviour — no deferral, recursive IDB can
+// still be scheduled first if its hint says so. Guards against
+// over-correction.
+func TestPlan_Disj2Round4_NoDemandPreservesLegacyOrder(t *testing.T) {
+	v := func(name string) datalog.Var { return datalog.Var{Name: name} }
+	pos := func(pred string, args ...datalog.Term) datalog.Literal {
+		return datalog.Literal{Positive: true, Atom: datalog.Atom{Predicate: pred, Args: args}}
+	}
+
+	body := []datalog.Literal{
+		pos("functionContainsStar", v("argFn"), v("inner")),
+		pos("UseStateSetterCall", v("c")),
+		pos("CallArg", v("c"), datalog.IntConst{Value: 0}, v("argFn")),
+	}
+	head := datalog.Atom{Predicate: "R", Args: []datalog.Term{v("c"), v("inner")}}
+	hints := map[string]int{
+		"UseStateSetterCall":   7,
+		"CallArg":              50000,
+		"functionContainsStar": 50000,
+	}
+
+	// nil demand → no IDB-call deferral
+	stepsNil := orderJoinsWithDemandAndIDB(head, body, hints, nil, nil)
+	// orderJoinsWithDemand wrapper → byte-identical
+	stepsWrap := orderJoinsWithDemand(head, body, hints, nil)
+	if len(stepsNil) != len(stepsWrap) {
+		t.Fatalf("nil-demand vs wrapper length mismatch: %d vs %d", len(stepsNil), len(stepsWrap))
+	}
+	for i := range stepsNil {
+		if stepsNil[i].Literal.Atom.Predicate != stepsWrap[i].Literal.Atom.Predicate {
+			t.Fatalf("nil-demand vs wrapper diverge at step %d: %s vs %s",
+				i, stepsNil[i].Literal.Atom.Predicate, stepsWrap[i].Literal.Atom.Predicate)
+		}
+	}
+}
+
+// Companion test: small-hinted IDBs MUST NOT be deferred even when
+// their demand cols aren't bound. Otherwise the existing tiny-seed
+// heuristic — which depends on small-hinted class extents like
+// TaintSink (size 7) winning slot 0 — would regress.
+func TestPlan_Disj2Round4_SmallIDBNotDeferredEvenWithUnboundDemand(t *testing.T) {
+	v := func(name string) datalog.Var { return datalog.Var{Name: name} }
+	pos := func(pred string, args ...datalog.Term) datalog.Literal {
+		return datalog.Literal{Positive: true, Atom: datalog.Atom{Predicate: pred, Args: args}}
+	}
+
+	body := []datalog.Literal{
+		pos("BigBase", v("x"), v("y")),
+		pos("TinySink", v("y")), // small IDB, demand[y] not bound
+	}
+	head := datalog.Atom{Predicate: "Alert", Args: []datalog.Term{v("x"), v("y")}}
+	hints := map[string]int{"BigBase": 1_000_000, "TinySink": 7}
+	demand := DemandMap{"TinySink": {0}}
+
+	steps := orderJoinsWithDemandAndIDB(head, body, hints, nil, demand)
+	if len(steps) == 0 || steps[0].Literal.Atom.Predicate != "TinySink" {
+		t.Fatalf("small-hinted IDB must NOT be deferred; expected TinySink first, got order=%v",
+			predicateOrder(steps))
+	}
+}
+
+// Companion test: a recursive self-call (literal whose predicate equals
+// the rule's own head) must NEVER be deferred — that would forbid the
+// recursive case from being scheduled at all and break fixpoint
+// convergence.
+func TestPlan_Disj2Round4_RecursiveSelfCallNotDeferred(t *testing.T) {
+	v := func(name string) datalog.Var { return datalog.Var{Name: name} }
+	pos := func(pred string, args ...datalog.Term) datalog.Literal {
+		return datalog.Literal{Positive: true, Atom: datalog.Atom{Predicate: pred, Args: args}}
+	}
+
+	// Path(x, z) :- Path(x, y), Edge(y, z).
+	body := []datalog.Literal{
+		pos("Path", v("x"), v("y")),
+		pos("Edge", v("y"), v("z")),
+	}
+	head := datalog.Atom{Predicate: "Path", Args: []datalog.Term{v("x"), v("z")}}
+	hints := map[string]int{"Path": 50000, "Edge": 100000}
+	demand := DemandMap{"Path": {0}}
+
+	// Should not panic / should not produce empty plan / should
+	// schedule both literals. Order itself is not asserted — the
+	// safety property is that the recursive call is not infinitely
+	// deferred.
+	steps := orderJoinsWithDemandAndIDB(head, body, hints, nil, demand)
+	if len(steps) != 2 {
+		t.Fatalf("expected 2 steps, got %d (order=%v)", len(steps), predicateOrder(steps))
+	}
+}

--- a/ql/plan/plan.go
+++ b/ql/plan/plan.go
@@ -369,7 +369,7 @@ func PlanWithClassExtents(prog *datalog.Program, sizeHints map[string]int, class
 		ps := Stratum{}
 		for _, rule := range stratum {
 			headDemand := demand[rule.Head.Predicate]
-			order := orderJoinsWithDemand(rule.Head, rule.Body, sizeHints, headDemand)
+			order := orderJoinsWithDemandAndIDB(rule.Head, rule.Body, sizeHints, headDemand, demand)
 			// P3b: annotate each step with the demand frontier so the
 			// evaluator can drop unused columns from intermediate
 			// bindings.
@@ -460,7 +460,7 @@ func RePlanStratumWithDemand(s *Stratum, sizeHints map[string]int, demand Demand
 			continue
 		}
 		headDemand := demand[s.Rules[i].Head.Predicate]
-		s.Rules[i].JoinOrder = orderJoinsWithDemand(s.Rules[i].Head, body, sizeHints, headDemand)
+		s.Rules[i].JoinOrder = orderJoinsWithDemandAndIDB(s.Rules[i].Head, body, sizeHints, headDemand, demand)
 		computeLiveVars(s.Rules[i].JoinOrder, headVars(s.Rules[i].Head))
 	}
 }


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Summary
Round-4 follow-up to #161. PR #161 fixed the inner `_disj_2` cap-hit by threading materialised class extents through demand inference. Magic-set now correctly infers `demand[_disj_2]=[0]` with seed rules. But the **outer** rule `setStateUpdaterCallsOtherSetState` continued to cap-hit at 20M.

## Root cause
Even with `demand[functionContainsStar]=[0]` correctly inferred, the planner still considered the recursive IDB literal as cheap at slot 0 (small / default size hint) and placed it BEFORE the small grounder chain (`UseStateSetterCall(c) → CallArg(c,0,argFn)`). Without bound `argFn` the recursive call iterates the entire star and blows the binding cap at step 2.

## Fix
Extend `orderJoinsWithDemand` to consult the per-IDB DemandMap when scoring each candidate. A positive IDB call whose demand bindings are NOT yet runtime-bound, AND whose size hint is not "small", is penalised with `SaturatedSizeHint` so the planner picks any other reasonable alternative first. Once a later step grounds the required vars, the literal regains its true cost and is scheduled in its proper place.

## Guards (anti-over-correction)
- **Small-hinted IDBs (≤ `SmallExtentThreshold`) are NEVER deferred** — their full scan is cheap and the tiny-seed heuristic relies on them (e.g. `TaintSink` at size 7) winning slot 0. Without this guard, `TestPlan_TaintShape_NativeBackwardSeedChoice` regresses.
- **Recursive self-calls (`pred == head.Predicate`) are NEVER deferred** — that would forbid the recursive case from being scheduled and break fixpoint convergence.
- **Constants/wildcards at demand positions count as bound** — the magic-set seed is satisfied without runtime binding.
- **Empty/nil DemandMap → byte-identical to pre-round4 plans.**

## Threading
- New `orderJoinsWithDemandAndIDB(head, body, sizeHints, headDemand, idbDemand DemandMap)` carries the full demand map.
- Existing `orderJoinsWithDemand` becomes a thin wrapper passing nil — preserves all 50+ test/external call sites.
- `Plan()` and `RePlanStratumWithDemand` route through the new entry point with the demand map produced by `InferBackwardDemand`.

## Test plan
- [x] `TestPlan_Disj2Round4_DefersDemandIDBUntilBound` — production-failure shape, asserts `functionContainsStar` is scheduled AFTER `CallArg` binds `argFn`.
- [x] `TestPlan_Disj2Round4_NoDemandPreservesLegacyOrder` — nil demand → byte-identical to wrapper.
- [x] `TestPlan_Disj2Round4_SmallIDBNotDeferredEvenWithUnboundDemand` — small-hint exemption holds.
- [x] `TestPlan_Disj2Round4_RecursiveSelfCallNotDeferred` — `Path :- Path, Edge` still planable.
- [x] Regression evidence: `TestPlan_Disj2Round4_DefersDemandIDBUntilBound` FAILS with the size-penalty hunk disabled (verified via sed), PASSES with it.
- [x] Full `go test ./... -count=1` green across 17 packages.
- [ ] Bench validation on cain-nas mastodon/jitsi corpora — deferred per Cain's directive (prioritise landing the fix).

## Honest call-outs
- **Mastodon-scale parity not measured.** The synthetic test reproduces the structural pathology; cain-nas bench should be re-run post-merge to confirm the cap-hit on `setStateUpdaterCallsOtherSetState` is gone.
- **Penalty is a single magic value (`1<<30`)**, aligned with `eval.SaturatedSizeHint`. Could in principle be a softer multiplier, but the binary "defer" semantic matches the planner's existing greedy/bounded structure.
- **Body-IDB demand is read; head-IDB demand on the rule being planned is unchanged.** The head-demand path (`headDemand` arg) was the P3a feature; round4 adds the symmetric body-call case.

Refs #161, the round-3 fix that produced the correct demand map without acting on it.