### PR TITLE
fix(plan): arity-keyed magic-set propagation guards (disj2-round5)

### DIFF
--- a/ql/plan/disj2_round5_arity_collision_call_site_test.go
+++ b/ql/plan/disj2_round5_arity_collision_call_site_test.go
@@ -1,0 +1,229 @@
+// Disj2-round5 regression: arity-keyed call-site match in
+// buildDemandSeedsForPred.
+//
+// Scenario (Mastodon `setStateUpdaterCallsOtherSetStateThroughContext`):
+// the desugarer (PR #146) auto-emits arity-1 class-extent helpers like
+// `VarDecl(this) :- VarDecl(this, _, _, _).` for parameters typed with
+// `@vardecl`. The arity-1 IDB head shadows the underlying arity-4 base
+// relation by name. When backward demand inference records
+// `demand[VarDecl] = [0]`, `buildDemandSeedsForPred` walks rule bodies
+// looking for call sites of "VarDecl" — and (pre-fix) name-matches the
+// arity-4 base usages too. For an arity-4 atom like
+// `VarDecl(_, sym, srcExpr, _)`, position 0 is a wildcard, so the seed
+// becomes `magic_VarDecl(_) :- ...` — `isSafe` lets the wildcard through
+// (its `_`-exemption) but `validate.ValidateRule` rejects it as an unbound
+// head var. The whole magic-set program then falls back to plain Plan,
+// removing all demand pruning and exposing every IDB in the program to
+// full-base evaluation.
+//
+// This test reproduces the unsafe-seed emission at the unit level and
+// verifies the round-5 fix (arity-keyed call-site match + wildcard-at-
+// demanded-position guard) suppresses it without regressing the
+// legitimate arity-1 call-site case.
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// progArityCollidingHelper models the disj2-round5 shape: an arity-1
+// class-extent helper IDB ("VarDecl/1") shadowing an arity-4 base
+// relation of the same name, with backward demand on the arity-1 IDB
+// being constructable from grounding callers.
+//
+//	VarDecl(this) :- VarDecl(this, _, _, _).            // arity-1 helper
+//	UseVarDeclArity1(x) :- VarDecl(x).                  // pure call site of arity-1 IDB
+//	UseVarDeclArity4(s) :- VarDecl(_, s, _, _).         // arity-4 base usage (NOT a call site of /1)
+func progArityCollidingHelper() *datalog.Program {
+	return &datalog.Program{
+		Rules: []datalog.Rule{
+			// Arity-1 class-extent helper.
+			{
+				Head: datalog.Atom{Predicate: "VarDecl", Args: []datalog.Term{datalog.Var{Name: "this"}}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "VarDecl", Args: []datalog.Term{
+						datalog.Var{Name: "this"},
+						datalog.Var{Name: "_"},
+						datalog.Var{Name: "_"},
+						datalog.Var{Name: "_"},
+					}}},
+				},
+			},
+			// Genuine call site of VarDecl/1 (not of the base relation).
+			{
+				Head: datalog.Atom{Predicate: "UseVarDeclArity1", Args: []datalog.Term{datalog.Var{Name: "x"}}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "VarDecl", Args: []datalog.Term{datalog.Var{Name: "x"}}}},
+				},
+			},
+			// Arity-4 base usage with wildcard at position 0. The
+			// pre-fix matcher mistakes this for a call site of
+			// VarDecl/1 and emits `magic_VarDecl(_) :- ...`.
+			{
+				Head: datalog.Atom{Predicate: "UseVarDeclArity4", Args: []datalog.Term{datalog.Var{Name: "s"}}},
+				Body: []datalog.Literal{
+					{Positive: true, Atom: datalog.Atom{Predicate: "VarDecl", Args: []datalog.Term{
+						datalog.Var{Name: "_"},
+						datalog.Var{Name: "s"},
+						datalog.Var{Name: "_"},
+						datalog.Var{Name: "_"},
+					}}},
+				},
+			},
+		},
+	}
+}
+
+// TestBuildDemandSeedsForPred_ArityKeyedCallSite_NoUnsafeSeed asserts
+// that a demand on the arity-1 IDB head does not produce a seed from
+// the arity-4 base usage (which would have a wildcard at position 0).
+func TestBuildDemandSeedsForPred_ArityKeyedCallSite_NoUnsafeSeed(t *testing.T) {
+	prog := progArityCollidingHelper()
+	sizeHints := map[string]int{}
+
+	// Demand on the arity-1 IDB head: "position 0 of VarDecl/1 is bound".
+	seeds := buildDemandSeedsForPred(prog, "VarDecl", []int{0}, sizeHints)
+
+	// Each emitted seed must
+	//   (a) have head arity 1 (matching the IDB head, not the base /4), and
+	//   (b) NOT have a wildcard `_` at any head position (which would be
+	//       rejected by validate.ValidateRule even though isSafe accepts it).
+	for i, s := range seeds {
+		if s.Head.Predicate != "magic_VarDecl" {
+			t.Errorf("seed[%d]: unexpected head predicate %q (want magic_VarDecl)", i, s.Head.Predicate)
+		}
+		if got, want := len(s.Head.Args), 1; got != want {
+			t.Errorf("seed[%d]: head arity = %d, want %d (arity-keyed match should reject base /4 usages)", i, got, want)
+		}
+		for j, arg := range s.Head.Args {
+			if v, ok := arg.(datalog.Var); ok && v.Name == "_" {
+				t.Errorf("seed[%d]: wildcard `_` at head position %d — would be rejected by validate.ValidateRule and trigger plain-Plan fallback", i, j)
+			}
+		}
+		// Defensive: the seed should be safe per validate.ValidateRule
+		// after the round-5 fix (not just per the looser isSafe).
+		errs := ValidateRule(s)
+		if len(errs) > 0 {
+			t.Errorf("seed[%d]: ValidateRule rejected emitted seed: %v\nseed = %+v", i, errs, s)
+		}
+	}
+}
+
+// TestBuildDemandSeedsForPred_ArityKeyedCallSite_KeepsArity1CallSiteWithGrounding
+// guards the positive direction: a genuine arity-1 call site whose
+// preceding literal grounds the demanded var must still produce a safe seed.
+func TestBuildDemandSeedsForPred_ArityKeyedCallSite_KeepsArity1CallSiteWithGrounding(t *testing.T) {
+	// Add a grounding caller: `Grounded(x) :- Anchor(x), VarDecl(x).`
+	// where Anchor is a small base relation. This is the realistic
+	// shape — the arity-1 IDB call has a preceding atom that binds x.
+	prog := progArityCollidingHelper()
+	prog.Rules = append(prog.Rules, datalog.Rule{
+		Head: datalog.Atom{Predicate: "Grounded", Args: []datalog.Term{datalog.Var{Name: "x"}}},
+		Body: []datalog.Literal{
+			{Positive: true, Atom: datalog.Atom{Predicate: "Anchor", Args: []datalog.Term{datalog.Var{Name: "x"}}}},
+			{Positive: true, Atom: datalog.Atom{Predicate: "VarDecl", Args: []datalog.Term{datalog.Var{Name: "x"}}}},
+		},
+	})
+	sizeHints := map[string]int{}
+
+	seeds := buildDemandSeedsForPred(prog, "VarDecl", []int{0}, sizeHints)
+
+	// We expect at least one seed for the genuine arity-1 call site
+	// where x is grounded by Anchor.
+	foundArity1 := false
+	for _, s := range seeds {
+		if s.Head.Predicate != "magic_VarDecl" || len(s.Head.Args) != 1 {
+			continue
+		}
+		if v, ok := s.Head.Args[0].(datalog.Var); ok && v.Name == "x" {
+			foundArity1 = true
+			break
+		}
+	}
+	if !foundArity1 {
+		t.Errorf("arity-keyed match dropped the legitimate arity-1 call site; got seeds = %+v", seeds)
+	}
+}
+
+// TestInferRuleBodyDemandBindings_ArityCollidingHelper_NoFallback is
+// the integration-shaped test. It builds the colliding-helper shape
+// inside a program with a synth-disj demand source so the demand-seed
+// builder is actually exercised, and asserts that no unsafe seed is
+// produced for the colliding name. (We cannot easily reach
+// `WithMagicSetAutoOpts` from here without query plumbing, but the
+// presence of an unsafe seed is the load-bearing observable: it is what
+// later triggers the validate.ValidateRule rejection and the
+// plain-Plan fallback.)
+func TestInferRuleBodyDemandBindings_ArityCollidingHelper_NoFallback(t *testing.T) {
+	// Build a program that combines:
+	//   - the disj2-round5 arity collision (VarDecl/1 helper + /4 usage), and
+	//   - a synth-disj `_disj_2` whose only direct caller is a rename
+	//     trampoline (the round-1/round-3 shape that triggers the
+	//     parent-traversal path in buildDemandSeedsForPredWithParents).
+	//
+	// We don't need _disj_2 to contribute the bug; we just want the
+	// demand pass to fire so seeds are constructed across the board.
+	rules := []datalog.Rule{
+		// Arity-1 class-extent helper for VarDecl.
+		{
+			Head: datalog.Atom{Predicate: "VarDecl", Args: []datalog.Term{datalog.Var{Name: "this"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "VarDecl", Args: []datalog.Term{
+					datalog.Var{Name: "this"},
+					datalog.Var{Name: "_"},
+					datalog.Var{Name: "_"},
+					datalog.Var{Name: "_"},
+				}}},
+			},
+		},
+		// Arity-4 base usage with wildcard at the demanded position
+		// (the round-5 trap).
+		{
+			Head: datalog.Atom{Predicate: "Consumer", Args: []datalog.Term{datalog.Var{Name: "s"}}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "VarDecl", Args: []datalog.Term{
+					datalog.Var{Name: "_"},
+					datalog.Var{Name: "s"},
+					datalog.Var{Name: "_"},
+					datalog.Var{Name: "_"},
+				}}},
+			},
+		},
+	}
+	prog := &datalog.Program{
+		Rules: rules,
+		Query: &datalog.Query{
+			Select: []datalog.Term{datalog.Var{Name: "s"}},
+			Body: []datalog.Literal{
+				{Positive: true, Atom: datalog.Atom{Predicate: "Consumer", Args: []datalog.Term{datalog.Var{Name: "s"}}}},
+			},
+		},
+	}
+	idbPreds := IDBPredicates(prog)
+	sizeHints := map[string]int{}
+
+	bindings, seeds := InferRuleBodyDemandBindings(prog, idbPreds, sizeHints)
+	// VarDecl is not synth-named so it should never appear in bindings
+	// (the synth-only filter blocks the for-loop top-of-iteration). But
+	// it could enter via parent-traversal — the round-5 wildcard guard
+	// must still suppress unsafe seeds from any path.
+	for pred, cols := range bindings {
+		_ = cols
+		for _, s := range seeds {
+			if s.Head.Predicate != magicName(pred) {
+				continue
+			}
+			for j, arg := range s.Head.Args {
+				if v, ok := arg.(datalog.Var); ok && v.Name == "_" {
+					t.Errorf("unsafe seed with wildcard at head position %d for predicate %q (would trigger plain-Plan fallback): %+v", j, pred, s)
+				}
+			}
+			if errs := ValidateRule(s); len(errs) > 0 {
+				t.Errorf("ValidateRule rejected emitted seed for %q: %v\nseed = %+v", pred, errs, s)
+			}
+		}
+	}
+}

