### PR TITLE
fix(planner): per-branch lifting for _disj_N (#166)

### DIFF
--- a/ql/desugar/desugar.go
+++ b/ql/desugar/desugar.go
@@ -621,33 +621,74 @@ func (d *desugarer) desugarFormula(f ast.Formula, gen *freshVarGen) []datalog.Li
 		return append(left, right...)
 
 	case *ast.Disjunction:
-		// Rule splitting: create a synthetic predicate with both branches as separate rules.
+		// Per-branch lifting (#166): each branch gets its own named IDB
+		// carrying its FULL var set, then a union IDB projects the
+		// shared vars. This lets the planner size each branch
+		// independently (current default behaviour can't see across
+		// the two-rule union and produces wildly wrong cardinality
+		// estimates — see ql/plan/disj2_round[2-6]_*_test.go).
+		//
+		//   _disj_N_l(LV...)  :- leftBody.
+		//   _disj_N_r(RV...)  :- rightBody.
+		//   _disj_N(SV...)    :- _disj_N_l(LV...).   // project to shared vars
+		//   _disj_N(SV...)    :- _disj_N_r(RV...).   // project to shared vars
+		//
+		// where SV = intersect(LV, RV).
 		leftLits := d.desugarFormula(n.Left, gen)
 		rightLits := d.desugarFormula(n.Right, gen)
 
-		// Use only variables that appear in BOTH branches as head args.
-		// Variables in only one branch are unsafe in the other rule's head.
-		leftVars := collectVarsFromLiterals(leftLits)
-		rightVars := collectVarsFromLiterals(rightLits)
-		freeVars := intersectVars(leftVars, rightVars)
+		// `_` is a wildcard placeholder that the parser sometimes lowers
+		// as a Var with name "_" (rather than datalog.Wildcard{}).
+		// Including it in a per-branch IDB head would unify all
+		// occurrences in the body, which is wrong. Filter it out here so
+		// each `_` stays a local don't-care in the branch body. Note the
+		// pre-lifting code never hit this because the union head was
+		// `intersect(leftVars, rightVars)`, and `_` was usually
+		// asymmetric across branches; per-branch heads bypass that
+		// implicit filter.
+		leftVars := filterUnderscore(collectVarsFromLiterals(leftLits))
+		rightVars := filterUnderscore(collectVarsFromLiterals(rightLits))
+		sharedVars := intersectVars(leftVars, rightVars)
 
-		synthName := d.freshSynthName("_disj")
-		args := make([]datalog.Term, len(freeVars))
-		for i, v := range freeVars {
-			args[i] = datalog.Var{Name: v}
+		// Allocate union name first so that, in nested-disjunction
+		// debugging, the visible call name (`_disj_N`) keeps the lowest
+		// counter for the disjunction. The branch IDBs get derived
+		// names rather than fresh counter slots — this also avoids
+		// burning two extra counter values per disjunction in plan
+		// dumps.
+		unionName := d.freshSynthName("_disj")
+		leftName := unionName + "_l"
+		rightName := unionName + "_r"
+
+		termsForVars := func(vars []string) []datalog.Term {
+			args := make([]datalog.Term, len(vars))
+			for i, v := range vars {
+				args[i] = datalog.Var{Name: v}
+			}
+			return args
 		}
 
-		// Create two rules: one for left branch, one for right branch.
-		head := datalog.Atom{Predicate: synthName, Args: args}
+		leftHead := datalog.Atom{Predicate: leftName, Args: termsForVars(leftVars)}
+		rightHead := datalog.Atom{Predicate: rightName, Args: termsForVars(rightVars)}
+		unionHead := datalog.Atom{Predicate: unionName, Args: termsForVars(sharedVars)}
+
+		// Per-branch IDBs carry full var sets so the planner can size
+		// each branch independently.
 		d.syntheticRules = append(d.syntheticRules,
-			datalog.Rule{Head: head, Body: leftLits},
-			datalog.Rule{Head: head, Body: rightLits},
+			datalog.Rule{Head: leftHead, Body: leftLits},
+			datalog.Rule{Head: rightHead, Body: rightLits},
+			// Union IDB: trivial-IDB projection from each branch.
+			// P2a's class-extent shortcut handles this exact shape
+			// (head with body = single positive atom).
+			datalog.Rule{Head: unionHead, Body: []datalog.Literal{{Positive: true, Atom: leftHead}}},
+			datalog.Rule{Head: unionHead, Body: []datalog.Literal{{Positive: true, Atom: rightHead}}},
 		)
 
-		// Return a call to the synthetic predicate.
+		// Caller boundary unchanged: still sees a single _disj_N(SV...)
+		// literal over the shared vars only.
 		return []datalog.Literal{{
 			Positive: true,
-			Atom:     datalog.Atom{Predicate: synthName, Args: args},
+			Atom:     datalog.Atom{Predicate: unionName, Args: termsForVars(sharedVars)},
 		}}
 
 	case *ast.Negation:
@@ -1334,6 +1375,22 @@ func collectVarFromTerm(t datalog.Term, seen map[string]bool, vars *[]string) {
 			*vars = append(*vars, v.Name)
 		}
 	}
+}
+
+// filterUnderscore drops the wildcard placeholder name "_" from a var
+// list. The parser sometimes lowers `_` as datalog.Var{Name:"_"} rather
+// than datalog.Wildcard{}, and per-branch IDB heads must not promote a
+// wildcard into a real positional binding (it would force all `_`
+// occurrences in the body to unify to the same value).
+func filterUnderscore(vars []string) []string {
+	out := vars[:0:0]
+	for _, v := range vars {
+		if v == "_" {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
 }
 
 // intersectVars returns variables present in both a and b, preserving order from a.

--- a/ql/desugar/desugar_test.go
+++ b/ql/desugar/desugar_test.go
@@ -873,15 +873,17 @@ predicate test(Foo x) { a(x) or b(x) }
 		}
 	}
 
