### PR TITLE
fix(plan): anchor magic_<pred> literals to defeat unseeded-propagation cap-hits (disj2-round6)

### DIFF
--- a/ql/plan/backward.go
+++ b/ql/plan/backward.go
@@ -785,48 +785,74 @@ func orderJoinsWithDemandAndIDB(
 		// before its bound vars are grounded, defeating the round4 fix.
 		// We pass placedView equal to placed but block IDB-demand-deferred
 		// candidates by marking them temporarily placed for this lookup.
-		var tinyMask []bool
-		if hasIDBDemand(body, idbDemand) {
-			tinyMask = make([]bool, len(body))
-			copy(tinyMask, placed)
-			for i, lit := range body {
-				if tinyMask[i] {
-					continue
+		// disj2-round6: magic-pred anchor. Any unplaced positive literal
+		// whose predicate carries the `magic_` prefix MUST win the next
+		// slot regardless of normal cost scoring (boundCount /
+		// sizeHint / tiny-seed). Magic predicates are the seed-driven
+		// demand source after `MagicSetTransform`: their extension is
+		// either empty (rule produces nothing — correct) or non-empty
+		// (the only values worth driving the join with — correct).
+		// Placing them late lets the planner cross-product the
+		// preceding base/IDB literals before pruning, which is the
+		// pathology behind the round-6 cap-hit on
+		// `magic__disj_28` (VarDecl ⋈ DestructureField on no shared
+		// vars, ~10M tuples, hits the 5M cap before
+		// `magic_contextDestructureBinding` ever filters).
+		//
+		// Eligibility: positive atoms are always eligible (isEligible
+		// returns true unconditionally for positive non-comparison
+		// literals), so the anchor pass need only check `placed`.
+		// Multiple magic literals in one body (rare but possible —
+		// e.g. a propagation rule built from a body where the
+		// preceding lits already include a magic prereq) are
+		// scheduled in body order; subsequent ones become filters once
+		// runtimeBound covers their args.
+		if magicIdx := pickMagicAnchor(body, placed); magicIdx != -1 {
+			bestIdx = magicIdx
+		} else {
+			var tinyMask []bool
+			if hasIDBDemand(body, idbDemand) {
+				tinyMask = make([]bool, len(body))
+				copy(tinyMask, placed)
+				for i, lit := range body {
+					if tinyMask[i] {
+						continue
+					}
+					if isIDBCallDeferred(lit, head.Predicate, idbDemand, runtimeBound, sizeHints) {
+						tinyMask[i] = true
+					}
 				}
-				if isIDBCallDeferred(lit, head.Predicate, idbDemand, runtimeBound, sizeHints) {
-					tinyMask[i] = true
+			} else {
+				tinyMask = placed
+			}
+			tinyIdx := pickTinySeed(body, tinyMask, runtimeBound, sizeHints, defaultSizeHint)
+			if tinyIdx != -1 && isEligible(body[tinyIdx], runtimeBound) {
+				bestIdx = tinyIdx
+			} else {
+				for i, lit := range body {
+					if placed[i] {
+						continue
+					}
+					if !isEligible(lit, runtimeBound) {
+						continue
+					}
+					negBound, size := scoreLiteral(lit, plannerBound, sizeHints)
+					// Round4: defer IDB literals whose demand requires
+					// positions not yet runtime-bound. Inflate their size to
+					// SaturatedSizeHint so any other eligible candidate wins;
+					// when a later step binds the required vars they regain
+					// their true cost and become competitive again.
+					if isIDBCallDeferred(lit, head.Predicate, idbDemand, runtimeBound, sizeHints) {
+						size = idbDeferredPenalty
+					}
+					if bestIdx == -1 || negBound < bestNegBound || (negBound == bestNegBound && size < bestSize) {
+						bestIdx = i
+						bestNegBound = negBound
+						bestSize = size
+					}
 				}
 			}
-		} else {
-			tinyMask = placed
-		}
-		tinyIdx := pickTinySeed(body, tinyMask, runtimeBound, sizeHints, defaultSizeHint)
-		if tinyIdx != -1 && isEligible(body[tinyIdx], runtimeBound) {
-			bestIdx = tinyIdx
-		} else {
-			for i, lit := range body {
-				if placed[i] {
-					continue
-				}
-				if !isEligible(lit, runtimeBound) {
-					continue
-				}
-				negBound, size := scoreLiteral(lit, plannerBound, sizeHints)
-				// Round4: defer IDB literals whose demand requires
-				// positions not yet runtime-bound. Inflate their size to
-				// SaturatedSizeHint so any other eligible candidate wins;
-				// when a later step binds the required vars they regain
-				// their true cost and become competitive again.
-				if isIDBCallDeferred(lit, head.Predicate, idbDemand, runtimeBound, sizeHints) {
-					size = idbDeferredPenalty
-				}
-				if bestIdx == -1 || negBound < bestNegBound || (negBound == bestNegBound && size < bestSize) {
-					bestIdx = i
-					bestNegBound = negBound
-					bestSize = size
-				}
-			}
-		}
+		} // end of magic-anchor else
 
 		if bestIdx == -1 {
 			for i, p := range placed {

--- a/ql/plan/disj2_round6_magic_anchor_test.go
+++ b/ql/plan/disj2_round6_magic_anchor_test.go
@@ -1,0 +1,221 @@
+// Disj2-round6 regression: magic-pred anchoring in the join planner.
+//
+// Scenario (Mastodon `setStateUpdaterCallsOtherSetStateThroughContext`):
+// after PR #168 (round-5) lands, the magic-set transform applies cleanly
+// for the through-context query. A propagation rule of shape
+//
+//	magic_<inner>(args) :- magic_<outer>(args), <preceding body lits>.
+//
+// is generated for `magic__disj_28`. Concretely:
+//
+//	magic__disj_28(initExpr) :-
+//	   magic_contextDestructureBinding(ctxSym, fieldName),
+//	   VarDecl(varDecl, _, initExpr, _),
+//	   Contains(varDecl, parent),
+//	   DestructureField(parent, fieldName, _, paramSym, _).
+//
+// `magic__disj_28` has head-demand [0] (position 0 = initExpr), so the
+// pre-round6 planner pre-binds initExpr in plannerBound. The greedy
+// scorer then sees VarDecl as the only literal sharing initExpr at
+// slot 0 (boundCount=1) and places it first. After VarDecl, the
+// remaining literals — magic_contextDestructureBinding (no overlap),
+// DestructureField (no overlap with bound={varDecl,initExpr}), and
+// Contains (one overlap, varDecl) — combine into a cap-blowing cross
+// product before `magic_contextDestructureBinding` ever filters.
+//
+// Round-6 fix: any `magic_<pred>` literal in a rule body MUST win the
+// next slot regardless of normal cost scoring. Magic predicates are
+// the seed-driven demand source — placing them late lets the
+// surrounding bases blow the binding cap. With the anchor in place,
+// the magic literal is scheduled at slot 0 and the join becomes
+// driven by the small magic seed extension.
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// progRound6PropagationCapHit models the magic__disj_28 propagation
+// rule shape. The body literals correspond to the dump observed on
+// Mastodon at commit 78d0138.
+func progRound6PropagationCapHit() datalog.Rule {
+	// magic__disj_28(initExpr) :-
+	//   magic_contextDestructureBinding(ctxSym, fieldName),
+	//   VarDecl(varDecl, _, initExpr, _),
+	//   Contains(varDecl, parent),
+	//   DestructureField(parent, fieldName, _, paramSym, _).
+	return datalog.Rule{
+		Head: datalog.Atom{Predicate: "magic__disj_28", Args: []datalog.Term{
+			datalog.Var{Name: "initExpr"},
+		}},
+		Body: []datalog.Literal{
+			{Positive: true, Atom: datalog.Atom{Predicate: "magic_contextDestructureBinding", Args: []datalog.Term{
+				datalog.Var{Name: "ctxSym"},
+				datalog.Var{Name: "fieldName"},
+			}}},
+			{Positive: true, Atom: datalog.Atom{Predicate: "VarDecl", Args: []datalog.Term{
+				datalog.Var{Name: "varDecl"},
+				datalog.Var{Name: "_"},
+				datalog.Var{Name: "initExpr"},
+				datalog.Var{Name: "_"},
+			}}},
+			{Positive: true, Atom: datalog.Atom{Predicate: "Contains", Args: []datalog.Term{
+				datalog.Var{Name: "varDecl"},
+				datalog.Var{Name: "parent"},
+			}}},
+			{Positive: true, Atom: datalog.Atom{Predicate: "DestructureField", Args: []datalog.Term{
+				datalog.Var{Name: "parent"},
+				datalog.Var{Name: "fieldName"},
+				datalog.Var{Name: "_"},
+				datalog.Var{Name: "paramSym"},
+				datalog.Var{Name: "_"},
+			}}},
+		},
+	}
+}
+
+// TestRound6_MagicAnchor_OrderJoins verifies that the plain orderJoins
+// planner schedules the magic literal at slot 0.
+func TestRound6_MagicAnchor_OrderJoins(t *testing.T) {
+	rule := progRound6PropagationCapHit()
+	sizeHints := map[string]int{
+		"VarDecl":          5011,
+		"Contains":         455468,
+		"DestructureField": 2188,
+		// magic_* deliberately unhinted — defaultSizeHint applies.
+	}
+	steps := orderJoins(rule.Body, sizeHints)
+	if len(steps) != len(rule.Body) {
+		t.Fatalf("len(steps)=%d want %d", len(steps), len(rule.Body))
+	}
+	if got := steps[0].Literal.Atom.Predicate; got != "magic_contextDestructureBinding" {
+		t.Errorf("orderJoins slot 0 = %q want magic_contextDestructureBinding (round-6 anchor)", got)
+	}
+}
+
+// TestRound6_MagicAnchor_OrderJoinsWithDemandAndIDB verifies that the
+// demand-aware planner also anchors magic literals — even when
+// head-demand pre-binds a var that another body literal happens to
+// share. This is the production failure mode: head-demand on
+// `initExpr` would otherwise hand slot 0 to VarDecl.
+func TestRound6_MagicAnchor_OrderJoinsWithDemandAndIDB(t *testing.T) {
+	rule := progRound6PropagationCapHit()
+	sizeHints := map[string]int{
+		"VarDecl":          5011,
+		"Contains":         455468,
+		"DestructureField": 2188,
+	}
+	headDemand := []int{0} // initExpr is demand-bound.
+	steps := orderJoinsWithDemandAndIDB(rule.Head, rule.Body, sizeHints, headDemand, nil)
+	if len(steps) != len(rule.Body) {
+		t.Fatalf("len(steps)=%d want %d", len(steps), len(rule.Body))
+	}
+	if got := steps[0].Literal.Atom.Predicate; got != "magic_contextDestructureBinding" {
+		t.Errorf("orderJoinsWithDemandAndIDB slot 0 = %q want magic_contextDestructureBinding (round-6 anchor); full plan: %s", got, planTrace(steps))
+	}
+}
+
+// TestRound6_MagicAnchor_BeatsTinySeed verifies the magic-anchor pass
+// runs BEFORE the tiny-seed override. A magic literal must win even
+// when a hinted-tiny base relation is also present.
+func TestRound6_MagicAnchor_BeatsTinySeed(t *testing.T) {
+	body := []datalog.Literal{
+		// Tiny-seed candidate: hinted ≤ tinySeedThreshold.
+		{Positive: true, Atom: datalog.Atom{Predicate: "TinyBase", Args: []datalog.Term{
+			datalog.Var{Name: "x"},
+		}}},
+		// Magic literal — must still anchor at slot 0.
+		{Positive: true, Atom: datalog.Atom{Predicate: "magic_Foo", Args: []datalog.Term{
+			datalog.Var{Name: "y"},
+		}}},
+	}
+	sizeHints := map[string]int{
+		"TinyBase": 5, // qualifies as tiny seed.
+	}
+	steps := orderJoins(body, sizeHints)
+	if got := steps[0].Literal.Atom.Predicate; got != "magic_Foo" {
+		t.Errorf("orderJoins slot 0 = %q want magic_Foo (anchor must beat tiny-seed)", got)
+	}
+}
+
+// TestRound6_MagicAnchor_NoMagicLiteral_DegradesIdentically verifies
+// that bodies with no magic literals plan identically to before the
+// round-6 patch — the anchor pass is a strict pre-pass that returns
+// -1 when no candidate qualifies.
+func TestRound6_MagicAnchor_NoMagicLiteral_DegradesIdentically(t *testing.T) {
+	body := []datalog.Literal{
+		{Positive: true, Atom: datalog.Atom{Predicate: "A", Args: []datalog.Term{datalog.Var{Name: "x"}}}},
+		{Positive: true, Atom: datalog.Atom{Predicate: "B", Args: []datalog.Term{datalog.Var{Name: "x"}}}},
+	}
+	sizeHints := map[string]int{"A": 100, "B": 50}
+	steps := orderJoins(body, sizeHints)
+	// Smallest size at slot 0 → B.
+	if got := steps[0].Literal.Atom.Predicate; got != "B" {
+		t.Errorf("orderJoins slot 0 = %q want B (no magic anchor → fall through to scoring)", got)
+	}
+}
+
+// TestRound6_IsMagicLiteral covers the predicate-name detection helper.
+func TestRound6_IsMagicLiteral(t *testing.T) {
+	tests := []struct {
+		name     string
+		lit      datalog.Literal
+		wantTrue bool
+	}{
+		{
+			name: "magic_ prefix positive",
+			lit: datalog.Literal{Positive: true, Atom: datalog.Atom{
+				Predicate: "magic_Foo",
+			}},
+			wantTrue: true,
+		},
+		{
+			name: "no prefix",
+			lit: datalog.Literal{Positive: true, Atom: datalog.Atom{
+				Predicate: "Foo",
+			}},
+			wantTrue: false,
+		},
+		{
+			name: "exact prefix only (length match)",
+			lit: datalog.Literal{Positive: true, Atom: datalog.Atom{
+				Predicate: "magic_",
+			}},
+			wantTrue: false, // requires more after the prefix
+		},
+		{
+			name: "negated magic literal",
+			lit: datalog.Literal{Positive: false, Atom: datalog.Atom{
+				Predicate: "magic_Foo",
+			}},
+			wantTrue: false, // negation excluded
+		},
+		{
+			name:     "magic-named comparison",
+			lit:      datalog.Literal{Cmp: &datalog.Comparison{}},
+			wantTrue: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isMagicLiteral(tc.lit)
+			if got != tc.wantTrue {
+				t.Errorf("isMagicLiteral=%v want %v", got, tc.wantTrue)
+			}
+		})
+	}
+}
+
+func planTrace(steps []JoinStep) string {
+	out := ""
+	for i, s := range steps {
+		if i > 0 {
+			out += " | "
+		}
+		out += s.Literal.Atom.Predicate
+	}
+	return out
+}

--- a/ql/plan/join.go
+++ b/ql/plan/join.go
@@ -395,15 +395,65 @@ func selectVars(sel []datalog.Term) []string {
 	return out
 }
 
+// magicPredPrefix is the predicate-name prefix used by MagicSetTransform
+// for synthesised seed/propagation predicates. Anchoring literals with
+// this prefix to slot 0 (see pickMagicAnchor) is the disj2-round6 fix
+// for the unseeded-propagation cap-hit on `magic__disj_28` —
+// magic_<pred> literals are the seed-driven demand source and must
+// drive the join, never act as a tail-end filter against a base-only
+// cross product.
+const magicPredPrefix = "magic_"
+
+// isMagicLiteral reports whether lit is a positive atom whose predicate
+// name carries the `magic_` prefix. Comparisons, aggregates, and
+// negative literals are excluded — only positive atom drivers qualify
+// for the round-6 anchor.
+func isMagicLiteral(lit datalog.Literal) bool {
+	if !lit.Positive || lit.Cmp != nil || lit.Agg != nil {
+		return false
+	}
+	p := lit.Atom.Predicate
+	return len(p) > len(magicPredPrefix) && p[:len(magicPredPrefix)] == magicPredPrefix
+}
+
+// pickMagicAnchor returns the index of the next unplaced positive
+// literal whose predicate is a magic-set seed predicate (name prefixed
+// with `magic_`), or -1 if none qualifies. It runs BEFORE the
+// tiny-seed override and the standard greedy scorer in
+// orderJoins/orderJoinsWithDemandAndIDB. See `magicPredPrefix` for the
+// full rationale.
+//
+// Selection rule among multiple magic literals: the FIRST unplaced one
+// in body order wins. This is body-order-stable (matters for tests
+// that pin plans) and is the order MagicSetTransform itself uses when
+// constructing rewritten bodies (magic head-prereq first, then
+// preceding original body lits).
+//
+// Eligibility: positive atoms are always eligible (isEligible returns
+// true unconditionally), so this function only consults `placed`.
+func pickMagicAnchor(body []datalog.Literal, placed []bool) int {
+	for i, lit := range body {
+		if placed[i] {
+			continue
+		}
+		if isMagicLiteral(lit) {
+			return i
+		}
+	}
+	return -1
+}
+
 // orderJoins implements greedy join ordering for a rule body.
 //
 // Selection rule per slot:
-//  1. Among eligible candidates, prefer any "tiny seed" (see isTinySeed)
-//     — this is the issue #98 defensive heuristic against missing/wrong
-//     sizeHints. Among multiple tiny candidates, the one with the smaller
-//     known sizeHint wins (with constants tiebreaking over no-constants).
-//  2. Otherwise fall back to normal cost scoring: most-bound-first, then
-//     smallest-relation-first.
+//  1. Magic-anchor (disj2-round6): any unplaced `magic_<pred>` positive
+//     literal wins immediately. See pickMagicAnchor / magicPredPrefix.
+//  2. Otherwise, prefer any "tiny seed" (see isTinySeed) — issue #98
+//     defensive heuristic against missing/wrong sizeHints. Among
+//     multiple tiny candidates, the one with the smaller known
+//     sizeHint wins (with constants tiebreaking over no-constants).
+//  3. Otherwise fall back to normal cost scoring: most-bound-first,
+//     then smallest-relation-first.
 func orderJoins(body []datalog.Literal, sizeHints map[string]int) []JoinStep {
 	if len(body) == 0 {
 		return nil
@@ -418,9 +468,11 @@ func orderJoins(body []datalog.Literal, sizeHints map[string]int) []JoinStep {
 		bestNegBound := 0
 		bestSize := 0
 
-		// Pass 1 — tiny-seed override (issue #98 + #109). See pickTinySeed.
-		tinyIdx := pickTinySeed(body, placed, bound, sizeHints, defaultSizeHint)
-		if tinyIdx != -1 {
+		// Pass 0 — magic-anchor override (disj2-round6).
+		if magicIdx := pickMagicAnchor(body, placed); magicIdx != -1 {
+			bestIdx = magicIdx
+		} else if tinyIdx := pickTinySeed(body, placed, bound, sizeHints, defaultSizeHint); tinyIdx != -1 {
+			// Pass 1 — tiny-seed override (issue #98 + #109). See pickTinySeed.
 			bestIdx = tinyIdx
 		} else {
 			// Pass 2 — fallback to standard greedy scoring.


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Summary

Round-5 (#168) fixed the arity-keyed magic-set propagation guards so the through-context query no longer falls back to plain Plan. With that landed, a separate cap-hit surfaces on `magic__disj_28` against `find_setstate_updater_calls_other_setstate_through_context.ql` on Mastodon scale.

This PR adds an unconditional **magic-pred anchor** in the join planner: any positive `magic_<pred>` literal in a rule body wins the next available join slot regardless of normal cost scoring or the tiny-seed override. Magic predicates are the seed-driven demand source after `MagicSetTransform` — placing them late lets the surrounding bases blow the binding cap.

## Root cause

Pre-fix plan dump (`-magic-sets -dump-plan`):
```
rule magic__disj_28(initExpr) :-
  +[0] VarDecl(varDecl, _, initExpr, _)
  +[1] DestructureField(parent, fieldName, _, paramSym, _)
  +[2] magic_contextDestructureBinding(ctxSym, fieldName)
  f[3] Contains(varDecl, parent)
```

`magic__disj_28` has head-demand `[0]` (initExpr), so the planner pre-binds initExpr in plannerBound. VarDecl is the only literal sharing initExpr at slot 0 (boundCount=1) → wins. After VarDecl, `magic_contextDestructureBinding` (no overlap with bound={varDecl, initExpr}) falls behind DestructureField on size hint. VarDecl ⋈ DestructureField on no shared vars = ~10M tuples → 5M cap blown at step 1.

## Fix (Option B — anchor magic_*)

- New `pickMagicAnchor` in `ql/plan/join.go`: matches positive literals whose predicate name carries the `magic_` prefix. Negative literals, comparisons, and aggregates are excluded.
- `orderJoins` runs the anchor pre-pass at slot 0 before the tiny-seed override and the standard greedy scorer.
- `orderJoinsWithDemandAndIDB` runs the same pre-pass before its demand-aware scoring path. Empty-magic safety: a rule with no magic literals matches `pickMagicAnchor`'s -1 fast path and degrades byte-identical to the pre-round6 plan.

## Why anchoring is correct

A `magic_<pred>` literal has two possible runtime states:
1. **Empty extension** — the rule produces nothing (correct: magic seeded an empty demand set).
2. **Non-empty extension** — exactly the values worth driving the join with.

In both cases, scheduling the magic literal first is at worst a no-op (zero tuples flow through) and at best the entire point of the magic-set rewrite. Placing it as a tail-end filter cannot be more correct and, as the round-6 cap-hit shows, can be catastrophically worse.

## Cain-nas verification

**Before** (commit `78d0138` baseline):
```
$ tsq query -db mastodon.db -magic-sets find_setstate_updater_calls_other_setstate_through_context.ql
error: evaluate: rule "magic__disj_28" exceeded binding cap of 5000000 at join step 1 (intermediate cardinality=5000001)
```

**After** (this PR, commit `45bd9ce`):
```
$ /usr/bin/time -v tsq-r6-fix query -db mastodon.db -magic-sets -format csv find_setstate_updater_calls_other_setstate_through_context.ql > out.csv
EXIT=0
wall: 0:46.02
user: 80.35s
maxrss: 4.2 GB
rows: 1 (header only — query has no real-world matches in the Mastodon corpus)
```

Same query on `jitsi.db`: EXIT=0, 1 row (header only, no matches in jitsi either).

Cross-check that existing queries still produce results:
- `find_setstate_updater_calls_other_setstate -magic-sets` on mastodon: still returns matches (e.g. `2086288374,86`).
- `find_setstate_updater_calls_fn -magic-sets` on mastodon: still returns matches (multiple rows).

## Tests

`ql/plan/disj2_round6_magic_anchor_test.go`:
- `TestRound6_MagicAnchor_OrderJoinsWithDemandAndIDB` — reproduces the exact Mastodon production failure shape and asserts magic literal at slot 0. **Verified true regression guard:** with the anchor disabled (manually short-circuited), this test fails with the production order `VarDecl | DestructureField | magic_contextDestructureBinding | Contains` (the cap-hitting plan). With anchor enabled, magic wins slot 0 cleanly.
- `TestRound6_MagicAnchor_OrderJoins` — covers the plain orderJoins planner.
- `TestRound6_MagicAnchor_BeatsTinySeed` — pins ordering precedence over the tiny-seed override.
- `TestRound6_MagicAnchor_NoMagicLiteral_DegradesIdentically` — pins the no-op contract for non-magic bodies.
- `TestRound6_IsMagicLiteral` — covers predicate-name detection edges (negation, comparison, exact-prefix-only).

Local test runs:
- `go test ./ql/... -count=1 -short` — all green across 7 ql packages.
- `go test ./ql/plan/... ./ql/eval/... -race -count=1` — race-clean.
- `go test -run "TestSetStateUpdaterCallsOtherSetStateThroughContext|TestContextChain|TestR3|TestSetState|TestIssue88|TestRegression" -count=1` — all green; the through-context positive integration test (Consumer.tsx fixture) confirms correct results with the anchor in place.

## Test plan

- [x] Reproduce round-6 cap-hit on cain-nas Mastodon
- [x] Implement magic-anchor pre-pass
- [x] Failing-test → fix → passing-test cycle
- [x] Verify cap-hit gone on cain-nas Mastodon (EXIT=0 in 46s, 4.2GB peak)
- [x] Cross-check no regression on existing setstate queries (mastodon)
- [x] Cross-check on jitsi corpus (EXIT=0)
- [x] Through-context positive integration tests pass (Consumer.tsx fixture)