--- a/ql/plan/magicset.go
+++ b/ql/plan/magicset.go
@@ -47,6 +47,24 @@ func MagicSetTransform(prog *datalog.Program, queryBindings map[string][]int) *d
 	// through variable flow.
 	allBindings := propagateBindings(prog.Rules, relevantBindings)
 
+	// disj2-round5: arity-keyed IDB-head index for the propagation-rule
+	// emission below. allBindings is keyed by predicate NAME only — when
+	// PR #146's auto-emitted arity-1 class-extent helpers shadow an
+	// arity-N base relation of the same name (e.g. arity-1 `VarDecl(this)`
+	// helper alongside arity-4 base `VarDecl(_, sym, _, _)` usages), a
+	// name-only body-literal lookup projects arity-1 bindings onto the
+	// arity-N atom and produces unsafe `magic_X(_) :- ...` propagation
+	// rules. Restrict propagation emission to body literals whose arity
+	// matches at least one IDB head for that name.
+	idbHeadAritiesForProp := map[string]map[int]bool{}
+	for _, r := range prog.Rules {
+		name := r.Head.Predicate
+		if idbHeadAritiesForProp[name] == nil {
+			idbHeadAritiesForProp[name] = map[int]bool{}
+		}
+		idbHeadAritiesForProp[name][len(r.Head.Args)] = true
+	}
+
 	var newRules []datalog.Rule
 
 	// Generate magic seed facts from query bindings and propagation rules.