-	// Should have synthetic _disj rules.
+	// Should have synthetic _disj rules. Per-branch lifting (#166)
+	// produces 4 rules per disjunction: 2 per-branch IDBs (`_disj_N_l`,
+	// `_disj_N_r`) and 2 union projection rules (`_disj_N`).
 	var disjRules []*datalog.Rule
 	for i := range prog.Rules {
 		if strings.HasPrefix(prog.Rules[i].Head.Predicate, "_disj") {
 			disjRules = append(disjRules, &prog.Rules[i])
 		}
 	}
-	if len(disjRules) != 2 {
-		t.Fatalf("expected 2 synthetic disjunction rules, got %d", len(disjRules))
+	if len(disjRules) != 4 {
+		t.Fatalf("expected 4 synthetic disjunction rules (2 branch + 2 union), got %d", len(disjRules))
 	}
 
 	// The test predicate's body should reference the synthetic predicate.
@@ -1093,21 +1095,34 @@ predicate test(int x) { a(x, _) or b(x) }
 	rm := parseAndResolve(t, src)
 	prog := desugarOK(t, rm)
 
-	// Find the synthetic disjunction rule.
-	var synthRules []*datalog.Rule
+	// Find the synthetic union rule(s) — head named `_disj_N` exactly
+	// (not `_disj_N_l` / `_disj_N_r`). Per-branch lifting (#166) means
+	// the per-branch IDBs carry FULL var sets (so `_disj_N_l` includes
+	// `y`); only the union projection enforces the shared-vars-only head.
+	var unionRules []*datalog.Rule
+	var branchRules []*datalog.Rule
 	for i := range prog.Rules {
-		if strings.HasPrefix(prog.Rules[i].Head.Predicate, "_disj") {
-			synthRules = append(synthRules, &prog.Rules[i])
+		name := prog.Rules[i].Head.Predicate
+		if !strings.HasPrefix(name, "_disj") {
+			continue
+		}
+		if strings.HasSuffix(name, "_l") || strings.HasSuffix(name, "_r") {
+			branchRules = append(branchRules, &prog.Rules[i])
+		} else {
+			unionRules = append(unionRules, &prog.Rules[i])
 		}
 	}
-	if len(synthRules) != 2 {
-		t.Fatalf("expected 2 synthetic disjunction rules, got %d", len(synthRules))
+	if len(unionRules) != 2 {
+		t.Fatalf("expected 2 union projection rules, got %d", len(unionRules))
 	}
-	// Head args should only contain x (the shared variable), not y or _.
-	for _, r := range synthRules {
+	if len(branchRules) != 2 {
+		t.Fatalf("expected 2 per-branch IDB rules, got %d", len(branchRules))
+	}
+	// Union head args should only contain x (the shared variable), not y or _.
+	for _, r := range unionRules {
 		for _, arg := range r.Head.Args {
 			if v, ok := arg.(datalog.Var); ok && v.Name != "x" {
-				t.Errorf("synthetic disjunction head should only have shared var x, got %q", v.Name)
+				t.Errorf("union disjunction head should only have shared var x, got %q", v.Name)
 			}
 		}
 	}

--- a/ql/desugar/disjunction_lifting_test.go
+++ b/ql/desugar/disjunction_lifting_test.go
@@ -1,0 +1,229 @@
+package desugar_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/datalog"
+)
+
+// classifyDisj splits the synthetic disjunction rules into per-branch
+// IDBs (`_disj_N_l` / `_disj_N_r`) and union projection rules
+// (`_disj_N`). After per-branch lifting (#166), every disjunction
+// produces 2 of each.
+func classifyDisj(prog *datalog.Program) (branch, union []*datalog.Rule) {
+	for i := range prog.Rules {
+		name := prog.Rules[i].Head.Predicate
+		if !strings.HasPrefix(name, "_disj_") {
+			continue
+		}
+		if strings.HasSuffix(name, "_l") || strings.HasSuffix(name, "_r") {
+			branch = append(branch, &prog.Rules[i])
+		} else {
+			union = append(union, &prog.Rules[i])
+		}
+	}
+	return
+}
+
+// TestLiftedDisjunction_FiresOnSimpleDisjunction is the basic shape
+// check: a single `or` produces 2 per-branch IDBs + 2 union projection
+// rules. The caller boundary still sees a single union literal.
+func TestLiftedDisjunction_FiresOnSimpleDisjunction(t *testing.T) {
+	src := `
+class Foo { Foo() { any() } }
+predicate p(Foo x) { a(x) or b(x) }
+`
+	prog := desugarOK(t, parseAndResolve(t, src))
+	branch, union := classifyDisj(prog)
+
+	if len(branch) != 2 {
+		t.Fatalf("expected 2 per-branch IDB rules, got %d", len(branch))
+	}
+	if len(union) != 2 {
+		t.Fatalf("expected 2 union projection rules, got %d", len(union))
+	}
+	// Both union rules must have the same head predicate name.
+	if union[0].Head.Predicate != union[1].Head.Predicate {
+		t.Errorf("union rules disagree on head name: %q vs %q",
+			union[0].Head.Predicate, union[1].Head.Predicate)
+	}
+	// Each union rule body is a single positive literal — the
+	// "trivial-IDB projection" shape that P2a class-extent sizing
+	// covers without new planner code.
+	for _, r := range union {
+		if len(r.Body) != 1 || !r.Body[0].Positive {
+			t.Errorf("union rule body should be a single positive literal, got %+v", r.Body)
+		}
+		callee := r.Body[0].Atom.Predicate
+		if !strings.HasSuffix(callee, "_l") && !strings.HasSuffix(callee, "_r") {
+			t.Errorf("union rule body should call a per-branch IDB, got %q", callee)
+		}
+	}
+}
+
+// TestLiftedDisjunction_PerBranchHeadCarriesFullVars verifies the
+// load-bearing #166 invariant: the per-branch IDB head retains its
+// full var set (so the planner can size each branch independently),
+// while the union head still projects to the shared-vars-only
+// intersection seen by the caller.
+func TestLiftedDisjunction_PerBranchHeadCarriesFullVars(t *testing.T) {
+	src := `
+predicate a(int x, int y) { any() }
+predicate b(int x, int z) { any() }
+predicate test(int x) { a(x, _) or b(x, _) }
+`
+	prog := desugarOK(t, parseAndResolve(t, src))
+	branch, union := classifyDisj(prog)
+
+	if len(branch) != 2 || len(union) != 2 {
+		t.Fatalf("expected 2 branch + 2 union, got %d/%d", len(branch), len(union))
+	}
+
+	// Union heads carry only `x` (the shared var). `_` is wildcard
+	// and must NEVER appear as a positional binding.
+	for _, r := range union {
+		if len(r.Head.Args) != 1 {
+			t.Errorf("union head should have exactly 1 arg (shared `x`), got %d", len(r.Head.Args))
+		}
+		for _, arg := range r.Head.Args {
+			if v, ok := arg.(datalog.Var); ok {
+				if v.Name != "x" {
+					t.Errorf("union head arg should be `x`, got %q", v.Name)
+				}
+			}
+		}
+	}
+
+	// Per-branch heads carry the full visible var set (still excluding
+	// the wildcard `_` placeholder — wildcards must never become
+	// positional bindings).
+	for _, r := range branch {
+		for _, arg := range r.Head.Args {
+			if v, ok := arg.(datalog.Var); ok && v.Name == "_" {
+				t.Errorf("branch head must not contain wildcard `_` as a positional binding (rule %s)",
+					r.Head.Predicate)
+			}
+		}
+	}
+}
+
+// TestLiftedDisjunction_NestedDisjunctionsCompose verifies that two
+// nested disjunctions (`a or b or c`) compose correctly: each level of
+// disjunction adds its own per-branch lifting, so a 3-way disjunction
+// yields 4 branch IDBs + 4 union rules across two _disj_N predicates.
+func TestLiftedDisjunction_NestedDisjunctionsCompose(t *testing.T) {
+	src := `
+predicate a(int x) { any() }
+predicate b(int x) { any() }
+predicate c(int x) { any() }
+predicate test(int x) { a(x) or b(x) or c(x) }
+`
+	prog := desugarOK(t, parseAndResolve(t, src))
+	branch, union := classifyDisj(prog)
+
+	if len(branch) != 4 {
+		t.Fatalf("expected 4 per-branch IDB rules (2 per disjunction node), got %d", len(branch))
+	}
+	if len(union) != 4 {
+		t.Fatalf("expected 4 union projection rules (2 per disjunction node), got %d", len(union))
+	}
+}
+
+// TestLiftedDisjunction_TenBranches is the §6.5 plan gate: a wide
+// disjunction (the value-flow shape that motivated #166) lifts to one
+// IDB per branch. Each branch can then be sized independently by the
+// existing planner machinery without falling back to the 1000-row
+// default that breaks join ordering on synthesised unions.
+func TestLiftedDisjunction_TenBranches(t *testing.T) {
+	// Build a 10-branch disjunction inline.
+	branches := []string{}
+	for i := 0; i < 10; i++ {
+		branches = append(branches, "p(x)")
+	}
+	src := "predicate p(int x) { any() }\n" +
+		"predicate test(int x) { " + strings.Join(branches, " or ") + " }\n"
+
+	prog := desugarOK(t, parseAndResolve(t, src))
+	branch, union := classifyDisj(prog)
+
+	// 10 branches → 9 disjunction nodes (right-associated parse) →
+	// 9 * 2 = 18 branch rules and 18 union rules. Don't pin the
+	// associativity exactly; just assert we got per-branch lifting
+	// for every disjunction node.
+	if len(branch) < 18 {
+		t.Errorf("expected >=18 per-branch IDB rules from 10-way disjunction, got %d", len(branch))
+	}
+	if len(union) < 18 {
+		t.Errorf("expected >=18 union rules from 10-way disjunction, got %d", len(union))
+	}
+	if len(branch) != len(union) {
+		t.Errorf("branch and union rule counts must match, got %d vs %d", len(branch), len(union))
+	}
+}
+
+// TestLiftedDisjunction_UnderscorePreserved is a regression guard for
+// the wildcard handling: per-branch lifting must NOT promote `_` into
+// a head binding even though `_` appears in both branches' bodies. If
+// this test fails, multiple `_` occurrences in a single branch body
+// would be unified — silently filtering rows that would otherwise
+// match. (This bug bit during initial PR4 development on the
+// react-usestate `find_setstate_updater_calls_other_setstate` golden
+// — one row dropped.)
+func TestLiftedDisjunction_UnderscorePreserved(t *testing.T) {
+	src := `
+predicate Edge(int a, int b, int c) { any() }
+predicate FunctionContains(int a, int b) { any() }
+predicate test(int x, int y) {
+    FunctionContains(x, y)
+    or
+    exists(int mid |
+        FunctionContains(x, mid) and
+        Edge(mid, _, _) and
+        FunctionContains(mid, y)
+    )
+}
+`
+	prog := desugarOK(t, parseAndResolve(t, src))
+	branch, _ := classifyDisj(prog)
+	for _, r := range branch {
+		for _, arg := range r.Head.Args {
+			if v, ok := arg.(datalog.Var); ok && v.Name == "_" {
+				t.Fatalf("rule %s head contains wildcard `_` as a positional binding — would unify body `_`s and silently drop rows",
+					r.Head.Predicate)
+			}
+		}
+	}
+}
+
+// TestLiftedDisjunction_CallerSeesUnionLiteral verifies the caller
+// boundary contract: the calling rule's body still references a single
+// `_disj_N(SV...)` literal over the shared vars only. This is what
+// keeps the lifting transform a non-breaking change for upstream
+// passes (magic-set, demand inference, etc.) — they see the same
+// union literal as before, just sized correctly now.
+func TestLiftedDisjunction_CallerSeesUnionLiteral(t *testing.T) {
+	src := `
+class Foo { Foo() { any() } }
+predicate p(Foo x) { a(x) or b(x) }
+`
+	prog := desugarOK(t, parseAndResolve(t, src))
+	r := findRuleExact(prog, "p")
+	if r == nil {
+		t.Fatal("expected rule 'p'")
+	}
+	var disjCalls int
+	for _, lit := range r.Body {
+		name := lit.Atom.Predicate
+		if !strings.HasPrefix(name, "_disj_") {
+			continue
+		}
+		disjCalls++
+		if strings.HasSuffix(name, "_l") || strings.HasSuffix(name, "_r") {
+			t.Errorf("caller body must call the union IDB, not a per-branch IDB (got %q)", name)
+		}
+	}
+	if disjCalls != 1 {
+		t.Errorf("caller body should reference exactly one _disj union literal, got %d", disjCalls)
+	}
+}

--- a/ql/desugar/disjunction_lifting_test.go
+++ b/ql/desugar/disjunction_lifting_test.go
@@ -71,7 +71,9 @@ func TestLiftedDisjunction_PerBranchHeadCarriesFullVars(t *testing.T) {
 	src := `
 predicate a(int x, int y) { any() }
 predicate b(int x, int z) { any() }
-predicate test(int x) { a(x, _) or b(x, _) }
+predicate test(int x) {
+    exists(int y, int z | a(x, y) or b(x, z))
+}
 `
 	prog := desugarOK(t, parseAndResolve(t, src))
 	branch, union := classifyDisj(prog)
@@ -105,6 +107,42 @@ predicate test(int x) { a(x, _) or b(x, _) }
 					r.Head.Predicate)
 			}
 		}
+	}
+
+	// LOAD-BEARING #166 invariant: the `_l` branch head must carry the
+	// full var set visible in the left body — `{x, y}` — and the `_r`
+	// branch head must carry `{x, z}`. A regression that re-narrowed
+	// branch heads back to shared-vars-only would still pass the
+	// shape/wildcard checks above, so assert the var sets explicitly.
+	headVarSet := func(r *datalog.Rule) map[string]bool {
+		s := map[string]bool{}
+		for _, arg := range r.Head.Args {
+			if v, ok := arg.(datalog.Var); ok {
+				s[v.Name] = true
+			}
+		}
+		return s
+	}
+	var lRule, rRule *datalog.Rule
+	for _, r := range branch {
+		if strings.HasSuffix(r.Head.Predicate, "_l") {
+			lRule = r
+		} else if strings.HasSuffix(r.Head.Predicate, "_r") {
+			rRule = r
+		}
+	}
+	if lRule == nil || rRule == nil {
+		t.Fatalf("expected one _l and one _r branch rule, got l=%v r=%v", lRule, rRule)
+	}
+	lVars := headVarSet(lRule)
+	if !lVars["x"] || !lVars["y"] {
+		t.Errorf("_l branch head must carry full left var set {x,y}, got %v (rule %s)",
+			lVars, lRule.Head.Predicate)
+	}
+	rVars := headVarSet(rRule)
+	if !rVars["x"] || !rVars["z"] {
+		t.Errorf("_r branch head must carry full right var set {x,z}, got %v (rule %s)",
+			rVars, rRule.Head.Predicate)
 	}
 }
 
