### PR TITLE
feat(bridge): track setState aliases through React Context (round-2)

### DIFF
--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -64,6 +64,7 @@ func v2Manifest() *CapabilityManifest {
 			{Name: "DestructureField", Relation: "DestructureField", File: "tsq_expressions.qll"},
 			{Name: "ArrayDestructure", Relation: "ArrayDestructure", File: "tsq_expressions.qll"},
 			{Name: "DestructureRest", Relation: "DestructureRest", File: "tsq_expressions.qll"},
+			{Name: "ObjectLiteralField", Relation: "ObjectLiteralField", File: "tsq_expressions.qll"},
 			{Name: "JsxElement", Relation: "JsxElement", File: "tsq_jsx.qll"},
 			{Name: "JsxAttribute", Relation: "JsxAttribute", File: "tsq_jsx.qll"},
 			{Name: "ImportBinding", Relation: "ImportBinding", File: "tsq_imports.qll"},

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -17,8 +17,9 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	// Phase E: +3 HTTP + 2 IO + 2 RegExp = 114
 	// C3/C4/C6: +1 Decorator + 2 Namespace + 1 TypeGuard = 118
 	// Phase A3: +2 AdditionalTaintStep + AdditionalFlowStep = 120
-	if got := len(m.Available); got != 120 {
-		t.Errorf("expected 120 available classes, got %d", got)
+	// Round-2 setState alias (context): +1 ObjectLiteralField = 121
+	if got := len(m.Available); got != 121 {
+		t.Errorf("expected 121 available classes, got %d", got)
 	}
 }
 

--- a/bridge/tsq_expressions.qll
+++ b/bridge/tsq_expressions.qll
@@ -98,6 +98,35 @@ class Cast extends @cast {
 }
 
 /**
+ * A field in an object literal expression ({ a, b: expr }).
+ *
+ * For shorthand `{ foo }` the fieldName equals the binding name and
+ * valueExpr is the Identifier node (which has its own ExprMayRef row).
+ * For `{ foo: expr }` the fieldName is the source key and valueExpr is the
+ * value-position expression. Spread elements (`{ ...rest }`) and computed-key
+ * properties are skipped by the extractor — v1 limitation.
+ *
+ * NOTE: `this` binds to col 0 (parent), which is not a unique identifier.
+ * Multiple fields in the same object literal share the same col-0 value,
+ * causing entity collapse. Same v1 limitation as DestructureField.
+ */
+class ObjectLiteralField extends @object_literal_field {
+    ObjectLiteralField() { ObjectLiteralField(this, _, _) }
+
+    /** Gets the parent object-literal node. */
+    ASTNode getParent() { result = this }
+
+    /** Gets the field name (shorthand binding name OR source key). */
+    string getFieldName() { ObjectLiteralField(this, result, _) }
+
+    /** Gets the value-position expression node. */
+    ASTNode getValueExpr() { ObjectLiteralField(this, _, result) }
+
+    /** Gets a textual representation. */
+    string toString() { result = this.getFieldName() }
+}
+
+/**
  * A field in a destructuring pattern ({ key: binding }).
  *
  * NOTE: `this` binds to col 0 (parent), which is not a unique identifier.

--- a/bridge/tsq_react.qll
+++ b/bridge/tsq_react.qll
@@ -397,6 +397,467 @@ predicate setStateUpdaterCallsOtherSetStateThroughProps(int call, int line) {
     )
 }
 
+/* -----------------------------------------------------------------------
+ * Round-2 of setState alias tracking — through React Context
+ * -----------------------------------------------------------------------
+ *
+ * Extends `useStateSetterAlias` to follow setters that arrive at a call
+ * site through `createContext` + `<Ctx.Provider value={{ setX }}>` +
+ * `useContext(Ctx)` (or a hook wrapping useContext) + destructure.
+ *
+ * Motivating shape:
+ *
+ *   const ViewerStateActions = createContext<...>(null);
+ *
+ *   function ViewerProvider({ children }) {
+ *     const [zoom, setZoom] = useState(1);
+ *     return <ViewerStateActions.Provider value={{ setZoom }}>{children}</...>;
+ *   }
+ *
+ *   function useViewerActions() { return useContext(ViewerStateActions); }
+ *
+ *   function ZoomButton() {
+ *     const { setZoom } = useViewerActions();
+ *     setZoom(prev => prev + 1);   // <-- recognised as a setter-alias call
+ *   }
+ *
+ * Soundness vs. precision call-outs (deferrals documented in the round-2
+ * wiki page):
+ *  - createContext recognition is name-based on the callee identifier
+ *    binding (`ImportBinding(_, "react", "createContext")`). Aliased
+ *    `import { createContext as cc }` works because the callee sym still
+ *    resolves to the imported binding, but a wholesale `import * as React`
+ *    + `React.createContext(...)` callee shape is NOT covered in v1.
+ *  - Multi-Provider disambiguation is intentionally over-approximate —
+ *    a useContext(Ctx) resolves to the value of ANY Provider for Ctx in
+ *    the program. A program with two unrelated Providers for the same
+ *    context will produce false positives.
+ *  - Hook-indirection depth is hand-unrolled to two levels (useContext,
+ *    useFoo() = useContext, useBar() = useFoo()). Same planner-sizing
+ *    rationale as `functionContainsStar` and `useStateSetterAlias`.
+ *  - Object-literal field tracking treats `value={{ a, b }}` as exposing
+ *    BOTH `a` and `b`; field-name binding to destructure-key is enforced
+ *    on the consumer side via `DestructureField(parent, propName, _, _, _)`
+ *    matched against `ObjectLiteralField(obj, propName, valueExpr)`.
+ */
+
+/**
+ * Holds if `sym` is a symbol bound to a `createContext(...)` call result —
+ * i.e. the context handle.
+ *
+ *   const ViewerStateActions = createContext<...>(null);
+ *
+ * Recognition is name-based on the callee identifier binding via
+ * `ImportBinding(_, "react", "createContext")`. Namespace-import call sites
+ * (e.g. `React.createContext(...)`) are NOT recognised in v1 — same
+ * deferral as the namespace shape for useState in the round-1 base case.
+ */
+predicate contextSym(int sym) {
+    exists(int initExpr, int createCtxSym |
+        VarDecl(_, sym, initExpr, _) and
+        CallCalleeSym(initExpr, createCtxSym) and
+        ImportBinding(createCtxSym, "react", "createContext")
+    )
+}
+
+/**
+ * Holds if `objExpr` is contained, directly or transitively via the
+ * JsxExpression wrapper, by `valueAttrExpr`. Used to find the object
+ * literal expression inside a Provider's `value={{ ... }}` attribute
+ * (the JsxAttribute valueExpr column points at the `{ ... }` JsxExpression
+ * node, not at the inner Object literal directly).
+ */
+predicate jsxAttrValueObject(int valueAttrExpr, int objExpr) {
+    valueAttrExpr = objExpr
+    or
+    Contains(valueAttrExpr, objExpr)
+}
+
+/**
+ * Holds if a JSX element `elem` is a Provider for context symbol `ctxSym`
+ * — i.e. its tag is the member access `<ctxSym.Provider ...>` — and its
+ * `value` attribute carries object literal `objExpr`.
+ *
+ * The tag of a `<Foo.Provider />` JSX element is a MemberExpression node;
+ * the walker emits a FieldRead row for it with `baseSym = Foo` and
+ * `fieldName = "Provider"`. We pivot on that to identify the context.
+ *
+ * Limitations:
+ *  - `Contains(valueAttrExpr, objExpr)` over-approximates: nested object
+ *    literals inside a non-object value (e.g. `value={makeActions({...})}`)
+ *    would also match. The downstream field-name match constrains this.
+ *  - Only direct object-literal values are recognised; values built by a
+ *    helper function call (`value={makeActions()}`) are out of scope.
+ */
+predicate contextProviderValueObject(int ctxSym, int objExpr) {
+    exists(int elem, int tagNode, int valueAttrExpr |
+        JsxElement(elem, tagNode, _) and
+        FieldRead(tagNode, ctxSym, "Provider") and
+        JsxAttribute(elem, "value", valueAttrExpr) and
+        jsxAttrValueObject(valueAttrExpr, objExpr) and
+        ObjectLiteralField(objExpr, _, _)
+    )
+}
+
+/**
+ * Holds if a Provider for context symbol `ctxSym` exposes field `fieldName`
+ * bound to a value expression that may-refs `valueSym`.
+ *
+ * Combines `contextProviderValueObject` with `ObjectLiteralField`. The
+ * shorthand form `{ setX }` is the load-bearing case — the walker emits
+ * the field with valueExpr pointing at the Identifier node and the
+ * Identifier emit-pass produces the ExprMayRef row we then look up.
+ */
+predicate contextProviderField(int ctxSym, string fieldName, int valueSym) {
+    exists(int objExpr, int valueExpr |
+        contextProviderValueObject(ctxSym, objExpr) and
+        ObjectLiteralField(objExpr, fieldName, valueExpr) and
+        ExprMayRef(valueExpr, valueSym)
+    )
+}
+
+/**
+ * Holds if `call` is a direct `useContext(ctxSym)` invocation, where the
+ * argument may-refs the given context symbol. `useContext` is recognised
+ * by the same import-name shape as `useState` and `createContext`.
+ */
+predicate useContextCall(int call, int ctxSym) {
+    exists(int useCtxSym, int argNode |
+        CallCalleeSym(call, useCtxSym) and
+        ImportBinding(useCtxSym, "react", "useContext") and
+        CallArg(call, 0, argNode) and
+        ExprMayRef(argNode, ctxSym)
+    )
+}
+
+/**
+ * Holds if `hookFn` is a function whose body has a return statement whose
+ * expression is a `useContext(ctxSym)` call. This is the "hook indirection"
+ * pattern:
+ *
+ *   function useViewerActions() {
+ *     return useContext(ViewerStateActions);
+ *   }
+ *
+ * Hand-unrolled to depth 2 (useContext directly, OR a hook returning a
+ * call to a hook returning useContext). Same planner-sizing rationale as
+ * `useStateSetterAlias`. Deeper chains (3+) are deferred follow-up.
+ */
+predicate hookIndirectionD1(int hookFn, int ctxSym) {
+    exists(int retExpr, int innerCall |
+        ReturnStmt(hookFn, _, retExpr) and
+        ExprIsCall(retExpr, innerCall) and
+        useContextCall(innerCall, ctxSym)
+    )
+}
+
+predicate hookIndirectionD2(int hookFn, int ctxSym) {
+    exists(int retExpr, int innerCall, int innerCalleeSym, int innerHookFn |
+        ReturnStmt(hookFn, _, retExpr) and
+        ExprIsCall(retExpr, innerCall) and
+        CallCalleeSym(innerCall, innerCalleeSym) and
+        FunctionSymbol(innerCalleeSym, innerHookFn) and
+        innerHookFn != hookFn and
+        hookIndirectionD1(innerHookFn, ctxSym)
+    )
+}
+
+predicate hookIndirection(int hookFn, int ctxSym) {
+    hookIndirectionD1(hookFn, ctxSym)
+    or
+    hookIndirectionD2(hookFn, ctxSym)
+}
+
+/**
+ * Holds if `call` is a call site that resolves (directly or via a hook
+ * indirection) to a useContext(ctxSym) value, i.e. its result symbol carries
+ * the Provider's value object for context `ctxSym`.
+ *
+ * Direct path: `useContext(ctx)` — `call` is the useContext call itself.
+ * Indirect path: `useFoo()` where `useFoo` is a `hookIndirection` for ctx.
+ */
+/**
+ * Holds if `localSym` (a callee binding seen at a call site) resolves —
+ * possibly across module boundaries via an import/export pair on the same
+ * exported name — to function symbol `targetFnSym`. v1 cross-module
+ * resolution: import-binding name matches an export-binding name, and the
+ * export-binding symbol is the target function's defining symbol.
+ *
+ * The module-spec path string from `ImportBinding` is NOT compared against
+ * the export-binding's file path (different shapes), so this is loosely
+ * over-approximated by name. Disambiguation is left to downstream filters
+ * (only callers using a specific imported name will match).
+ */
+predicate importedFunctionSymbol(int localSym, int targetFn) {
+    exists(string importedName, int exportSym |
+        ImportBinding(localSym, _, importedName) and
+        ExportBinding(importedName, exportSym, _) and
+        FunctionSymbol(exportSym, targetFn)
+    )
+}
+
+predicate useContextCallSiteResolvesContext(int call, int ctxSym) {
+    useContextCall(call, ctxSym)
+    or
+    exists(int hookSym, int hookFn |
+        CallCalleeSym(call, hookSym) and
+        FunctionSymbol(hookSym, hookFn) and
+        hookIndirection(hookFn, ctxSym)
+    )
+    or
+    exists(int hookSym, int hookFn |
+        CallCalleeSym(call, hookSym) and
+        importedFunctionSymbol(hookSym, hookFn) and
+        hookIndirection(hookFn, ctxSym)
+    )
+}
+
+/**
+ * Holds if `paramSym` is the symbol bound by destructuring the field
+ * `fieldName` from the result of a `useContextCallSiteResolvesContext`
+ * call for context `ctxSym`.
+ *
+ *   const { setZoom } = useViewerActions();
+ *   //      ^^^^^^^ paramSym; fieldName = "setZoom"
+ *
+ * Matches the shape:
+ *   VarDecl(varDecl, _, initExpr, _) where initExpr is (transitively via
+ *   non-null assertion / cast) a `useContextCallSiteResolvesContext` call,
+ *   and the destructure pattern is contained in the same VarDecl.
+ *
+ * Implementation note: we tolerate a single Cast hop on the initExpr to
+ * cover the common `useContext(...)!` non-null assertion shape.
+ */
+predicate contextDestructureBinding(int ctxSym, string fieldName, int paramSym) {
+    exists(int varDecl, int parent, int initExpr, int callExpr, int call |
+        VarDecl(varDecl, _, initExpr, _) and
+        Contains(varDecl, parent) and
+        DestructureField(parent, fieldName, _, paramSym, _) and
+        // initExpr resolves to a useContextCallSite call, possibly via a
+        // single non-null assertion / cast hop.
+        (
+            callExpr = initExpr
+            or
+            Cast(initExpr, callExpr)
+        ) and
+        ExprIsCall(callExpr, call) and
+        useContextCallSiteResolvesContext(call, ctxSym)
+    )
+}
+
+/**
+ * One-hop CONTEXT alias step: holds if `paramSym` is a destructured
+ * binding from a useContext call site for context `ctxSym`, AND a Provider
+ * for `ctxSym` exposes a field of that name bound to symbol `valueSym`.
+ *
+ * Mirrors `setterAliasStep` but for the context channel. `paramSym`
+ * therefore aliases `valueSym` for callers that invoke `paramSym(...)` in
+ * the consumer body.
+ *
+ * The field-name match between `contextDestructureBinding` and
+ * `contextProviderField` is what disambiguates which provided field the
+ * destructure is reading — even though a single Provider's value object
+ * may expose many fields, only the one matching the destructure binding
+ * name participates in this alias step.
+ */
+/**
+ * Links a Provider-side context symbol to a Consumer-side context symbol
+ * across the import/export boundary (or trivially, the same symbol when
+ * Provider and Consumer share a module). Cross-module link is by exported
+ * name match. v1 doesn't try to disambiguate module paths — same-name
+ * collisions are over-approximated.
+ */
+predicate contextSymLink(int providerCtxSym, int consumerCtxSym) {
+    providerCtxSym = consumerCtxSym
+    or
+    exists(string name |
+        ExportBinding(name, providerCtxSym, _) and
+        ImportBinding(consumerCtxSym, _, name)
+    )
+}
+
+predicate contextSetterAliasStep(int valueSym, int paramSym) {
+    exists(int providerCtxSym, int consumerCtxSym, string fieldName |
+        contextSym(providerCtxSym) and
+        contextProviderField(providerCtxSym, fieldName, valueSym) and
+        contextSymLink(providerCtxSym, consumerCtxSym) and
+        contextDestructureBinding(consumerCtxSym, fieldName, paramSym)
+    )
+}
+
+/**
+ * Extension of `useStateSetterAlias` to ALSO follow the context-provided
+ * setter chain. Adds disjuncts of the form
+ *   "useStateSetterSym(s0) and contextSetterAliasStep(s0, sym)"
+ * up to depth 3, mirroring the JSX-prop-alias unrolling. Mixed chains
+ * (prop hop then context hop, or context then prop) are also covered up
+ * to combined depth 3.
+ *
+ * Why hand-unrolled: identical planner-sizing rationale as the round-1
+ * `useStateSetterAlias`. The base relation set is finite (createContext
+ * call results, Provider JSX elements, useContext / hook calls) so each
+ * step is a finite extent.
+ *
+ * Note: the round-1 `useStateSetterAlias` predicate is REPLACED rather
+ * than wrapped — this avoids defining two predicates with the same name
+ * and keeps a single point-of-truth for the alias closure.
+ */
+predicate setterAliasStepAny(int valueSym, int paramSym) {
+    setterAliasStep(valueSym, paramSym)
+    or
+    contextSetterAliasStep(valueSym, paramSym)
+}
+
+/**
+ * Round-2 alias closure. SUPERSEDES the round-1 `useStateSetterAlias`
+ * disjunction body; round-1's predicate is preserved above for source
+ * compatibility but new code should reference this one.
+ *
+ * Hand-unrolled to depth 3 over `setterAliasStepAny`, which mixes JSX prop
+ * hops and Context hops freely.
+ */
+predicate useStateSetterAliasV2(int sym) {
+    useStateSetterSym(sym)
+    or
+    exists(int s0 |
+        useStateSetterSym(s0) and
+        setterAliasStepAny(s0, sym)
+    )
+    or
+    exists(int s0, int s1 |
+        useStateSetterSym(s0) and
+        setterAliasStepAny(s0, s1) and
+        setterAliasStepAny(s1, sym)
+    )
+    or
+    exists(int s0, int s1, int s2 |
+        useStateSetterSym(s0) and
+        setterAliasStepAny(s0, s1) and
+        setterAliasStepAny(s1, s2) and
+        setterAliasStepAny(s2, sym)
+    )
+}
+
+/**
+ * V2 sibling of `useStateSetterAliasCall`. Recognises calls whose callee
+ * symbol may-refs ANY useStateSetterAliasV2 symbol — i.e. a direct
+ * useState setter, a JSX-prop-aliased parameter, OR a context-aliased
+ * destructure binding.
+ */
+predicate useStateSetterAliasCallV2(int call) {
+    exists(int sym |
+        CallCalleeSym(call, sym) and
+        useStateSetterAliasV2(sym)
+    )
+}
+
+/**
+ * Holds if `sym` is a context-aliased setter binding — i.e. a paramSym
+ * produced by `contextSetterAliasStep` for some chain rooted at a
+ * useStateSetterSym. This is the "at least one context hop" filter used
+ * to keep the through-context query diagnostically distinct from the
+ * direct-form and through-props queries. Hand-unrolled to depth 3 to
+ * mirror the alias closure.
+ */
+predicate isContextAliasedSetterSym(int sym) {
+    exists(int s0 |
+        useStateSetterSym(s0) and
+        contextSetterAliasStep(s0, sym)
+    )
+    or
+    exists(int s0, int s1 |
+        useStateSetterSym(s0) and
+        setterAliasStepAny(s0, s1) and
+        contextSetterAliasStep(s1, sym)
+    )
+    or
+    exists(int s0, int s1 |
+        useStateSetterSym(s0) and
+        contextSetterAliasStep(s0, s1) and
+        setterAliasStepAny(s1, sym)
+    )
+    or
+    exists(int s0, int s1, int s2 |
+        useStateSetterSym(s0) and
+        setterAliasStepAny(s0, s1) and
+        contextSetterAliasStep(s1, s2) and
+        setterAliasStepAny(s2, sym)
+    )
+}
+
+/**
+ * Holds if `call` is a setter-alias call AND its callee chain involves at
+ * least one Context hop. Filters out direct + pure-prop alias matches so
+ * the through-context query reports only matches that are diagnostically
+ * about the context channel.
+ */
+predicate useStateSetterContextAliasCall(int call) {
+    exists(int sym |
+        CallCalleeSym(call, sym) and
+        isContextAliasedSetterSym(sym)
+    )
+}
+
+/**
+ * Sibling of `setStateUpdaterCallsOtherSetStateThroughProps` that requires
+ * at least ONE side of the outer/inner setter pair to be reached through
+ * React Context aliasing. The other side may be a direct setter, a
+ * prop-aliased setter, or another context-aliased setter. Covers the
+ * canonical motivating shape:
+ *
+ *   function ZoomButton() {
+ *     const { setZoom, setPan } = useViewerActions();
+ *     setZoom(prev => { setPan(p => ...); return ...; });
+ *   }
+ *
+ * The "at least one context hop" filter (`useStateSetterContextAliasCall`)
+ * keeps this query diagnostically distinct from the direct-form and the
+ * through-props queries — a pure direct-form match would not surface here
+ * even though the underlying `useStateSetterAliasV2` closure is a strict
+ * superset.
+ *
+ * `line` is the start line of the OUTER call's callee identifier.
+ */
+predicate setStateUpdaterCallsOtherSetStateThroughContext_outerCtx(int call, int line) {
+    useStateSetterAliasCallV2(call) and
+    useStateSetterContextAliasCall(call) and
+    exists(int innerCall, int argFn, int callee, int outerSym, int innerSym |
+        useStateSetterAliasCallV2(innerCall) and
+        CallArg(call, 0, argFn) and
+        Function(argFn, _, _, _, _, _) and
+        functionContainsStar(argFn, innerCall) and
+        Call(innerCall, _, _) and
+        Call(call, callee, _) and
+        Node(callee, _, _, line, _, _, _) and
+        CallCalleeSym(call, outerSym) and
+        CallCalleeSym(innerCall, innerSym) and
+        outerSym != innerSym
+    )
+}
+
+predicate setStateUpdaterCallsOtherSetStateThroughContext_innerCtx(int call, int line) {
+    useStateSetterAliasCallV2(call) and
+    exists(int innerCall, int argFn, int callee, int outerSym, int innerSym |
+        useStateSetterAliasCallV2(innerCall) and
+        useStateSetterContextAliasCall(innerCall) and
+        CallArg(call, 0, argFn) and
+        Function(argFn, _, _, _, _, _) and
+        functionContainsStar(argFn, innerCall) and
+        Call(innerCall, _, _) and
+        Call(call, callee, _) and
+        Node(callee, _, _, line, _, _, _) and
+        CallCalleeSym(call, outerSym) and
+        CallCalleeSym(innerCall, innerSym) and
+        outerSym != innerSym
+    )
+}
+
+predicate setStateUpdaterCallsOtherSetStateThroughContext(int call, int line) {
+    setStateUpdaterCallsOtherSetStateThroughContext_outerCtx(call, line)
+    or
+    setStateUpdaterCallsOtherSetStateThroughContext_innerCtx(call, line)
+}
+
 /**
  * A React XSS sink via dangerouslySetInnerHTML. These are TaintSink facts
  * with kind "xss" derived from JsxAttribute facts matching the attribute

--- a/extract/schema/relations.go
+++ b/extract/schema/relations.go
@@ -155,6 +155,21 @@ func init() {
 		{Name: "sym", Type: TypeEntityRef},
 		{Name: "libName", Type: TypeString},
 	}})
+	// Object literals
+	// ObjectLiteralField: a field in an object literal expression.
+	// For shorthand `{ foo }` the fieldName equals the binding name and
+	// valueExpr is the Identifier node (which in turn has an ExprMayRef row).
+	// For `{ foo: expr }` the fieldName is the source key and valueExpr is
+	// the value-position expression.
+	// Used by the React context-alias tracking in `bridge/tsq_react.qll` to
+	// look up which symbol a Provider's value object exposes under a given
+	// field name. v1 limitations: spread elements (`{ ...rest }`) and
+	// computed-key properties are skipped silently.
+	RegisterRelation(RelationDef{Name: "ObjectLiteralField", Version: 1, Columns: []ColumnDef{
+		{Name: "parent", Type: TypeEntityRef},
+		{Name: "fieldName", Type: TypeString},
+		{Name: "valueExpr", Type: TypeEntityRef},
+	}})
 	// JSX
 	RegisterRelation(RelationDef{Name: "JsxElement", Version: 1, Columns: []ColumnDef{
 		{Name: "id", Type: TypeEntityRef},

--- a/extract/schema/relations_test.go
+++ b/extract/schema/relations_test.go
@@ -14,6 +14,7 @@ func TestAllRelationsRegistered(t *testing.T) {
 		"ExprMayRef", "ExprIsCall", "FieldRead", "FieldWrite", "Await", "Cast",
 		"DestructureField", "ArrayDestructure", "DestructureRest",
 		"ImportBinding", "ExportBinding", "TypeFromLib",
+		"ObjectLiteralField",
 		"JsxElement", "JsxAttribute",
 		// v2 type-aware relations
 		"ClassDecl", "InterfaceDecl", "Implements", "Extends",
@@ -49,8 +50,8 @@ func TestAllRelationsRegistered(t *testing.T) {
 }
 
 func TestRelationCount(t *testing.T) {
-	if len(Registry) != 93 {
-		t.Fatalf("expected 93 relations in registry, got %d", len(Registry))
+	if len(Registry) != 94 {
+		t.Fatalf("expected 94 relations in registry, got %d", len(Registry))
 	}
 }
 

--- a/extract/walker.go
+++ b/extract/walker.go
@@ -160,6 +160,8 @@ func (fw *FactWalker) enterNode(node ASTNode) (bool, error) {
 		fw.emitCast(node, id)
 	case "ObjectPattern":
 		fw.emitDestructureObject(node, id)
+	case "Object":
+		fw.emitObjectLiteral(node, id)
 	case "ArrayPattern":
 		fw.emitDestructureArray(node, id)
 	case "ImportDeclaration":
@@ -562,6 +564,68 @@ func (fw *FactWalker) emitCast(node ASTNode, id uint32) {
 		innerID = fw.nid(innerNode)
 	}
 	fw.emit("Cast", id, innerID)
+}
+
+// ---- Object Literals ----
+
+// emitObjectLiteral emits an ObjectLiteralField row for each named field of an
+// object expression `{ a, b: expr, c }`. Spread elements (`...rest`) and
+// computed-key properties are skipped silently — v1 limitations documented in
+// the schema. The valueExpr column points at the value-position node:
+//   - shorthand `{ foo }`        → valueExpr is the Identifier `foo`
+//   - pair       `{ foo: expr }` → valueExpr is `expr`
+//
+// This is consumed by the React context-alias tracking in
+// `bridge/tsq_react.qll` to look up which symbol a Provider value object
+// exposes under a given field name. See round-2 of the setState-alias work.
+func (fw *FactWalker) emitObjectLiteral(node ASTNode, id uint32) {
+	count := node.ChildCount()
+	for i := 0; i < count; i++ {
+		child := node.Child(i)
+		if child == nil {
+			continue
+		}
+		switch child.Kind() {
+		case ",", "{", "}":
+			continue
+		case "ShorthandPropertyIdentifier":
+			// `{ foo }` — value is the identifier itself. The visitor
+			// dispatches `case "Identifier"` to emit ExprMayRef, but
+			// tree-sitter classifies the shorthand-property identifier as
+			// `ShorthandPropertyIdentifier` (NOT `Identifier`), so the
+			// visitor never emits the expected ExprMayRef row. Emit it
+			// explicitly here so downstream context-alias predicates can
+			// resolve the shorthand binding back to its declaration.
+			name := child.Text()
+			valID := fw.nid(child)
+			fw.emit("ObjectLiteralField", id, name, valID)
+			if decl, ok := fw.scope.Resolve(name, child); ok {
+				symID := SymID(decl.FilePath, decl.Name, decl.StartLine, decl.StartCol)
+				fw.emit("ExprMayRef", valID, symID)
+			}
+		case "Pair":
+			keyNode := childByField(child, "key")
+			valNode := childByField(child, "value")
+			if keyNode == nil || valNode == nil {
+				continue
+			}
+			// Skip computed keys and string/numeric literal keys — only
+			// PropertyIdentifier keys produce a stable named field.
+			if keyNode.Kind() != "PropertyIdentifier" && keyNode.Kind() != "Identifier" {
+				continue
+			}
+			name := keyNode.Text()
+			valID := fw.nid(valNode)
+			fw.emit("ObjectLiteralField", id, name, valID)
+		case "MethodDefinition":
+			// `{ foo() { ... } }` — method shorthand. Skip for v1; not
+			// load-bearing for context-alias tracking.
+			continue
+		case "SpreadElement":
+			// `{ ...rest }` — skipped for v1.
+			continue
+		}
+	}
 }
 
 // ---- Destructuring ----

--- a/setstate_context_alias_integration_test.go
+++ b/setstate_context_alias_integration_test.go
@@ -1,0 +1,242 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gjdoalfnrxu/tsq/bridge"
+	extractrules "github.com/Gjdoalfnrxu/tsq/extract/rules"
+	"github.com/Gjdoalfnrxu/tsq/extract/schema"
+	"github.com/Gjdoalfnrxu/tsq/ql/desugar"
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+	"github.com/Gjdoalfnrxu/tsq/ql/parse"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+	"github.com/Gjdoalfnrxu/tsq/ql/resolve"
+)
+
+// TestSetStateUpdaterCallsOtherSetStateThroughContext_Positive is the positive
+// regression test for the React-Context variant of the setStateUpdater rule.
+//
+// Fixture: testdata/projects/react-usestate-context-alias/ contains
+//
+//	Provider.tsx  — createContext(...) + <Ctx.Provider value={{ setZoom, setPan }}>
+//	Hook.tsx      — useViewerActions() { return useContext(Ctx); }
+//	Consumer.tsx  — const { setZoom, setPan } = useViewerActions()!;
+//	                setZoom(prev => { setPan(...); return ...; });
+//	Negative.tsx  — plain useState (direct form only; must NOT be matched
+//	                by the context predicate).
+//
+// The bridge predicate `setStateUpdaterCallsOtherSetStateThroughContext`
+// should match the outer `setZoom(...)` call in Consumer.tsx.
+func TestSetStateUpdaterCallsOtherSetStateThroughContext_Positive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping extraction-heavy integration test in short mode")
+	}
+
+	factDB := extractProject(t, "testdata/projects/react-usestate-context-alias")
+
+	src, err := os.ReadFile("testdata/queries/v2/find_setstate_updater_calls_other_setstate_through_context.ql")
+	if err != nil {
+		t.Fatalf("read query: %v", err)
+	}
+
+	bridgeFiles := bridge.LoadBridge()
+	importLoader := makeBridgeImportLoader(bridgeFiles)
+
+	p := parse.NewParser(string(src), "find_setstate_updater_calls_other_setstate_through_context.ql")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	resolved, err := resolve.Resolve(mod, importLoader)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(resolved.Errors) > 0 {
+		t.Fatalf("resolve errors: %v", resolved.Errors)
+	}
+	prog, dsErrors := desugar.Desugar(resolved)
+	if len(dsErrors) > 0 {
+		t.Fatalf("desugar: %v", dsErrors)
+	}
+	prog = extractrules.MergeSystemRules(prog, extractrules.AllSystemRules())
+
+	hints := make(map[string]int, len(schema.Registry))
+	for _, def := range schema.Registry {
+		hints[def.Name] = factDB.Relation(def.Name).Tuples()
+	}
+
+	const cap = 200_000
+
+	baseRels, err := eval.LoadBaseRelations(factDB)
+	if err != nil {
+		t.Fatalf("load base relations: %v", err)
+	}
+	execPlan, planErrs := plan.EstimateAndPlan(
+		prog,
+		hints,
+		cap,
+		eval.MakeEstimatorHook(baseRels),
+		plan.Plan,
+	)
+	if len(planErrs) > 0 {
+		t.Fatalf("plan: %v", planErrs)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rs, err := eval.Evaluate(
+		ctx,
+		execPlan,
+		baseRels,
+		eval.WithMaxBindingsPerRule(cap),
+		eval.WithSizeHints(hints),
+	)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+
+	// Diagnostic: print ObjectLiteralField rows so a failure leaves a
+	// breadcrumb about whether the schema-side plumbing is the problem.
+	if olf := factDB.Relation("ObjectLiteralField"); olf != nil {
+		t.Logf("ObjectLiteralField tuples=%d", olf.Tuples())
+	}
+
+	if len(rs.Rows) == 0 {
+		t.Fatalf("expected at least one context-alias setStateUpdater match on the fixture, got 0 rows. Bridge predicate is not seeing the context chain. ObjectLiteralField tuples=%d",
+			factDB.Relation("ObjectLiteralField").Tuples())
+	}
+
+	// Positive: at least one match should be in Consumer.tsx. Negatives live in
+	// Negative.tsx (direct-form matches there must NOT surface via this query).
+	var consumerHits, negativeHits int
+	for _, row := range rs.Rows {
+		for _, cell := range row {
+			s := fmt.Sprintf("%v", cell)
+			if strings.Contains(s, "Consumer.tsx") {
+				consumerHits++
+				break
+			}
+			if strings.Contains(s, "Negative.tsx") {
+				negativeHits++
+				break
+			}
+		}
+	}
+	if consumerHits == 0 {
+		t.Fatalf("expected Consumer.tsx in result rows, got: %v", rs.Rows)
+	}
+	if negativeHits > 0 {
+		t.Fatalf("context predicate matched Negative.tsx (direct-only pattern); false-positive count=%d rows=%v", negativeHits, rs.Rows)
+	}
+	t.Logf("setStateUpdaterCallsOtherSetStateThroughContext matched %d rows (Consumer.tsx hits=%d, Negative.tsx hits=%d)",
+		len(rs.Rows), consumerHits, negativeHits)
+}
+
+// TestContextChain_LinkPredicates exercises each link of the context chain
+// individually so end-to-end test failures localise quickly: if the positive
+// test fails, run this and look for the first zero-row link.
+func TestContextChain_LinkPredicates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping extraction-heavy debug test in short mode")
+	}
+	factDB := extractProject(t, "testdata/projects/react-usestate-context-alias")
+
+	bridgeFiles := bridge.LoadBridge()
+	importLoader := makeBridgeImportLoader(bridgeFiles)
+
+	common := "import tsq::react\nimport tsq::base\nimport tsq::expressions\nimport tsq::functions\nimport tsq::calls\n"
+
+	queries := []struct {
+		name      string
+		src       string
+		mustHaveN int // 0 = just report count, no assertion
+	}{
+		{"contextSym", common + "from int s where contextSym(s) select s", 1},
+		{"contextProviderValueObject", common + "from int s, int o where contextProviderValueObject(s, o) select s, o", 1},
+		{"contextProviderField", common + "from int s, string f, int v where contextProviderField(s, f, v) select s, f, v", 2},
+		{"useContextCall", common + "from int c, int s where useContextCall(c, s) select c, s", 1},
+		{"hookIndirection", common + "from int fn, int s where hookIndirection(fn, s) select fn, s", 1},
+		{"useContextCallSiteResolvesContext", common + "from int c, int s where useContextCallSiteResolvesContext(c, s) select c, s", 2},
+		{"contextDestructureBinding", common + "from int s, string f, int p where contextDestructureBinding(s, f, p) select s, f, p", 2},
+		{"contextSetterAliasStep", common + "from int v, int p where contextSetterAliasStep(v, p) select v, p", 2},
+		{"useStateSetterAliasV2", common + "from int s where useStateSetterAliasV2(s) select s", 6},
+		{"useStateSetterContextAliasCall", common + "from int c where useStateSetterContextAliasCall(c) select c", 2},
+	}
+	hints := make(map[string]int, len(schema.Registry))
+	for _, def := range schema.Registry {
+		hints[def.Name] = factDB.Relation(def.Name).Tuples()
+	}
+	const cap = 200_000
+	baseRels, err := eval.LoadBaseRelations(factDB)
+	if err != nil {
+		t.Fatalf("load base relations: %v", err)
+	}
+	for _, q := range queries {
+		p := parse.NewParser(q.src, q.name+".ql")
+		mod, err := p.Parse()
+		if err != nil {
+			t.Errorf("[%s] parse err: %v", q.name, err)
+			continue
+		}
+		resolved, err := resolve.Resolve(mod, importLoader)
+		if err != nil {
+			t.Errorf("[%s] resolve err: %v", q.name, err)
+			continue
+		}
+		if len(resolved.Errors) > 0 {
+			t.Errorf("[%s] resolve errors: %v", q.name, resolved.Errors)
+			continue
+		}
+		prog, dsErrors := desugar.Desugar(resolved)
+		if len(dsErrors) > 0 {
+			t.Errorf("[%s] desugar errors: %v", q.name, dsErrors)
+			continue
+		}
+		prog = extractrules.MergeSystemRules(prog, extractrules.AllSystemRules())
+		execPlan, planErrs := plan.EstimateAndPlan(prog, hints, cap, eval.MakeEstimatorHook(baseRels), plan.Plan)
+		if len(planErrs) > 0 {
+			t.Errorf("[%s] plan err: %v", q.name, planErrs)
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		rs, err := eval.Evaluate(ctx, execPlan, baseRels, eval.WithMaxBindingsPerRule(cap), eval.WithSizeHints(hints))
+		cancel()
+		if err != nil {
+			t.Errorf("[%s] eval err: %v", q.name, err)
+			continue
+		}
+		t.Logf("link %-40s rows=%d", q.name, len(rs.Rows))
+		if q.mustHaveN > 0 && len(rs.Rows) != q.mustHaveN {
+			t.Errorf("[%s] expected %d rows, got %d (rows=%v)", q.name, q.mustHaveN, len(rs.Rows), rs.Rows)
+		}
+	}
+}
+
+// ObjectLiteralField rows for `value={{ setZoom, setPan }}` — the new
+// schema plumbing introduced for the context-alias round-2. If this fails,
+// the bridge predicate has zero chance of firing.
+func TestObjectLiteralField_Extraction(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping extraction-heavy integration test in short mode")
+	}
+	factDB := extractProject(t, "testdata/projects/react-usestate-context-alias")
+	olf := factDB.Relation("ObjectLiteralField")
+	if olf == nil {
+		t.Fatalf("ObjectLiteralField relation not registered")
+	}
+	if olf.Tuples() == 0 {
+		t.Fatalf("expected ObjectLiteralField tuples for the Provider's value={{ setZoom, setPan }} object literal, got 0")
+	}
+	// The Provider's value={{ setZoom, setPan }} contributes 2 tuples; total
+	// across the fixture is stable but we only assert the floor.
+	if olf.Tuples() < 2 {
+		t.Fatalf("expected at least 2 ObjectLiteralField tuples (setZoom + setPan shorthand fields), got %d", olf.Tuples())
+	}
+	t.Logf("ObjectLiteralField tuples=%d (>=2 expected)", olf.Tuples())
+}

--- a/stdlib_coverage_test.go
+++ b/stdlib_coverage_test.go
@@ -59,6 +59,7 @@ var stdlibCoverageAllowlist = map[string]string{
 	"DestructureField":    "destructuring; coverage_probe.ql added",
 	"ArrayDestructure":    "array destructuring; coverage_probe.ql added",
 	"DestructureRest":     "destructure rest; coverage_probe.ql added",
+	"ObjectLiteralField":  "object literal field; covered by react context-alias integration test (round-2)",
 	"JsxElement":          "JSX; coverage_probe.ql added",
 	"JsxAttribute":        "JSX attribute; coverage_probe.ql added",
 	"ImportBinding":       "import binding; coverage_probe.ql added",

--- a/testdata/projects/react-usestate-context-alias/Consumer.tsx
+++ b/testdata/projects/react-usestate-context-alias/Consumer.tsx
@@ -1,0 +1,25 @@
+import { useViewerActions } from './Hook';
+
+// The motivating positive case: outer setter (`setZoom`) is reached through
+// the context-alias closure, AND its updater body invokes a DIFFERENT
+// context-alias setter (`setPan`). The bridge predicate
+// `setStateUpdaterCallsOtherSetStateThroughContext` should match the outer
+// `setZoom(...)` call.
+export function ZoomButton() {
+  const { setZoom, setPan } = useViewerActions()!;
+  return (
+    <button
+      onClick={() => {
+        setZoom(prev => {
+          // Inner setter: `setPan` arrived through the same context hop.
+          // Both outer and inner are context-aliased setters with different
+          // callee symbols.
+          setPan(p => ({ ...p, pan: p.pan + 1 }));
+          return { ...prev, zoom: prev.zoom + 1 };
+        });
+      }}
+    >
+      Zoom + Pan
+    </button>
+  );
+}

--- a/testdata/projects/react-usestate-context-alias/Hook.tsx
+++ b/testdata/projects/react-usestate-context-alias/Hook.tsx
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { ViewerStateActions } from './Provider';
+
+// Hook indirection: a function whose body returns useContext(ContextSym).
+// Round-2 should recognise calls to `useViewerActions()` as resolving to the
+// same value that useContext(ViewerStateActions) resolves to — which is the
+// Provider's `value={{ setZoom, setPan }}` object.
+export function useViewerActions() {
+  return useContext(ViewerStateActions);
+}

--- a/testdata/projects/react-usestate-context-alias/Negative.tsx
+++ b/testdata/projects/react-usestate-context-alias/Negative.tsx
@@ -1,0 +1,31 @@
+// Negative cases: setters that are NOT context-aliased should not match the
+// context-through predicate. (They may still match the direct-form predicate
+// — that's by design and out of scope for this fixture's negative coverage.)
+
+import { useState } from 'react';
+
+// 1) Plain useState updater that calls another plain useState setter — the
+// DIRECT form would catch this; the context predicate must NOT.
+export function Plain() {
+  const [a, setA] = useState(0);
+  const [b, setB] = useState(0);
+  return (
+    <button
+      onClick={() => {
+        setA(prev => {
+          setB(b + 1);
+          return prev + 1;
+        });
+      }}
+    >
+      {a + b}
+    </button>
+  );
+}
+
+// 2) An identifier called `setX` that has nothing to do with useState or
+// useContext — purely a local function. Must not be flagged.
+export function Bare() {
+  const setNothing = (n: number) => n + 1;
+  return <button onClick={() => setNothing(1)}>noop</button>;
+}

--- a/testdata/projects/react-usestate-context-alias/Provider.tsx
+++ b/testdata/projects/react-usestate-context-alias/Provider.tsx
@@ -1,0 +1,34 @@
+import { useState, createContext, ReactNode } from 'react';
+
+interface ZoomConfig {
+  zoom: number;
+  pan: number;
+}
+
+interface ViewerActions {
+  setZoom: (updater: (prev: ZoomConfig) => ZoomConfig) => void;
+  setPan: (updater: (prev: ZoomConfig) => ZoomConfig) => void;
+}
+
+// The context symbol — `ViewerStateActions` is the VarDecl bound to the
+// createContext call result. Its `.Provider` JSX surface is the
+// "context provider" pattern the round-2 alias closure needs to recognise.
+export const ViewerStateActions = createContext<ViewerActions | null>(null);
+
+// Provider component holds the useState pair locally and exposes the setter
+// through the Context Provider's `value` prop using a shorthand object literal.
+// Both setZoom and setPan are useState setters by the round-1 base case — the
+// new round-2 hop is "make these also useStateSetterAlias when reached through
+// useContext + destructure".
+export function ViewerProvider({ children }: { children: ReactNode }) {
+  const [zoom, setZoom] = useState<ZoomConfig>({ zoom: 1, pan: 0 });
+  const [pan, setPan] = useState<ZoomConfig>({ zoom: 1, pan: 0 });
+  // suppress unused-var noise from the type-side
+  void zoom;
+  void pan;
+  return (
+    <ViewerStateActions.Provider value={{ setZoom, setPan }}>
+      {children}
+    </ViewerStateActions.Provider>
+  );
+}

--- a/testdata/queries/v2/find_setstate_updater_calls_other_setstate_through_context.ql
+++ b/testdata/queries/v2/find_setstate_updater_calls_other_setstate_through_context.ql
@@ -1,0 +1,34 @@
+/**
+ * @name useState setter call (with context-alias) whose updater calls another setter (with path)
+ * @description Round-2 sibling of find_setstate_updater_calls_other_setstate_through_props.ql.
+ *              Recognises setState calls reached through React Context — i.e. setters
+ *              passed via `<Ctx.Provider value={{ setX }}>` and read back via
+ *              `useContext(Ctx)` (directly or through a wrapping hook) and a
+ *              destructure binding. Either side of the updater pair (outer or
+ *              inner) may be reached through context aliasing OR JSX-prop aliasing
+ *              (round-1).
+ *
+ *              Limitations: namespace-import createContext (`React.createContext`)
+ *              is out of scope; multi-Provider disambiguation is over-approximate
+ *              (any Provider for the context is fused with any useContext); hook
+ *              indirection is depth-limited to 2.
+ * @kind problem
+ * @id js/tsq/setstate-updater-calls-other-setstate-through-context
+ */
+
+import tsq::react
+import tsq::calls
+import tsq::variables
+import tsq::functions
+import tsq::expressions
+import tsq::jsx
+import tsq::symbols
+import tsq::imports
+import tsq::base
+
+from Call c, int line
+where setStateUpdaterCallsOtherSetStateThroughContext(c, line)
+select
+  c.getCalleeNode().getFile().getPath() as "path",
+  line as "line",
+  c as "call"


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Summary

Round-2 of the React `useState`-setter alias closure: extends the round-1 JSX-prop-hop predicate (PR #164) to also follow setters provided through React Context. Recognises the canonical pattern below and matches the outer `setX(prev => { setY(...) })` call regardless of whether either side arrived through props or context.

```tsx
const Ctx = createContext(...);
function Provider() {
  const [_, setX] = useState(...);
  return <Ctx.Provider value={{ setX }}>{children}</Ctx.Provider>;
}
function useActions() { return useContext(Ctx); }
function Consumer() {
  const { setX } = useActions()!;
  setX(prev => { ... });
}
```

## Scope

- New schema relation `ObjectLiteralField(parent, fieldName, valueExpr)` populated by the walker for shorthand `{ foo }` and `{ key: expr }` properties (spread + computed keys deferred).
- Walker also explicitly emits `ExprMayRef` for the shorthand property identifier — tree-sitter classifies it as `ShorthandPropertyIdentifier` (not `Identifier`), so the Identifier-pass would otherwise skip it.
- Bridge predicates in `bridge/tsq_react.qll`: `contextSym`, `contextProviderValueObject`, `contextProviderField`, `useContextCall`, `hookIndirection` (depth 2, split into `D1`/`D2` predicates and union'd at top level), `useContextCallSiteResolvesContext`, `importedFunctionSymbol` + `contextSymLink` (cross-module name bridge), `contextDestructureBinding` (tolerates a single `Cast`/non-null hop), `contextSetterAliasStep`, `useStateSetterAliasV2` (depth-3, mixes prop and context steps freely), `isContextAliasedSetterSym`, `useStateSetterContextAliasCall`, `setStateUpdaterCallsOtherSetStateThroughContext` (split into `_outerCtx`/`_innerCtx` halves and union'd at top level).
- New query `testdata/queries/v2/find_setstate_updater_calls_other_setstate_through_context.ql`.
- Fixture `testdata/projects/react-usestate-context-alias/{Provider,Hook,Consumer,Negative}.tsx`.
- Three integration tests:
  - `TestSetStateUpdaterCallsOtherSetStateThroughContext_Positive` — Consumer.tsx must match, Negative.tsx must NOT.
  - `TestContextChain_LinkPredicates` — per-link tuple-count assertions for fast localisation.
  - `TestObjectLiteralField_Extraction` — schema-side smoke.

## Why several predicates are split into ``_D1` / `_D2`` or ``_outerCtx` / `_innerCtx``

When a single predicate body has the form ``A or exists(...heavy chain...)``, the planner has been observed to drop matches from the cheap disjunct in the presence of the expensive one (same family of issues addressed by the recent disj_2 patches). Splitting each disjunct into its own named predicate and union'ing at the top level avoids the interaction. This is intentional — please don't collapse them back without a planner-side fix.

## Why depth-3 (round-1) is preserved here

`useStateSetterAliasV2` keeps the round-1 hand-unrolled depth-3 closure shape over a wider step relation `setterAliasStepAny`, which mixes prop and context hops freely. Same planner-sizing rationale as round-1 — recursive IDBs are sized at the default 1000-tuple hint pre-evaluation and trivial-IDB pre-pass cannot size them, so unbounded recursion can produce Cartesian-heavy plans on real corpora.

## v1 deferrals (intentional, documented in code)

- Namespace-import `createContext` / `useContext` (`React.createContext`, `React.useContext`).
- Multi-Provider disambiguation — any Provider for a context is fused with any `useContext` for it.
- `hookIndirection` capped at depth 2.
- `setterAliasStepAny` capped at depth 3 (matches round-1).
- Cross-module symbol bridge is name-only — same-name collisions over-approximated; module-spec path matching deferred.
- `value={makeActions()}` (helper call) is out of scope; only direct object-literal values resolve.

## Test plan

- [x] `go test -count=1 -run TestSetStateUpdaterCallsOtherSetStateThroughContext_Positive ./...` (cain-nas)
- [x] `go test -count=1 -run TestContextChain_LinkPredicates ./...` (cain-nas)
- [x] `go test -count=1 -run TestObjectLiteralField_Extraction ./...` (cain-nas)
- [x] Round-1 regression: `go test -count=1 -run TestSetStateUpdaterCallsOtherSetStateThroughProps_PropAlias ./...` (cain-nas)
- [x] `go test -count=1 -short ./...` (cain-nas) — all packages green
- [ ] Adversarial review subagent (in worktree) — pending
- [ ] CI green