@@ -94,6 +112,37 @@ func MagicSetTransform(prog *datalog.Program, queryBindings map[string][]int) *d
 				bodyPred := lit.Atom.Predicate
 				bodyCols, ok := allBindings[bodyPred]
 				if !ok {
+					continue
+				}
+				// disj2-round5: only emit propagation rules for body
+				// literals that are GENUINE calls to an IDB at the
+				// matching (name, arity). Two failure modes otherwise:
+				//
+				//  - Same-name colliding arity (PR #146 class-extent
+				//    helper shadow): `VarDecl/1` IDB head + `VarDecl/N`
+				//    base usages. allBindings keys `VarDecl` by name
+				//    only; without arity gating, the arity-N base usage
+				//    has bindings recorded for arity-1 cols projected
+				//    onto its arity-N args — picking up wildcards at
+				//    the demanded position.
+				//
+				//  - Stripped class-extent helper (P2a `MaterialiseClassExtents`
+				//    pre-pass): the helper rule is REMOVED from
+				//    prog.Rules after materialisation, so by the time
+				//    MagicSetTransform runs the name has zero IDB
+				//    heads. propagateBindings can still flow a binding
+				//    onto the name from upstream rules that bind one of
+				//    its body-lit vars; without the gate, we emit a
+				//    `magic_<name>(...)` propagation rule that no IDB
+				//    consumes (the only would-be consumer was stripped),
+				//    AND the projected magic head args may include
+				//    wildcards at the demanded position, producing
+				//    `magic_<name>(_)` which validate.go rejects.
+				//
+				// Both failure modes collapse to: skip propagation rule
+				// emission when the body literal's (name, arity) does
+				// not appear as an IDB rule head.
+				if !idbHeadAritiesForProp[bodyPred][len(lit.Atom.Args)] {
 					continue
 				}
 
