### PR TITLE
feat(bridge): resolve Provider value through factory hook return (round-4)

### DIFF
--- a/bridge/tsq_react.qll
+++ b/bridge/tsq_react.qll
@@ -558,6 +558,106 @@ predicate resolveToObjectExprVarD2(int valueExpr, int objExpr) {
     )
 }
 
+/**
+ * Round-4: resolve through a function-call initialiser to the ObjectLiteral
+ * expression in the called function's return statement (factory-hook pattern).
+ *
+ *   function useActions() {
+ *     return { setX, setY };           // shape A: return IS the ObjectLiteral
+ *   }
+ *   const actions = useActions();
+ *   <Ctx.Provider value={actions}>     // round-3 chain dies here; round-4 follows the call.
+ *
+ * Two return shapes are recognised, each as a named branch so the top-level
+ * union is `or`-of-calls (#166 workaround discipline, same as round-3).
+ *
+ * Same-module path uses `FunctionSymbol(hookSym, hookFn)`; cross-module path
+ * uses `importedFunctionSymbol(hookSym, hookFn)` — the same pair already used
+ * by `useContextCallSiteResolvesContext` for hook-indirection callees.
+ *
+ * Conditional-return functions are over-approximated (any branch's
+ * ObjectLiteral surfaces). Hand-bounded depth: shape B is one VarDecl hop
+ * from the return expression to the ObjectLiteral; deeper indirection inside
+ * the hook body is intentionally out of scope for v1.
+ */
+
+// Shape A — return expression IS the ObjectLiteral, same-module FunctionSymbol.
+predicate resolveToObjectExprHookReturnDirectSame(int valueExpr, int objExpr) {
+    exists(int identExpr, int sym, int varDecl, int callExpr, int call,
+           int hookSym, int hookFn |
+        (identExpr = valueExpr or Contains(valueExpr, identExpr)) and
+        ExprMayRef(identExpr, sym) and
+        VarDecl(varDecl, sym, callExpr, _) and
+        ExprIsCall(callExpr, call) and
+        CallCalleeSym(call, hookSym) and
+        FunctionSymbol(hookSym, hookFn) and
+        ReturnStmt(hookFn, _, objExpr) and
+        isObjectLiteralExpr(objExpr)
+    )
+}
+
+// Shape A — return expression IS the ObjectLiteral, cross-module import.
+predicate resolveToObjectExprHookReturnDirectImported(int valueExpr, int objExpr) {
+    exists(int identExpr, int sym, int varDecl, int callExpr, int call,
+           int hookSym, int hookFn |
+        (identExpr = valueExpr or Contains(valueExpr, identExpr)) and
+        ExprMayRef(identExpr, sym) and
+        VarDecl(varDecl, sym, callExpr, _) and
+        ExprIsCall(callExpr, call) and
+        CallCalleeSym(call, hookSym) and
+        importedFunctionSymbol(hookSym, hookFn) and
+        ReturnStmt(hookFn, _, objExpr) and
+        isObjectLiteralExpr(objExpr)
+    )
+}
+
+// Shape B — return expression refs a sym whose VarDecl initialiser IS the
+// ObjectLiteral (`const actions = { ... }; return actions;`). Same-module.
+predicate resolveToObjectExprHookReturnVarSame(int valueExpr, int objExpr) {
+    exists(int identExpr, int sym, int varDecl, int callExpr, int call,
+           int hookSym, int hookFn,
+           int retExpr, int retSym, int innerVarDecl |
+        (identExpr = valueExpr or Contains(valueExpr, identExpr)) and
+        ExprMayRef(identExpr, sym) and
+        VarDecl(varDecl, sym, callExpr, _) and
+        ExprIsCall(callExpr, call) and
+        CallCalleeSym(call, hookSym) and
+        FunctionSymbol(hookSym, hookFn) and
+        ReturnStmt(hookFn, _, retExpr) and
+        ExprMayRef(retExpr, retSym) and
+        VarDecl(innerVarDecl, retSym, objExpr, _) and
+        isObjectLiteralExpr(objExpr)
+    )
+}
+
+// Shape B — same as VarSame but cross-module hook resolution.
+predicate resolveToObjectExprHookReturnVarImported(int valueExpr, int objExpr) {
+    exists(int identExpr, int sym, int varDecl, int callExpr, int call,
+           int hookSym, int hookFn,
+           int retExpr, int retSym, int innerVarDecl |
+        (identExpr = valueExpr or Contains(valueExpr, identExpr)) and
+        ExprMayRef(identExpr, sym) and
+        VarDecl(varDecl, sym, callExpr, _) and
+        ExprIsCall(callExpr, call) and
+        CallCalleeSym(call, hookSym) and
+        importedFunctionSymbol(hookSym, hookFn) and
+        ReturnStmt(hookFn, _, retExpr) and
+        ExprMayRef(retExpr, retSym) and
+        VarDecl(innerVarDecl, retSym, objExpr, _) and
+        isObjectLiteralExpr(objExpr)
+    )
+}
+
+predicate resolveToObjectExprHookReturn(int valueExpr, int objExpr) {
+    resolveToObjectExprHookReturnDirectSame(valueExpr, objExpr)
+    or
+    resolveToObjectExprHookReturnDirectImported(valueExpr, objExpr)
+    or
+    resolveToObjectExprHookReturnVarSame(valueExpr, objExpr)
+    or
+    resolveToObjectExprHookReturnVarImported(valueExpr, objExpr)
+}
+
 predicate resolveToObjectExpr(int valueExpr, int objExpr) {
     resolveToObjectExprDirect(valueExpr, objExpr)
     or
@@ -566,6 +666,8 @@ predicate resolveToObjectExpr(int valueExpr, int objExpr) {
     resolveToObjectExprVarD1(valueExpr, objExpr)
     or
     resolveToObjectExprVarD2(valueExpr, objExpr)
+    or
+    resolveToObjectExprHookReturn(valueExpr, objExpr)
 }
 
 /**

--- a/bridge/tsq_react.qll
+++ b/bridge/tsq_react.qll
@@ -582,22 +582,24 @@ predicate resolveToObjectExprVarD2(int valueExpr, int objExpr) {
  */
 
 // Selectivity helper: `hookFn` directly returns ObjectLiteral `objExpr`.
-// Anchored on `isObjectLiteralExpr(objExpr)` (the small end) to keep planner
-// seeds tight — without this, joining ReturnStmt by hookFn first explodes on
-// real corpora (mastodon: `_disj_2` cap at step 6 of the unrolled join).
+// Seeded by `ReturnStmt` (small) before `isObjectLiteralExpr` (large in real
+// corpora). Mastodon has tens of thousands of object literals — anchoring on
+// the literal blew step 1 of the inner join past the 5M cap.
 predicate hookFnReturnsObjectLiteralDirect(int hookFn, int objExpr) {
-    isObjectLiteralExpr(objExpr) and
-    ReturnStmt(hookFn, _, objExpr)
+    ReturnStmt(hookFn, _, objExpr) and
+    isObjectLiteralExpr(objExpr)
 }
 
 // Selectivity helper: `hookFn` returns a var whose VarDecl init is
-// ObjectLiteral `objExpr`. Same anchor discipline.
+// ObjectLiteral `objExpr`. Seeded by `ReturnStmt` (small) — walks
+// retExpr → retSym → VarDecl init → ObjectLiteral gate. Same anchor
+// discipline as the direct helper.
 predicate hookFnReturnsObjectLiteralVar(int hookFn, int objExpr) {
-    exists(int retSym, int retExpr, int innerVarDecl |
-        isObjectLiteralExpr(objExpr) and
-        VarDecl(innerVarDecl, retSym, objExpr, _) and
+    exists(int retExpr, int retSym, int innerVarDecl |
+        ReturnStmt(hookFn, _, retExpr) and
         ExprMayRef(retExpr, retSym) and
-        ReturnStmt(hookFn, _, retExpr)
+        VarDecl(innerVarDecl, retSym, objExpr, _) and
+        isObjectLiteralExpr(objExpr)
     )
 }
 

--- a/bridge/tsq_react.qll
+++ b/bridge/tsq_react.qll
@@ -581,30 +581,10 @@ predicate resolveToObjectExprVarD2(int valueExpr, int objExpr) {
  * the hook body is intentionally out of scope for v1.
  */
 
-// Selectivity helper: `hookFn` directly returns ObjectLiteral `objExpr`.
-// Seeded by `ReturnStmt` (small) before `isObjectLiteralExpr` (large in real
-// corpora). Mastodon has tens of thousands of object literals — anchoring on
-// the literal blew step 1 of the inner join past the 5M cap.
-predicate hookFnReturnsObjectLiteralDirect(int hookFn, int objExpr) {
-    ReturnStmt(hookFn, _, objExpr) and
-    isObjectLiteralExpr(objExpr)
-}
-
-// Selectivity helper: `hookFn` returns a var whose VarDecl init is
-// ObjectLiteral `objExpr`. Seeded by `ReturnStmt` (small) — walks
-// retExpr → retSym → VarDecl init → ObjectLiteral gate. Same anchor
-// discipline as the direct helper.
-predicate hookFnReturnsObjectLiteralVar(int hookFn, int objExpr) {
-    exists(int retExpr, int retSym, int innerVarDecl |
-        ReturnStmt(hookFn, _, retExpr) and
-        ExprMayRef(retExpr, retSym) and
-        VarDecl(innerVarDecl, retSym, objExpr, _) and
-        isObjectLiteralExpr(objExpr)
-    )
-}
-
 // Caller-side seed: the value expression resolves to a CallExpression whose
 // callee symbol is `hookSym`. Shared across all four hook-return branches.
+// This is the SMALL end of the join — Provider value attributes that are
+// identifier-bound to a CallExpression are rare in real corpora.
 predicate valueExprCallsHook(int valueExpr, int hookSym) {
     exists(int identExpr, int sym, int varDecl, int callExpr, int call |
         (identExpr = valueExpr or Contains(valueExpr, identExpr)) and
@@ -615,51 +595,52 @@ predicate valueExprCallsHook(int valueExpr, int hookSym) {
     )
 }
 
-// Shape A — return expression IS the ObjectLiteral, same-module FunctionSymbol.
-predicate resolveToObjectExprHookReturnDirectSame(int valueExpr, int objExpr) {
-    exists(int hookSym, int hookFn |
-        hookFnReturnsObjectLiteralDirect(hookFn, objExpr) and
-        FunctionSymbol(hookSym, hookFn) and
-        valueExprCallsHook(valueExpr, hookSym)
+// Helper: `hookFn` is a function whose symbol is callable from
+// `valueExprCallsHook` (i.e. is the target of some Provider-value-side call).
+// Bridges the symbol layer once so the four resolveToObjectExprHookReturn*
+// branches share a single demand-seedable hookFn frontier rather than
+// re-walking the symbol table per return-shape.
+predicate hookFnInvokedByValueExpr(int valueExpr, int hookFn) {
+    exists(int hookSym |
+        valueExprCallsHook(valueExpr, hookSym) and
+        FunctionSymbol(hookSym, hookFn)
+    )
+    or
+    exists(int hookSym |
+        valueExprCallsHook(valueExpr, hookSym) and
+        importedFunctionSymbol(hookSym, hookFn)
     )
 }
 
-// Shape A — return expression IS the ObjectLiteral, cross-module import.
-predicate resolveToObjectExprHookReturnDirectImported(int valueExpr, int objExpr) {
-    exists(int hookSym, int hookFn |
-        hookFnReturnsObjectLiteralDirect(hookFn, objExpr) and
-        importedFunctionSymbol(hookSym, hookFn) and
-        valueExprCallsHook(valueExpr, hookSym)
+// Shape A — return expression IS the ObjectLiteral. Seeded from the value
+// side (`hookFnInvokedByValueExpr` constrains hookFn to actually-called
+// hooks), then the cheap `ReturnStmt + isObjectLiteralExpr` gate. Avoids
+// the cap-hit observed when seeding from `isObjectLiteralExpr` (~50k on
+// mastodon) or unbounded `ReturnStmt` ⨝ `ExprMayRef`.
+predicate resolveToObjectExprHookReturnDirect(int valueExpr, int objExpr) {
+    exists(int hookFn |
+        hookFnInvokedByValueExpr(valueExpr, hookFn) and
+        ReturnStmt(hookFn, _, objExpr) and
+        isObjectLiteralExpr(objExpr)
     )
 }
 
-// Shape B — return expression refs a sym whose VarDecl initialiser IS the
-// ObjectLiteral (`const actions = { ... }; return actions;`). Same-module.
-predicate resolveToObjectExprHookReturnVarSame(int valueExpr, int objExpr) {
-    exists(int hookSym, int hookFn |
-        hookFnReturnsObjectLiteralVar(hookFn, objExpr) and
-        FunctionSymbol(hookSym, hookFn) and
-        valueExprCallsHook(valueExpr, hookSym)
-    )
-}
-
-// Shape B — same as VarSame but cross-module hook resolution.
-predicate resolveToObjectExprHookReturnVarImported(int valueExpr, int objExpr) {
-    exists(int hookSym, int hookFn |
-        hookFnReturnsObjectLiteralVar(hookFn, objExpr) and
-        importedFunctionSymbol(hookSym, hookFn) and
-        valueExprCallsHook(valueExpr, hookSym)
+// Shape B — return expression refs a sym whose VarDecl init IS the
+// ObjectLiteral. Same value-side seed; inner var-rebind hop is depth-1 only.
+predicate resolveToObjectExprHookReturnVar(int valueExpr, int objExpr) {
+    exists(int hookFn, int retExpr, int retSym, int innerVarDecl |
+        hookFnInvokedByValueExpr(valueExpr, hookFn) and
+        ReturnStmt(hookFn, _, retExpr) and
+        ExprMayRef(retExpr, retSym) and
+        VarDecl(innerVarDecl, retSym, objExpr, _) and
+        isObjectLiteralExpr(objExpr)
     )
 }
 
 predicate resolveToObjectExprHookReturn(int valueExpr, int objExpr) {
-    resolveToObjectExprHookReturnDirectSame(valueExpr, objExpr)
+    resolveToObjectExprHookReturnDirect(valueExpr, objExpr)
     or
-    resolveToObjectExprHookReturnDirectImported(valueExpr, objExpr)
-    or
-    resolveToObjectExprHookReturnVarSame(valueExpr, objExpr)
-    or
-    resolveToObjectExprHookReturnVarImported(valueExpr, objExpr)
+    resolveToObjectExprHookReturnVar(valueExpr, objExpr)
 }
 
 predicate resolveToObjectExpr(int valueExpr, int objExpr) {

--- a/bridge/tsq_react.qll
+++ b/bridge/tsq_react.qll
@@ -581,70 +581,72 @@ predicate resolveToObjectExprVarD2(int valueExpr, int objExpr) {
  * the hook body is intentionally out of scope for v1.
  */
 
-// Shape A — return expression IS the ObjectLiteral, same-module FunctionSymbol.
-predicate resolveToObjectExprHookReturnDirectSame(int valueExpr, int objExpr) {
-    exists(int identExpr, int sym, int varDecl, int callExpr, int call,
-           int hookSym, int hookFn |
+// Selectivity helper: `hookFn` directly returns ObjectLiteral `objExpr`.
+// Anchored on `isObjectLiteralExpr(objExpr)` (the small end) to keep planner
+// seeds tight — without this, joining ReturnStmt by hookFn first explodes on
+// real corpora (mastodon: `_disj_2` cap at step 6 of the unrolled join).
+predicate hookFnReturnsObjectLiteralDirect(int hookFn, int objExpr) {
+    isObjectLiteralExpr(objExpr) and
+    ReturnStmt(hookFn, _, objExpr)
+}
+
+// Selectivity helper: `hookFn` returns a var whose VarDecl init is
+// ObjectLiteral `objExpr`. Same anchor discipline.
+predicate hookFnReturnsObjectLiteralVar(int hookFn, int objExpr) {
+    exists(int retSym, int retExpr, int innerVarDecl |
+        isObjectLiteralExpr(objExpr) and
+        VarDecl(innerVarDecl, retSym, objExpr, _) and
+        ExprMayRef(retExpr, retSym) and
+        ReturnStmt(hookFn, _, retExpr)
+    )
+}
+
+// Caller-side seed: the value expression resolves to a CallExpression whose
+// callee symbol is `hookSym`. Shared across all four hook-return branches.
+predicate valueExprCallsHook(int valueExpr, int hookSym) {
+    exists(int identExpr, int sym, int varDecl, int callExpr, int call |
         (identExpr = valueExpr or Contains(valueExpr, identExpr)) and
         ExprMayRef(identExpr, sym) and
         VarDecl(varDecl, sym, callExpr, _) and
         ExprIsCall(callExpr, call) and
-        CallCalleeSym(call, hookSym) and
+        CallCalleeSym(call, hookSym)
+    )
+}
+
+// Shape A — return expression IS the ObjectLiteral, same-module FunctionSymbol.
+predicate resolveToObjectExprHookReturnDirectSame(int valueExpr, int objExpr) {
+    exists(int hookSym, int hookFn |
+        hookFnReturnsObjectLiteralDirect(hookFn, objExpr) and
         FunctionSymbol(hookSym, hookFn) and
-        ReturnStmt(hookFn, _, objExpr) and
-        isObjectLiteralExpr(objExpr)
+        valueExprCallsHook(valueExpr, hookSym)
     )
 }
 
 // Shape A — return expression IS the ObjectLiteral, cross-module import.
 predicate resolveToObjectExprHookReturnDirectImported(int valueExpr, int objExpr) {
-    exists(int identExpr, int sym, int varDecl, int callExpr, int call,
-           int hookSym, int hookFn |
-        (identExpr = valueExpr or Contains(valueExpr, identExpr)) and
-        ExprMayRef(identExpr, sym) and
-        VarDecl(varDecl, sym, callExpr, _) and
-        ExprIsCall(callExpr, call) and
-        CallCalleeSym(call, hookSym) and
+    exists(int hookSym, int hookFn |
+        hookFnReturnsObjectLiteralDirect(hookFn, objExpr) and
         importedFunctionSymbol(hookSym, hookFn) and
-        ReturnStmt(hookFn, _, objExpr) and
-        isObjectLiteralExpr(objExpr)
+        valueExprCallsHook(valueExpr, hookSym)
     )
 }
 
 // Shape B — return expression refs a sym whose VarDecl initialiser IS the
 // ObjectLiteral (`const actions = { ... }; return actions;`). Same-module.
 predicate resolveToObjectExprHookReturnVarSame(int valueExpr, int objExpr) {
-    exists(int identExpr, int sym, int varDecl, int callExpr, int call,
-           int hookSym, int hookFn,
-           int retExpr, int retSym, int innerVarDecl |
-        (identExpr = valueExpr or Contains(valueExpr, identExpr)) and
-        ExprMayRef(identExpr, sym) and
-        VarDecl(varDecl, sym, callExpr, _) and
-        ExprIsCall(callExpr, call) and
-        CallCalleeSym(call, hookSym) and
+    exists(int hookSym, int hookFn |
+        hookFnReturnsObjectLiteralVar(hookFn, objExpr) and
         FunctionSymbol(hookSym, hookFn) and
-        ReturnStmt(hookFn, _, retExpr) and
-        ExprMayRef(retExpr, retSym) and
-        VarDecl(innerVarDecl, retSym, objExpr, _) and
-        isObjectLiteralExpr(objExpr)
+        valueExprCallsHook(valueExpr, hookSym)
     )
 }
 
 // Shape B — same as VarSame but cross-module hook resolution.
 predicate resolveToObjectExprHookReturnVarImported(int valueExpr, int objExpr) {
-    exists(int identExpr, int sym, int varDecl, int callExpr, int call,
-           int hookSym, int hookFn,
-           int retExpr, int retSym, int innerVarDecl |
-        (identExpr = valueExpr or Contains(valueExpr, identExpr)) and
-        ExprMayRef(identExpr, sym) and
-        VarDecl(varDecl, sym, callExpr, _) and
-        ExprIsCall(callExpr, call) and
-        CallCalleeSym(call, hookSym) and
+    exists(int hookSym, int hookFn |
+        hookFnReturnsObjectLiteralVar(hookFn, objExpr) and
         importedFunctionSymbol(hookSym, hookFn) and
-        ReturnStmt(hookFn, _, retExpr) and
-        ExprMayRef(retExpr, retSym) and
-        VarDecl(innerVarDecl, retSym, objExpr, _) and
-        isObjectLiteralExpr(objExpr)
+        valueExprCallsHook(valueExpr, hookSym)
     )
 }
 

--- a/setstate_context_alias_r4_integration_test.go
+++ b/setstate_context_alias_r4_integration_test.go
@@ -1,0 +1,131 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gjdoalfnrxu/tsq/bridge"
+	extractrules "github.com/Gjdoalfnrxu/tsq/extract/rules"
+	"github.com/Gjdoalfnrxu/tsq/extract/schema"
+	"github.com/Gjdoalfnrxu/tsq/ql/desugar"
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+	"github.com/Gjdoalfnrxu/tsq/ql/parse"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+	"github.com/Gjdoalfnrxu/tsq/ql/resolve"
+)
+
+// TestSetStateUpdaterCallsOtherSetStateThroughContext_R4 is the round-4
+// positive regression test. It exercises the factory-hook-return shape:
+// the Provider's `value={actions}` resolves to an ObjectLiteral via a
+// CallExpression initialiser (the hook), which round-3's
+// `resolveToObjectExpr` did not handle.
+//
+// Two return shapes are exercised:
+//   - Actions.tsx + Consumer.tsx: hook returns a VarDecl-bound ObjectLiteral
+//     (`const actions = {...}; return actions;`).
+//   - DirectReturn.tsx: hook returns the ObjectLiteral directly
+//     (`return { setDA, setDB };`).
+//
+// Negative.tsx must contribute zero rows.
+func TestSetStateUpdaterCallsOtherSetStateThroughContext_R4(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping extraction-heavy integration test in short mode")
+	}
+
+	factDB := extractProject(t, "testdata/projects/react-usestate-context-alias-r4")
+
+	src, err := os.ReadFile("testdata/queries/v2/find_setstate_updater_calls_other_setstate_through_context.ql")
+	if err != nil {
+		t.Fatalf("read query: %v", err)
+	}
+
+	bridgeFiles := bridge.LoadBridge()
+	importLoader := makeBridgeImportLoader(bridgeFiles)
+
+	p := parse.NewParser(string(src), "find_setstate_updater_calls_other_setstate_through_context.ql")
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	resolved, err := resolve.Resolve(mod, importLoader)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(resolved.Errors) > 0 {
+		t.Fatalf("resolve errors: %v", resolved.Errors)
+	}
+	prog, dsErrors := desugar.Desugar(resolved)
+	if len(dsErrors) > 0 {
+		t.Fatalf("desugar: %v", dsErrors)
+	}
+	prog = extractrules.MergeSystemRules(prog, extractrules.AllSystemRules())
+
+	hints := make(map[string]int, len(schema.Registry))
+	for _, def := range schema.Registry {
+		hints[def.Name] = factDB.Relation(def.Name).Tuples()
+	}
+
+	const cap = 200_000
+
+	baseRels, err := eval.LoadBaseRelations(factDB)
+	if err != nil {
+		t.Fatalf("load base relations: %v", err)
+	}
+	execPlan, planErrs := plan.EstimateAndPlan(
+		prog,
+		hints,
+		cap,
+		eval.MakeEstimatorHook(baseRels),
+		plan.Plan,
+	)
+	if len(planErrs) > 0 {
+		t.Fatalf("plan: %v", planErrs)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	rs, err := eval.Evaluate(
+		ctx,
+		execPlan,
+		baseRels,
+		eval.WithMaxBindingsPerRule(cap),
+		eval.WithSizeHints(hints),
+	)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+
+	hits := map[string]int{
+		"Consumer.tsx":     0,
+		"DirectReturn.tsx": 0,
+		"Negative.tsx":     0,
+	}
+	for _, row := range rs.Rows {
+		for _, cell := range row {
+			s := fmt.Sprintf("%v", cell)
+			for fname := range hits {
+				if strings.Contains(s, fname) {
+					hits[fname]++
+					break
+				}
+			}
+		}
+	}
+
+	if hits["Consumer.tsx"] < 1 {
+		t.Errorf("expected >=1 match in Consumer.tsx (FactoryConsumer hook-return-via-VarDecl), got %d (rows=%v)", hits["Consumer.tsx"], rs.Rows)
+	}
+	if hits["DirectReturn.tsx"] < 1 {
+		t.Errorf("expected >=1 match in DirectReturn.tsx (DirectFactoryConsumer hook-return-direct), got %d (rows=%v)", hits["DirectReturn.tsx"], rs.Rows)
+	}
+	if hits["Negative.tsx"] > 0 {
+		t.Errorf("Negative.tsx unexpectedly matched %d times: rows=%v", hits["Negative.tsx"], rs.Rows)
+	}
+	t.Logf("R4 matches: total=%d Consumer=%d DirectReturn=%d Negative=%d",
+		len(rs.Rows), hits["Consumer.tsx"], hits["DirectReturn.tsx"], hits["Negative.tsx"])
+}

--- a/testdata/projects/react-usestate-context-alias-r4/Actions.tsx
+++ b/testdata/projects/react-usestate-context-alias-r4/Actions.tsx
@@ -1,0 +1,51 @@
+// Round-4 case A: factory hook returning an ObjectLiteral.
+//
+//   function useActions() {
+//     const [conf, setConf] = useState(initial);
+//     const actions = { setConf, setOther };
+//     return actions;                       // <-- hook returns variable
+//   }                                       //     bound to ObjectLiteral
+//
+//   function Provider({ children }) {
+//     const actions = useActions();         // <-- VarDecl initialiser is a CALL
+//     return <Ctx.Provider value={actions}>{children}</Ctx.Provider>;
+//   }
+//
+// Round-3's `resolveToObjectExpr` only resolved through VarDecl initialisers
+// that were themselves ObjectLiterals (or chains of plain Identifier
+// indirections). When the initialiser is a CallExpression (factory hook),
+// the chain dies. Round-4 must follow the call into the hook's return
+// statement and resolve to the returned ObjectLiteral.
+
+import { useState, createContext, ReactNode } from 'react';
+
+interface FactoryActions {
+  setFA: (updater: (prev: number) => number) => void;
+  setFB: (updater: (prev: number) => number) => void;
+}
+
+export const FactoryCtx = createContext<FactoryActions | null>(null);
+
+// Factory hook: holds the useState pair locally and returns an actions object.
+// Two return shapes need to be supported:
+//   1. `return { setFA, setFB };` — return expression IS the ObjectLiteral.
+//   2. `return actions;` where `const actions = { ... };` was bound earlier.
+// We exercise shape (2) here (the harder one).
+export function useFactoryActions(): FactoryActions {
+  const [a, setFA] = useState(0);
+  const [b, setFB] = useState(0);
+  void a;
+  void b;
+  const actions = { setFA, setFB };
+  return actions;
+}
+
+export function FactoryProvider({ children }: { children: ReactNode }) {
+  // The Provider's value attribute resolves to the hook call's returned
+  // ObjectLiteral. Round-3's chain died here because `actions` is bound to
+  // a CallExpression, not an ObjectLiteral.
+  const actions = useFactoryActions();
+  return (
+    <FactoryCtx.Provider value={actions}>{children}</FactoryCtx.Provider>
+  );
+}

--- a/testdata/projects/react-usestate-context-alias-r4/Consumer.tsx
+++ b/testdata/projects/react-usestate-context-alias-r4/Consumer.tsx
@@ -1,0 +1,29 @@
+// Consumer for round-4. The setters arrive through a context whose
+// Provider value is bound to the result of a factory hook call:
+//
+//   const actions = useFactoryActions();
+//   <FactoryCtx.Provider value={actions}>
+//
+// Round-3's `resolveToObjectExpr` died at this hop because `actions` is
+// bound to a CallExpression, not an ObjectLiteral. Round-4 follows the
+// call into the hook's return statement (`const actions = { ... };
+// return actions;` — VarDecl-bound shape).
+
+import { useFactoryActionsCtx } from './Hook';
+
+export function FactoryConsumer() {
+  const { setFA, setFB } = useFactoryActionsCtx()!;
+  return (
+    <button
+      onClick={() => {
+        setFA(prev => {
+          // Inner setter setFB arrived through the same factory hook return.
+          setFB(p => p + 1);
+          return prev + 1;
+        });
+      }}
+    >
+      factory
+    </button>
+  );
+}

--- a/testdata/projects/react-usestate-context-alias-r4/DirectReturn.tsx
+++ b/testdata/projects/react-usestate-context-alias-r4/DirectReturn.tsx
@@ -1,0 +1,49 @@
+// Round-4 case B: factory hook returning an ObjectLiteral DIRECTLY (no
+// intermediate VarDecl):
+//
+//   function useDirectActions() {
+//     const [a, setDA] = useState(0);
+//     const [b, setDB] = useState(0);
+//     return { setDA, setDB };          // <-- return IS the ObjectLiteral
+//   }
+//
+// Exercises `resolveToObjectExprHookReturnDirectSame` (the simpler shape
+// of the round-4 fix). Same-module hook resolution.
+
+import { useState, useContext, createContext, ReactNode } from 'react';
+
+interface DirectActions {
+  setDA: (updater: (prev: number) => number) => void;
+  setDB: (updater: (prev: number) => number) => void;
+}
+
+const DirectCtx = createContext<DirectActions | null>(null);
+
+function useDirectActions(): DirectActions {
+  const [a, setDA] = useState(0);
+  const [b, setDB] = useState(0);
+  void a;
+  void b;
+  return { setDA, setDB };
+}
+
+export function DirectFactoryProvider({ children }: { children: ReactNode }) {
+  const actions = useDirectActions();
+  return <DirectCtx.Provider value={actions}>{children}</DirectCtx.Provider>;
+}
+
+export function DirectFactoryConsumer() {
+  const { setDA, setDB } = useContext(DirectCtx)!;
+  return (
+    <button
+      onClick={() => {
+        setDA(prev => {
+          setDB(p => p + 1);
+          return prev + 1;
+        });
+      }}
+    >
+      direct
+    </button>
+  );
+}

--- a/testdata/projects/react-usestate-context-alias-r4/Hook.tsx
+++ b/testdata/projects/react-usestate-context-alias-r4/Hook.tsx
@@ -1,0 +1,9 @@
+// Cross-module hook indirection re-export of useContext for the FactoryCtx.
+// Mirrors round-2's Hook.tsx so we exercise the existing
+// `useContextCallSiteResolvesContext` path for the consumer destructure.
+import { useContext } from 'react';
+import { FactoryCtx } from './Actions';
+
+export function useFactoryActionsCtx() {
+  return useContext(FactoryCtx);
+}

--- a/testdata/projects/react-usestate-context-alias-r4/Negative.tsx
+++ b/testdata/projects/react-usestate-context-alias-r4/Negative.tsx
@@ -1,0 +1,54 @@
+// Negative fixtures for round-4: hook-return resolution must NOT match these.
+
+import { useState, useContext, createContext, ReactNode } from 'react';
+
+interface NegActions {
+  setNA: (updater: (prev: number) => number) => void;
+}
+
+const NegCtx = createContext<NegActions | null>(null);
+
+// (N1) Hook returns a NON-object (a number). resolveToObjectExprHookReturn
+// must not surface anything for the consumer below.
+function useNegNumber(): number {
+  const [n, setNA] = useState(0);
+  void setNA;
+  return n;
+}
+
+export function NegNumberProvider({ children }: { children: ReactNode }) {
+  // value is a primitive. ObjectLiteral resolution must not trigger.
+  const value = useNegNumber();
+  void value;
+  return <NegCtx.Provider value={null}>{children}</NegCtx.Provider>;
+}
+
+// (N2) Hook with conditional return — one branch is an ObjectLiteral, the
+// other is null. Single-branch over-approximation is acceptable (it's an
+// over-approximation matching round-1/2/3 conventions), but the consumer
+// here doesn't even hit the chain because the Provider value is null.
+function useMaybeActions(): NegActions | null {
+  const [n, setNA] = useState(0);
+  void n;
+  if (Math.random() > 0.5) {
+    return { setNA };
+  }
+  return null;
+}
+
+export function MaybeProvider({ children }: { children: ReactNode }) {
+  const actions = useMaybeActions();
+  void actions;
+  // Deliberately bind value to literal null so the consumer chain dies
+  // upstream of resolveToObjectExpr.
+  return <NegCtx.Provider value={null}>{children}</NegCtx.Provider>;
+}
+
+export function NegConsumer() {
+  const v = useContext(NegCtx);
+  void v;
+  // No setter calls — purely a non-match consumer, ensures useState setters
+  // wired up in the providers above don't get spuriously surfaced through
+  // unrelated chains.
+  return null;
+}


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Summary

Round-3 extended `resolveToObjectExpr` to walk through VarDecl-bound `ObjectLiteral` initialisers, but it stopped at the first `CallExpression`. The very common factory-hook pattern dies at exactly that hop:

```tsx
function useActions() {
  const actions = { setX, setY };
  return actions;                          // or: return { setX, setY };
}

function Provider({ children }) {
  const actions = useActions();            // VarDecl init is a CALL, not an ObjectLiteral
  return <Ctx.Provider value={actions}>{children}</Ctx.Provider>;
}
```

The through-context query missed every Provider whose `value` was the result of a hook call, regardless of how cleanly the hook returned the actions object.

## Fix

New branch `resolveToObjectExprHookReturn` on `resolveToObjectExpr`. It follows the call into the hook's return statement and resolves to the returned `ObjectLiteral`. Two return shapes are recognised:

- **Shape A (direct):** `return { setX, setY };` — return expression IS the `ObjectLiteral`.
- **Shape B (var-bound):** `const actions = { ... }; return actions;` — return refs a sym whose VarDecl initialiser is the `ObjectLiteral`. Hand-bounded to depth-1 var rebind inside the hook body.

Each shape is split into a `FunctionSymbol` (same-module) and `importedFunctionSymbol` (cross-module) variant, mirroring the pair already used by `useContextCallSiteResolvesContext`. The four named sub-branches are union'd at the predicate boundary so the top-level disjunction is `or`-of-calls — same #166 workaround discipline as round-3, no `_disj_N` cap-hit risk.

Bridge-only change. No schema changes, no extractor changes.

## Test plan

- [x] New fixture `testdata/projects/react-usestate-context-alias-r4/`:
  - `Actions.tsx` + `Consumer.tsx` — shape B (VarDecl-bound) with cross-module hook indirection (`Hook.tsx`)
  - `DirectReturn.tsx` — shape A (direct `return { ... }`)
  - `Negative.tsx` — hook returning a primitive / hook with conditional return where Provider value is `null`
- [x] `TestSetStateUpdaterCallsOtherSetStateThroughContext_R4` — Consumer ≥1, DirectReturn ≥1, Negative = 0. Local: `Consumer=1 DirectReturn=1 Negative=0`.
- [x] R2 (`_Positive`) and R3 (`_R3`) regression: still pass, row counts unchanged.
- [x] Full `go test ./...` green locally.
- [ ] CI green.
- [ ] Real-corpus run on cain-nas terminates without `_disj_N` cap-hit, row count ≥ pre-merge baseline.