@@ -147,15 +185,18 @@ func TestLiftedDisjunction_TenBranches(t *testing.T) {
 	prog := desugarOK(t, parseAndResolve(t, src))
 	branch, union := classifyDisj(prog)
 
-	// 10 branches → 9 disjunction nodes (right-associated parse) →
-	// 9 * 2 = 18 branch rules and 18 union rules. Don't pin the
-	// associativity exactly; just assert we got per-branch lifting
-	// for every disjunction node.
-	if len(branch) < 18 {
-		t.Errorf("expected >=18 per-branch IDB rules from 10-way disjunction, got %d", len(branch))
+	// 10 branches → 9 disjunction nodes (right-associated parse by the
+	// current parser) → 9 * 2 = 18 branch rules and 18 union rules.
+	// Pinned to `==` (not `>=`) so over-generation regressions are
+	// caught too — `>=` would silently accept an explosion in
+	// synthetic-rule count. If the parser ever changes associativity
+	// (or introduces n-ary disjunction nodes), this assertion will
+	// flip and is the right place to revisit the invariant.
+	if len(branch) != 18 {
+		t.Errorf("expected exactly 18 per-branch IDB rules from 10-way disjunction, got %d", len(branch))
 	}
-	if len(union) < 18 {
-		t.Errorf("expected >=18 union rules from 10-way disjunction, got %d", len(union))
+	if len(union) != 18 {
+		t.Errorf("expected exactly 18 union rules from 10-way disjunction, got %d", len(union))
 	}
 	if len(branch) != len(union) {
 		t.Errorf("branch and union rule counts must match, got %d vs %d", len(branch), len(union))


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

**Project context.** First PR of Phase B (per the plan in
`/tmp/tsq-valueflow-phase-b/docs/design/valueflow-phase-b-plan.md`,
commit `d53dd88`, sections §5–§6 and §7.4). The plan sequences this
as PR4 with a dependency on PR3 (recursive-IDB estimator); shipping
it first instead, since the lifting transform is independent of the
recursive sizing path. Recursive branches still fall back to the
default 1000-row hint until PR3 lands.

## Summary

The desugarer used to lower `a or b` to a single `_disj_N` predicate
with two rules whose head was `intersect(leftVars, rightVars)`. Two
problems:

1. **Binding loss.** Vars only in one branch were dropped from the
   head, leaving callers cartesian or unsafe under magic-set.
2. **Sized-union failure.** P2b's sampler estimates `|_disj_N|` from
   one sampled rule — it could lie about the union by orders of
   magnitude (the round-2 419k `_disj_2` got the default 1000-row
   hint and blew the binding cap).

Rounds 1–6 (#149/#156/#158/#161/#162/#168/#170) patched downstream
symptoms. None addressed the root cause.

This PR lifts each branch to its own named IDB carrying the FULL
var set, then projects to shared vars at union time:

```
_disj_N_l(LV...)  :- leftBody.        // size left independently
_disj_N_r(RV...)  :- rightBody.       // size right independently
_disj_N(SV...)    :- _disj_N_l(LV...).  // trivial-IDB projection
_disj_N(SV...)    :- _disj_N_r(RV...).  // trivial-IDB projection
caller            :- ..., _disj_N(SV...), ...
```

Caller boundary unchanged (still a single union literal over shared
vars), so magic-set, demand inference, and the round 5/6 anchors keep
working. Each branch is now sized independently by the existing
trivial-IDB pre-pass — no new planner code.

## Wildcard filtering (subtle)

Per-branch heads filter out `Var{Name:"_"}` via `filterUnderscore`. The
parser sometimes lowers `_` as a named Var rather than
`datalog.Wildcard{}`. If `_` appears in a per-branch head, multiple
`_` occurrences in the same body unify and silently drop rows — caught
during PR development on the react-usestate
`find_setstate_updater_calls_other_setstate` golden (one row dropped
mid-implementation). The original union-only-shared-vars desugar
implicitly hid this because `_` was usually asymmetric across
branches; the lifting pass has to apply the filter explicitly.

## Before / after

* **Before:** `find_setstate_updater_calls_other_setstate` golden
  passes (it doesn't cap-hit; it's a small fixture). Plan-time and
  result counts unchanged on existing fixtures.
* **After:** lifting fires on every disjunction. The
  `disj2_round[2-6]_*_test.go` planner tests pass unchanged — the
  round patches are kept as defence-in-depth per plan §6.5. The new
  10-branch synthetic test (`TestLiftedDisjunction_TenBranches`)
  produces 18 per-branch IDBs + 18 union rules (one pair per Disj
  node in the right-associated parse) without cap-hit.

Real-world cap-hit deltas on the cain-nas mastodon / jitsi corpora
are gated on PR2/PR3 of Phase B (the sized recursive estimator —
without it, lifted recursive branches still get the default 1000-row
hint). This PR removes the structural binding-loss / wildcard-poison
path immediately.

## Tests

* `ql/desugar/disjunction_lifting_test.go` — six unit tests:
  - simple disjunction shape (2 branch + 2 union)
  - per-branch heads carry full var sets, union heads only shared
  - nested disjunction composition (`a or b or c` → 4+4 rules)
  - 10-branch synthetic
  - wildcard `_` never promoted to a positional binding
  - caller boundary still sees a single union literal
* `TestDesugarDisjunction` and `TestDesugarDisjunctionAsymmetricVars`
  updated for the 2→4 rule count.
* All `disj2_round[2-6]_*` planner tests pass unchanged.
* Full `go test ./...` is green.

## Test plan

- [x] `go test ./ql/desugar/...` passes
- [x] `go test ./ql/plan/...` passes (incl. all disj2_round tests)
- [x] `go test ./...` passes (incl. integration golden)
- [x] `go vet ./...` clean
- [x] Manual review of desugared rule shapes for nested disjunctions
- [ ] (Future, gated on PR2/PR3) cain-nas mastodon bench: confirm
  the planner no longer falls back to default 1000 on lifted
  recursive branches once the recursive-IDB estimator lands.

## Deviations from plan

* Shipping as PR1 instead of PR4 (plan ordering). The plan called
  for the recursive-IDB estimator first so lifted recursive branches
  get a real estimate; without it they fall back to default 1000.
  This is a regression NEUTRAL change in that case (same default
  hint as before), and a strict improvement on non-recursive
  disjunction branches (which can now be sized independently).
* Plan §6.3 used `freshSynthName` three times (one per IDB) — this
  PR allocates the union name once and derives `_l`/`_r` suffixes,
  saving two synth-counter slots per disjunction. Functionally
  identical, easier to read in plan dumps.