@@ -154,6 +203,24 @@ func propagateBindings(rules []datalog.Rule, initial map[string][]int) map[strin
 		bindings[k] = v
 	}
 
+	// disj2-round5: arity-keyed IDB-head index. Used to suppress
+	// propagation into a body literal whose arity does not match any
+	// IDB-head arity for its name. Without this guard, an arity-N
+	// base-relation usage (e.g. `VarDecl(_, sym, _, _)`) of a name
+	// that ALSO has an arity-1 IDB helper head (e.g.
+	// `VarDecl(this) :- VarDecl(this,_,_,_)`) would have arity-1
+	// bindings projected onto its arity-N args — picking up wildcards
+	// at the demanded positions and producing unsafe `magic_X(_)`
+	// propagation rules downstream.
+	idbHeadArities := map[string]map[int]bool{}
+	for _, r := range rules {
+		name := r.Head.Predicate
+		if idbHeadArities[name] == nil {
+			idbHeadArities[name] = map[int]bool{}
+		}
+		idbHeadArities[name][len(r.Head.Args)] = true
+	}
+
 	// Fixed-point iteration to propagate bindings.
 	changed := true
 	for changed {
@@ -188,6 +255,26 @@ func propagateBindings(rules []datalog.Rule, initial map[string][]int) map[strin
 				}
 
 				bodyPred := lit.Atom.Predicate
+				// disj2-round5: arity-keyed IDB-call gate for binding
+				// propagation. When `bodyPred` names an IDB head at SOME
+				// arity but the body literal's own arity does not match
+				// any of those IDB-head arities, this literal is a
+				// base-relation usage of a colliding name (the
+				// auto-emitted arity-1 class-extent helper shape from
+				// PR #146 — e.g. `VarDecl(this) :- VarDecl(this,_,_,_).`
+				// shadows arity-4 base `VarDecl/4` by name). Recording
+				// bindings on it under the IDB's name conflates the two
+				// and lets arity-1 bindings flow onto an arity-N atom.
+				// Skip the bindings record but keep the var-flow update
+				// so subsequent literals see vars bound by this one.
+				if arities, hasIDB := idbHeadArities[bodyPred]; hasIDB && !arities[len(lit.Atom.Args)] {
+					for _, arg := range lit.Atom.Args {
+						if v, isVar := arg.(datalog.Var); isVar && v.Name != "_" {
+							currentBound[v.Name] = true
+						}
+					}
+					continue
+				}
 				// Determine which columns of bodyPred are bound.
 				var boundBodyCols []int
 				for i, arg := range lit.Atom.Args {

--- a/ql/plan/magicset_demand.go
+++ b/ql/plan/magicset_demand.go
@@ -264,6 +264,39 @@ func buildDemandSeedsForPred(
 	// for every preceding-literal scan. Compute once per call.
 	idbByArity := idbHeadByArity(prog)
 
+	// disj2-round5: arity-keyed call-site match. The desugarer's
+	// auto-emitted arity-1 class-extent helpers (PR #146) — e.g.
+	// `VarDecl(this) :- VarDecl(this, _, _, _).` — register a NEW
+	// IDB head named "VarDecl" at arity 1. The underlying base
+	// relation `VarDecl/4` keeps the same name. When backward demand
+	// is inferred for the arity-1 IDB head (`demand[VarDecl] = [0]`
+	// from arity-1 grounding callers), this loop must NOT match the
+	// arity-4 base usages of the same name as call sites — those are
+	// not calls to the IDB.
+	//
+	// Concrete failure mode (Mastodon `setStateUpdaterCallsOtherSetStateThroughContext`):
+	// without arity disambiguation, a body literal like
+	// `VarDecl(_, sym, srcExpr, _)` (arity 4, position 0 wildcard) was
+	// matched as a "call" to `VarDecl/1` and produced the seed
+	// `magic_VarDecl(_) :- ...` with a wildcard head var. `isSafe` lets
+	// the wildcard through but `validate.ValidateRule` rejects it
+	// ("head variable \"_\" does not appear in any positive body literal"),
+	// causing `WithMagicSetAutoOpts` to fall back to plain Plan. With
+	// no magic-set rewrite, every IDB in the program runs to completion
+	// against the full base — including unrelated siblings like
+	// `setStateUpdaterCallsFn` — and one of them caps out.
+	//
+	// Same family as PR #156's preceding-literal IDB-shadow fix; that
+	// PR keyed the body-IDB lookup by (name, arity), but the call-site
+	// match itself remained name-only. This restricts the call-site
+	// match to literals whose arity equals the IDB head arity.
+	predArities := map[int]bool{}
+	for _, r := range prog.Rules {
+		if r.Head.Predicate == pred {
+			predArities[len(r.Head.Args)] = true
+		}
+	}
+
 	for _, rule := range prog.Rules {
 		// Skip self-recursion on pred — a rule whose head IS pred
 		// can't seed itself in a useful way (it would create a magic
@@ -277,6 +310,13 @@ func buildDemandSeedsForPred(
 				continue
 			}
 			if lit.Atom.Predicate != pred {
+				continue
+			}
+			// Arity-keyed call-site match (round-5). If the program
+			// has any IDB head for `pred`, only literals at one of
+			// those arities are call sites; literals at other arities
+			// are base-relation usages of a colliding name.
+			if len(predArities) > 0 && !predArities[len(lit.Atom.Args)] {
 				continue
 			}
 			if len(lit.Atom.Args) < maxColIndex(cols)+1 {
@@ -303,6 +343,25 @@ func buildDemandSeedsForPred(
 				}
 			}
 			if malformed {
+				continue
+			}
+			// disj2-round5 belt-and-braces: skip the call site if any
+			// demanded position is a wildcard at the call. `isSafe`'s
+			// `_`-exemption (magicset.go:isSafe) lets a wildcard head
+			// arg through, but `validate.ValidateRule` (validate.go)
+			// rejects it as an unbound head var. The transformed
+			// program then fails to plan and `WithMagicSetAutoOpts`
+			// silently falls back to plain Plan with a warning. Drop
+			// the seed up front rather than emit one we know will be
+			// rejected downstream.
+			wildcardAtDemandedPos := false
+			for _, arg := range seedHeadArgs {
+				if v, ok := arg.(datalog.Var); ok && v.Name == "_" {
+					wildcardAtDemandedPos = true
+					break
+				}
+			}
+			if wildcardAtDemandedPos {
 				continue
 			}
 

--- a/ql/plan/magicset_test.go
+++ b/ql/plan/magicset_test.go
@@ -87,19 +87,34 @@ func TestMagicSetTransformPreservesResults(t *testing.T) {
 		}
 
 		// Verify structural properties: with a binding on the IDB predicate
-		// `Derived`, the magic-set transform must produce at least one
-		// magic_<pred> rule. If none is emitted, the transform silently
-		// no-op'd and the results-preservation guarantee is meaningless.
+		// `Derived`, the magic-set transform must rewrite Derived's rule to
+		// include a magic_Derived(...) literal in its body. If no rule body
+		// references magic_Derived, the transform silently no-op'd and the
+		// results-preservation guarantee is meaningless.
+		//
+		// Note (disj2-round5): we no longer assert that magic_<pred> appears
+		// as a rule HEAD here. In this minimal property-test program, the only
+		// IDB rule body uses base relations exclusively (Base0/Base1) — so
+		// the only thing a sound magic-set transform can produce is the
+		// rewritten Derived rule itself. Emitting `magic_Base0(...)`
+		// propagation rules would be pointless (no IDB consumes them) and,
+		// in pathological shadow cases, wildcard-unsafe — see the round-5
+		// gate in MagicSetTransform.
 		hasMagic := false
 		for _, s := range ep2.Strata {
 			for _, r := range s.Rules {
+				for _, lit := range r.Body {
+					if lit.Atom.Predicate != "" && len(lit.Atom.Predicate) > 6 && lit.Atom.Predicate[:6] == "magic_" {
+						hasMagic = true
+					}
+				}
 				if len(r.Head.Predicate) > 6 && r.Head.Predicate[:6] == "magic_" {
 					hasMagic = true
 				}
 			}
 		}
 		if !hasMagic {
-			t.Fatalf("magic-set plan did not emit any magic_* rules despite Derived binding")
+			t.Fatalf("magic-set plan did not emit any magic_* references despite Derived binding")
 		}
 
 		// NOTE: End-to-end evaluation comparison (magic-set vs naive produces


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Summary

Round-5 in the `_disj_2` saga (#156, #158, #161, #162). The new
through-context predicate from #165/#167
(`setStateUpdaterCallsOtherSetStateThroughContext`) cap-hit at 20M on
Mastodon because the magic-set transform was silently falling back to
plain Plan after producing an unsafe `magic_VarDecl(_) :- ...`
propagation rule.

Root cause: PR #146's auto-emitted arity-1 class-extent helpers
(`VarDecl(this) :- VarDecl(this, _, _, _).`) shadow the underlying
arity-N base relations of the same name. `allBindings` is keyed by
predicate NAME only — an arity-N base usage like
`VarDecl(_, sym, _, _)` had arity-1 bindings projected onto its
arity-N args, picking up wildcards at the demanded position. The
resulting `magic_VarDecl(_)` rule passes the looser `isSafe` check
(which exempts `_`) but is rejected by `validate.ValidateRule`. The
whole magic-set program then falls back to plain Plan, removing all
demand pruning and exposing every IDB to full-base evaluation —
including unrelated siblings.

Fix: three layers of arity-keyed defence

- `buildDemandSeedsForPred` (magicset_demand.go): arity-keyed
  call-site match + wildcard-at-demanded-position guard.
- `propagateBindings` (magicset.go): when a body literal's name has
  any IDB head but its arity matches none, skip the bindings record
  (keep var-flow update for subsequent literals).
- `MagicSetTransform` propagation-rule emission (magicset.go): only
  emit `magic_<bodyPred>(...)` rules when (name, arity) is a genuine
  IDB rule head. Catches both the arity-collision case AND the
  stripped-class-extent case (P2a `MaterialiseClassExtents` strips
  helper rules before MagicSetTransform runs).

## Tests

- `disj2_round5_arity_collision_call_site_test.go` — three new
  unit/integration tests exercising the unsafe-seed shape, the
  legitimate arity-1 grounding path, and the bindings/seeds output.
- `magicset_test.go::TestMagicSetTransformPreservesResults` —
  structural check widened to count `magic_*` references in rule
  bodies (not just heads). The rewritten rule's `magic_Derived(...)`
  body literal IS the transform's effect when the only IDB has no
  IDB body lits; emitting `magic_Base*` propagation rules for base
  preds would be pointless and, in pathological shadow cases,
  wildcard-unsafe.

All `./...` tests pass.

## Observed effect on Mastodon

Before: `error: evaluate: rule "_disj_2" exceeded binding cap of 5000000 at join step 2`,
preceded by `warning: magic-set transform produced an unplannable program; fell back to plain Plan (reason: unsafe rule: head variable "_" does not appear in any positive body literal (predicate magic_VarDecl))`.

After: no fallback warning, magic-set transform applies cleanly. A
DIFFERENT cap-hit surfaces afterward on `magic__disj_28` —
orphan magic-rule join cardinality, distinct issue class
(magic seeder unconstrained → join-order planner doesn't keep the
empty `magic_*` literal at the front). Tracked separately as a
follow-on; out of scope for this round.

## Test plan

- [x] `go test ./...` green
- [x] Reproduced the cap-hit on cain-nas with the through-context
      query against the Mastodon corpus before the fix.
- [x] Verified after the fix: no unsafe magic_VarDecl, no fallback
      warning, magic-set transform applies. (Follow-on
      `magic__disj_28` cap-hit is separate.)