### PR TITLE
feat(queries): markdown-renderable setstate-updater-calls-other-setstate variant

### DIFF
--- a/testdata/queries/v2/find_setstate_updater_calls_other_setstate_md.ql
+++ b/testdata/queries/v2/find_setstate_updater_calls_other_setstate_md.ql
@@ -1,0 +1,23 @@
+/**
+ * @name useState setter call whose updater calls another useState setter (with path)
+ * @description Same as find_setstate_updater_calls_other_setstate.ql, but the
+ *              select exposes `path` so `tsq query --format markdown` can
+ *              render file:line headers and source snippets. The bridge
+ *              predicate itself is unchanged; we just resolve the call site's
+ *              file path via the Call → callee Node → File chain.
+ * @kind problem
+ * @id js/tsq/setstate-updater-calls-other-setstate-md
+ */
+
+import tsq::react
+import tsq::calls
+import tsq::variables
+import tsq::functions
+import tsq::base
+
+from Call c, int line
+where setStateUpdaterCallsOtherSetState(c, line)
+select
+  c.getCalleeNode().getFile().getPath() as "path",
+  line as "line",
+  c as "call"


### PR DESCRIPTION
## Summary
Adds `find_setstate_updater_calls_other_setstate_md.ql` — same predicate as the original, but the `select` exposes a `path` column so `tsq query --format markdown` can render `## path:line` headers with ±5 line source snippets.

The bridge predicate `setStateUpdaterCallsOtherSetState` returns `(int c, int line)` where `c` is a Call entity ID. The markdown formatter looks for a `file`/`path`/`filepath`/`uri` column and falls back to a bullet list of raw column values when none is found — which is what Cain hit on his work codebase.

This wrapper resolves `c.getCalleeNode().getFile().getPath()` to expose the path. No changes to the bridge predicate or the canonical query.

## Test plan
- [x] `tsq check` passes on the new query
- [ ] Cain re-runs his query with the `_md.ql` variant against his work codebase and confirms markdown now renders snippets per result row