### PR TITLE
feat(valueflow): non-recursive mayResolveTo with 6 named branches (Phase A PR2)

### DIFF
--- a/bridge/bridge_test.go
+++ b/bridge/bridge_test.go
@@ -24,9 +24,27 @@ func TestBridgeFilesParseBasicStructure(t *testing.T) {
 	classRe := regexp.MustCompile(`(?m)^\s*(?:abstract\s+)?class\s+(\w+)\s+extends\s+`)
 	predicateRe := regexp.MustCompile(`(?m)^\s+(?:override\s+)?(string|int|predicate|ASTNode|File|Call|JsxElement|Function|Parameter|CallArg|ParameterRest|ParameterOptional|ParameterDestructured|ParamIsFunctionType|CallArgSpread|VarDecl|Assign|ExprMayRef|ExprIsCall|FieldRead|FieldWrite|Await|Cast|DestructureField|ArrayDestructure|DestructureRest|JsxAttribute|ImportBinding|ExportBinding|ExtractError|SchemaVersion|Contains)\s+\w+\(`)
 
+	// Predicate-only bridge files: pure rule libraries with no class wrappers.
+	// tsq_valueflow.qll (Phase A) is the first of these — it exposes a set of
+	// named predicates (`mayResolveTo`, `mayResolveToBase`, ...) consumed by
+	// other bridge files and queries directly. Adding a vacuous class wrapper
+	// would buy nothing and obscure intent. Skip the class-presence assertion
+	// for these files but still require they parse and contain top-level
+	// `predicate` declarations.
+	predicateOnlyFiles := map[string]bool{
+		"tsq_valueflow.qll": true,
+	}
+	topLevelPredRe := regexp.MustCompile(`(?m)^predicate\s+\w+\(`)
+
 	files := LoadBridge()
 	for name, data := range files {
 		src := string(data)
+		if predicateOnlyFiles[name] {
+			if !topLevelPredRe.MatchString(src) {
+				t.Errorf("predicate-only bridge file %q contains no top-level predicate declarations", name)
+			}
+			continue
+		}
 		classes := classRe.FindAllStringSubmatch(src, -1)
 		if len(classes) == 0 {
 			t.Errorf("bridge file %q contains no class declarations", name)

--- a/bridge/embed.go
+++ b/bridge/embed.go
@@ -2,7 +2,7 @@ package bridge
 
 import "embed"
 
-//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll tsq_summaries.qll tsq_composition.qll tsq_taint.qll tsq_express.qll tsq_react.qll tsq_node.qll compat_javascript.qll compat_dataflow.qll compat_tainttracking.qll compat_security_xss.qll compat_security_cmdi.qll compat_security_sqli.qll compat_security_pathtraversal.qll compat_dom.qll compat_crypto.qll compat_http.qll compat_io.qll compat_regexp.qll
+//go:embed tsq_base.qll tsq_functions.qll tsq_calls.qll tsq_variables.qll tsq_expressions.qll tsq_jsx.qll tsq_imports.qll tsq_errors.qll tsq_types.qll tsq_symbols.qll tsq_callgraph.qll tsq_dataflow.qll tsq_summaries.qll tsq_composition.qll tsq_taint.qll tsq_valueflow.qll tsq_express.qll tsq_react.qll tsq_node.qll compat_javascript.qll compat_dataflow.qll compat_tainttracking.qll compat_security_xss.qll compat_security_cmdi.qll compat_security_sqli.qll compat_security_pathtraversal.qll compat_dom.qll compat_crypto.qll compat_http.qll compat_io.qll compat_regexp.qll
 var bridgeFS embed.FS
 
 // LoadBridge returns all embedded .qll files as a map from filename to contents.
@@ -23,6 +23,7 @@ func LoadBridge() map[string][]byte {
 		"tsq_summaries.qll",
 		"tsq_composition.qll",
 		"tsq_taint.qll",
+		"tsq_valueflow.qll",
 		"tsq_express.qll",
 		"tsq_react.qll",
 		"tsq_node.qll",
@@ -70,6 +71,7 @@ var ImportPathToFile = map[string]string{
 	"tsq::summaries":      "tsq_summaries.qll",
 	"tsq::composition":    "tsq_composition.qll",
 	"tsq::taint":          "tsq_taint.qll",
+	"tsq::valueflow":      "tsq_valueflow.qll",
 	"tsq::express":        "tsq_express.qll",
 	"tsq::react":          "tsq_react.qll",
 	"tsq::node":           "tsq_node.qll",

--- a/bridge/embed_test.go
+++ b/bridge/embed_test.go
@@ -22,6 +22,7 @@ func TestLoadBridgeReturnsAllFiles(t *testing.T) {
 		"tsq_summaries.qll",
 		"tsq_composition.qll",
 		"tsq_taint.qll",
+		"tsq_valueflow.qll",
 		"tsq_express.qll",
 		"tsq_react.qll",
 		"tsq_node.qll",

--- a/bridge/tsq_valueflow.qll
+++ b/bridge/tsq_valueflow.qll
@@ -1,0 +1,183 @@
+/**
+ * Bridge library for the value-flow layer (Phase A).
+ *
+ * Provides a non-recursive `mayResolveTo(valueExpr, sourceExpr)` predicate
+ * built from six named branches, unioned at the top level via an
+ * `or`-of-calls. Each branch consumes only EDB / extractor-grounded
+ * relations — no branch body references `mayResolveTo` itself, so the
+ * planner's existing non-recursive sizing path (trivial-IDB pre-pass + P2b
+ * sampling estimator) handles cardinality without recursive-IDB work.
+ *
+ * The `or`-of-named-calls top-level shape is the known-good workaround for
+ * disjunction-poisoning bug #166: each branch is its own predicate and the
+ * union evaluates as a disjunction of literals each of which is a call to a
+ * separate IDB head. That keeps the planner's magic-set rewrite from
+ * collapsing the binding-loss case the inline `(A or B)` form triggers.
+ *
+ * Six branches per docs/design/valueflow-phase-a-plan.md §2:
+ *   2.1 mayResolveToBase         — identity on ExprValueSource
+ *   2.2 mayResolveToVarInit      — sym whose VarDecl init is a value-source
+ *   2.3 mayResolveToAssign       — sym whose Assign rhs is a value-source
+ *   2.4 mayResolveToParamBind    — sym is a parameter; arg at call site is value-source
+ *   2.5 mayResolveToFieldRead    — FieldRead of a field whose any FieldWrite is value-source
+ *   2.6 mayResolveToObjectField  — FieldRead through a VarDecl-bound object literal
+ *
+ * What Phase A explicitly does NOT cover (plan §6): no recursion, no
+ * two-hop var indirection, no spread, no JSX-wrapper unwrap, no call-return
+ * composition, no destructure-source, no cross-module, no method/inherit,
+ * no type-driven, no effect/Proxy, no await, no `as` cast, no depth bound.
+ *
+ * The `resolvesToFunctionDirect` derived helper exposes the
+ * "callee resolves to a function expression" question the bridge will ask
+ * once Phase A PR3 collapses the easy `resolveToObjectExpr*` branches in
+ * `tsq_react.qll`. Phase C will replace it with the recursive-aware form.
+ */
+
+/**
+ * Branch 2.1 — Identity on value-source expressions.
+ *
+ * Wraps `ExprValueSource` so the union in `mayResolveTo` is a disjunction
+ * of named-predicate calls (not raw EDB literals). Keeps the disj-#166
+ * workaround clean: every union arm is the same shape (an IDB head call).
+ */
+predicate mayResolveToBase(int valueExpr, int sourceExpr) {
+    ExprValueSource(valueExpr, sourceExpr)
+}
+
+/**
+ * Branch 2.2 — Var-init step.
+ *
+ * `valueExpr` references a sym whose `VarDecl` initialiser is itself a
+ * value-source. Non-recursive: the inner relation is `ExprValueSource`,
+ * not `mayResolveTo`. Two-hop var indirection (`const a = b; const b =
+ * {...};`) is intentionally out of scope; needs Phase C recursion.
+ */
+predicate mayResolveToVarInit(int valueExpr, int sourceExpr) {
+    exists(int sym, int initExpr, int varDecl |
+        ExprMayRef(valueExpr, sym) and
+        VarDecl(varDecl, sym, initExpr, _) and
+        ExprValueSource(initExpr, sourceExpr)
+    )
+}
+
+/**
+ * Branch 2.3 — Assign step.
+ *
+ * `valueExpr` references a sym that has been (re-)assigned a value-source
+ * RHS. Uses the `AssignExpr(lhsSym, rhsExpr)` projection added in PR1, not
+ * the 3-arity `Assign(lhsNode, rhsExpr, lhsSym)`, so the planner can key
+ * the join directly on `lhsSym` without dragging the unused `lhsNode`
+ * column through binding inference.
+ *
+ * No last-write-wins enforcement: every `AssignExpr` row whose RHS is a
+ * value-source contributes. Multi-write situations are over-approximated
+ * (consistent with the v1 mutation/flow-sensitivity dial in the parent
+ * design doc §5).
+ */
+predicate mayResolveToAssign(int valueExpr, int sourceExpr) {
+    exists(int sym, int rhsExpr |
+        ExprMayRef(valueExpr, sym) and
+        AssignExpr(sym, rhsExpr) and
+        ExprValueSource(rhsExpr, sourceExpr)
+    )
+}
+
+/**
+ * Branch 2.4 — Param-binding step.
+ *
+ * `valueExpr` references a parameter sym; some call site passes a
+ * value-source expression as the actual argument at the matching slot.
+ * Uses `ParamBinding(fn, paramIdx, paramSym, argExpr)` from PR1 — the
+ * 4-arity composition of `CallTarget × CallArg × Parameter` materialised
+ * once at extraction time. Carve-outs for spread args / rest params /
+ * destructured params are encoded in the extractor-side rule, so this
+ * branch does not need to repeat them.
+ *
+ * Cardinality budget: ParamBinding ≤ 5x CallArg (plan §7.3 budget gate
+ * enforced in `extract/rules/valueflow_budget_test.go`).
+ */
+predicate mayResolveToParamBind(int valueExpr, int sourceExpr) {
+    exists(int sym, int fn, int idx, int argExpr |
+        ExprMayRef(valueExpr, sym) and
+        ParamBinding(fn, idx, sym, argExpr) and
+        ExprValueSource(argExpr, sourceExpr)
+    )
+}
+
+/**
+ * Branch 2.5 — Field-read of any field-write of the same `(baseSym, fld)`.
+ *
+ * Field-name + base-sym match only; no shape recursion (parent design doc
+ * §5: "Field-named, no shape" is the v1 default). All writes are
+ * may-occur — last-write-wins is not enforced. This is the same precision
+ * posture as the existing `TaintedField` rule.
+ */
+predicate mayResolveToFieldRead(int valueExpr, int sourceExpr) {
+    exists(int baseSym, string fld, int rhsExpr, int writeNode |
+        FieldRead(valueExpr, baseSym, fld) and
+        FieldWrite(writeNode, baseSym, fld, rhsExpr) and
+        ExprValueSource(rhsExpr, sourceExpr)
+    )
+}
+
+/**
+ * Branch 2.6 — Object-literal field projection through a single VarDecl.
+ *
+ * `const o = { k: v }; o.k` resolves to `v`. Single VarDecl indirection,
+ * own field only. **No spread, no depth-2 var indirection, no computed
+ * key** — those need recursion through `mayResolveTo` (Phase C).
+ *
+ * This is the Phase A version of "the easy `resolveToObjectExpr` cases"
+ * in `tsq_react.qll`. PR3 of the Phase A series will delete the five
+ * subsumed bridge predicates listed in plan §3.1.
+ */
+predicate mayResolveToObjectField(int valueExpr, int sourceExpr) {
+    exists(int objExpr, string fld, int fieldValExpr, int baseSym, int varDecl |
+        FieldRead(valueExpr, baseSym, fld) and
+        VarDecl(varDecl, baseSym, objExpr, _) and
+        ObjectLiteralField(objExpr, fld, fieldValExpr) and
+        ExprValueSource(fieldValExpr, sourceExpr)
+    )
+}
+
+/**
+ * Top-level union — `or`-of-calls.
+ *
+ * Each disjunct is a call to a separate named IDB head. This shape
+ * sidesteps disjunction-poisoning bug #166 by construction: the planner's
+ * disjunction rewrite never sees a multi-branch literal-disjunction inside
+ * a single rule body, so the binding-loss case never fires. If a
+ * regression appears here in the future (per-branch row count > 0 but
+ * union row count = 0), that is the classic #166 signature — escalate to
+ * the planner team rather than rewriting the value-flow rules.
+ */
+predicate mayResolveTo(int valueExpr, int sourceExpr) {
+    mayResolveToBase(valueExpr, sourceExpr)
+    or mayResolveToVarInit(valueExpr, sourceExpr)
+    or mayResolveToAssign(valueExpr, sourceExpr)
+    or mayResolveToParamBind(valueExpr, sourceExpr)
+    or mayResolveToFieldRead(valueExpr, sourceExpr)
+    or mayResolveToObjectField(valueExpr, sourceExpr)
+}
+
+/**
+ * Derived helper — `resolvesToFunctionDirect(callee, fnId)`.
+ *
+ * Holds when the value-source `callee` may resolve to is a function
+ * expression node identified by `fnId`. Phase A surface for the bridge:
+ * "is this callee's resolved value-source a function expression node?"
+ * Phase C will replace this with a recursive-aware version that follows
+ * call-return composition, cross-module imports, and method dispatch.
+ *
+ * Uses `FunctionSymbol(sym, fn)` to confirm the resolved source is a
+ * declared function. The existential over `sourceExpr` keeps the predicate
+ * arity at 2 (callee, fnId) — the bridge cares about the function id, not
+ * the syntactic source expression.
+ */
+predicate resolvesToFunctionDirect(int callee, int fnId) {
+    exists(int sourceExpr, int sym |
+        mayResolveTo(callee, sourceExpr) and
+        FunctionSymbol(sym, fnId) and
+        sourceExpr = fnId
+    )
+}

--- a/bridge/tsq_valueflow.qll
+++ b/bridge/tsq_valueflow.qll
@@ -149,7 +149,9 @@ predicate mayResolveToObjectField(int valueExpr, int sourceExpr) {
  * a single rule body, so the binding-loss case never fires. If a
  * regression appears here in the future (per-branch row count > 0 but
  * union row count = 0), that is the classic #166 signature — escalate to
- * the planner team rather than rewriting the value-flow rules.
+ * the planner team rather than rewriting the value-flow rules. The
+ * regression guard is `TestValueflow_UnionMatchesSumOfBranches` in
+ * `valueflow_integration_test.go`.
  */
 predicate mayResolveTo(int valueExpr, int sourceExpr) {
     mayResolveToBase(valueExpr, sourceExpr)

--- a/integration_test.go
+++ b/integration_test.go
@@ -85,6 +85,7 @@ func makeBridgeImportLoader(bridgeFiles map[string][]byte) func(path string) (*a
 		"tsq::summaries":   "tsq_summaries.qll",
 		"tsq::composition": "tsq_composition.qll",
 		"tsq::taint":       "tsq_taint.qll",
+		"tsq::valueflow":   "tsq_valueflow.qll",
 		"tsq::express":     "tsq_express.qll",
 		"tsq::react":       "tsq_react.qll",
 		"tsq::node":        "tsq_node.qll",

--- a/testdata/projects/valueflow-base/assign.ts
+++ b/testdata/projects/valueflow-base/assign.ts
@@ -1,0 +1,6 @@
+// Branch 2.3 — Assign
+// `x` is a let; assigned an arrow function. The use-site `x()` references
+// the sym whose AssignExpr rhs is a value-source (arrow expression).
+let x: () => number;
+x = () => 1;
+const r = x();

--- a/testdata/projects/valueflow-base/field_read_write.ts
+++ b/testdata/projects/valueflow-base/field_read_write.ts
@@ -1,0 +1,6 @@
+// Branch 2.5 — FieldRead matching FieldWrite of same (baseSym, fld).
+// `o.cb` is read at the call site; `o.cb = () => 1` is the write whose rhs
+// is a value-source (arrow expression). Field-name + base-sym match only.
+const o: { cb: () => number } = { cb: () => 0 };
+o.cb = () => 1;
+const r = o.cb();

--- a/testdata/projects/valueflow-base/identity.ts
+++ b/testdata/projects/valueflow-base/identity.ts
@@ -1,0 +1,8 @@
+// Branch 2.1 — Identity (base case).
+// Any value-source expression resolves to itself via ExprValueSource.
+// This file produces multiple value-source rows: arrow, object literal,
+// number literal, string literal.
+const arrow = () => 1;
+const obj = { k: 1 };
+const num = 42;
+const str = "hi";

--- a/testdata/projects/valueflow-base/obj_field.ts
+++ b/testdata/projects/valueflow-base/obj_field.ts
@@ -1,0 +1,6 @@
+// Branch 2.6 — ObjectField projection through a single VarDecl.
+// `const o = { f: () => 1 }; o.f` — the FieldRead of `f` on baseSym `o`
+// resolves through the VarDecl init (object-literal) to the field's value
+// expression (arrow), which is itself a value-source.
+const o = { f: () => 1 };
+const r = o.f();

--- a/testdata/projects/valueflow-base/param_bind.ts
+++ b/testdata/projects/valueflow-base/param_bind.ts
@@ -1,0 +1,6 @@
+// Branch 2.4 — ParamBind
+// `g` is a parameter sym; the call site passes an arrow function (value-source)
+// at slot 0. Use-site `g()` references `g`; ParamBinding(f, 0, g, <arrow>)
+// pairs the param sym with the arg expression.
+function f(g: () => number): number { return g(); }
+const r = f(() => 1);

--- a/testdata/projects/valueflow-base/var_init.ts
+++ b/testdata/projects/valueflow-base/var_init.ts
@@ -1,0 +1,6 @@
+// Branch 2.2 — VarInit
+// `x` is a sym whose VarDecl initialiser is an object-literal value-source.
+// The use site `use(x)` references `x`; the VarDecl init is the value-source.
+const x = { a: 1 };
+function use(o: { a: number }): number { return o.a; }
+const r = use(x);

--- a/testdata/projects/valueflow-fnref/handler_assign.ts
+++ b/testdata/projects/valueflow-fnref/handler_assign.ts
@@ -1,0 +1,7 @@
+// resolvesToFunctionDirect fixture.
+// `cb` is initialised from a function expression (an arrow). The use site
+// `cb()` references `cb`; mayResolveTo's var-init branch resolves it to
+// the arrow node, which FunctionSymbol maps to the same fn id.
+// The integration test asserts at least one (callee, fnId) row.
+const cb = () => 42;
+const r = cb();

--- a/testdata/projects/valueflow-negative/field_write_aliased_base.ts
+++ b/testdata/projects/valueflow-negative/field_write_aliased_base.ts
@@ -1,0 +1,12 @@
+// Negative — field write through aliased base.
+// `o2.cb = ...` writes via the alias `o2`, but the read site reads via `o`.
+// Phase A's FieldRead branch keys on baseSym match — under v1's
+// "no shape" / no-alias-tracking posture this should not resolve.
+// (Whether `o` and `o2` collapse to the same baseSym depends on the
+// extractor's `ExprMayRef`/sym resolution; if they share a sym this
+// "negative" resolves and the test must surface that as a known
+// over-approximation rather than a leak.)
+const o: { cb: () => number } = { cb: () => 0 };
+const o2 = o;
+o2.cb = () => 1;
+const r = o.cb();

--- a/testdata/projects/valueflow-negative/spread_carrier.ts
+++ b/testdata/projects/valueflow-negative/spread_carrier.ts
@@ -1,0 +1,7 @@
+// Negative — object-literal spread.
+// `{ ...base }` is unmodelled in Phase A. The FieldRead `o.k` must NOT
+// resolve to the inner literal `1` through the spread. Phase C will
+// handle this when recursive `mayResolveTo` ships.
+const base = { k: 1 };
+const o = { ...base };
+const r = o.k;

--- a/testdata/projects/valueflow-negative/two_hop_var.ts
+++ b/testdata/projects/valueflow-negative/two_hop_var.ts
@@ -1,0 +1,8 @@
+// Negative — two-hop var indirection.
+// Phase A is depth-1 only. `const a = b; const b = {...};` requires
+// recursion through `mayResolveTo` (Phase C). The use-site `use(a)`
+// must NOT resolve to the object literal under Phase A.
+const b = { k: 1 };
+const a = b;
+function use(o: { k: number }): number { return o.k; }
+const r = use(a);

--- a/testdata/queries/v2/valueflow/all_mayResolveTo.ql
+++ b/testdata/queries/v2/valueflow/all_mayResolveTo.ql
@@ -1,0 +1,22 @@
+/**
+ * @name mayResolveTo — all rows
+ * @description Selects every (valueExpr, sourceExpr) pair the Phase A
+ *              non-recursive `mayResolveTo` predicate emits. Used by the
+ *              valueflow-base integration test to assert per-branch
+ *              coverage and by the union/sum-of-branches consistency check
+ *              for disjunction-poisoning regression detection.
+ * @kind table
+ * @id js/tsq/valueflow/all-may-resolve-to
+ */
+
+import tsq::valueflow
+import tsq::base
+import tsq::expressions
+import tsq::variables
+import tsq::calls
+import tsq::functions
+import tsq::symbols
+
+from int v, int s
+where mayResolveTo(v, s)
+select v as "valueExpr", s as "sourceExpr"

--- a/testdata/queries/v2/valueflow/branch_assign.ql
+++ b/testdata/queries/v2/valueflow/branch_assign.ql
@@ -1,0 +1,13 @@
+/**
+ * @name mayResolveToAssign — branch isolation
+ * @kind table
+ * @id js/tsq/valueflow/branch-assign
+ */
+import tsq::valueflow
+import tsq::base
+import tsq::expressions
+import tsq::variables
+import tsq::calls
+import tsq::functions
+import tsq::symbols
+from int v, int s where mayResolveToAssign(v, s) select v, s

--- a/testdata/queries/v2/valueflow/branch_base.ql
+++ b/testdata/queries/v2/valueflow/branch_base.ql
@@ -1,0 +1,13 @@
+/**
+ * @name mayResolveToBase — branch isolation
+ * @kind table
+ * @id js/tsq/valueflow/branch-base
+ */
+import tsq::valueflow
+import tsq::base
+import tsq::expressions
+import tsq::variables
+import tsq::calls
+import tsq::functions
+import tsq::symbols
+from int v, int s where mayResolveToBase(v, s) select v, s

--- a/testdata/queries/v2/valueflow/branch_field_read.ql
+++ b/testdata/queries/v2/valueflow/branch_field_read.ql
@@ -1,0 +1,13 @@
+/**
+ * @name mayResolveToFieldRead — branch isolation
+ * @kind table
+ * @id js/tsq/valueflow/branch-field-read
+ */
+import tsq::valueflow
+import tsq::base
+import tsq::expressions
+import tsq::variables
+import tsq::calls
+import tsq::functions
+import tsq::symbols
+from int v, int s where mayResolveToFieldRead(v, s) select v, s

--- a/testdata/queries/v2/valueflow/branch_object_field.ql
+++ b/testdata/queries/v2/valueflow/branch_object_field.ql
@@ -1,0 +1,13 @@
+/**
+ * @name mayResolveToObjectField — branch isolation
+ * @kind table
+ * @id js/tsq/valueflow/branch-object-field
+ */
+import tsq::valueflow
+import tsq::base
+import tsq::expressions
+import tsq::variables
+import tsq::calls
+import tsq::functions
+import tsq::symbols
+from int v, int s where mayResolveToObjectField(v, s) select v, s

--- a/testdata/queries/v2/valueflow/branch_param_bind.ql
+++ b/testdata/queries/v2/valueflow/branch_param_bind.ql
@@ -1,0 +1,13 @@
+/**
+ * @name mayResolveToParamBind — branch isolation
+ * @kind table
+ * @id js/tsq/valueflow/branch-param-bind
+ */
+import tsq::valueflow
+import tsq::base
+import tsq::expressions
+import tsq::variables
+import tsq::calls
+import tsq::functions
+import tsq::symbols
+from int v, int s where mayResolveToParamBind(v, s) select v, s

--- a/testdata/queries/v2/valueflow/branch_var_init.ql
+++ b/testdata/queries/v2/valueflow/branch_var_init.ql
@@ -1,0 +1,13 @@
+/**
+ * @name mayResolveToVarInit — branch isolation
+ * @kind table
+ * @id js/tsq/valueflow/branch-var-init
+ */
+import tsq::valueflow
+import tsq::base
+import tsq::expressions
+import tsq::variables
+import tsq::calls
+import tsq::functions
+import tsq::symbols
+from int v, int s where mayResolveToVarInit(v, s) select v, s

--- a/testdata/queries/v2/valueflow/negative_use_site_resolutions.ql
+++ b/testdata/queries/v2/valueflow/negative_use_site_resolutions.ql
@@ -1,0 +1,29 @@
+/**
+ * @name mayResolveTo — negative fixture, projected with locations
+ * @description Selects every (valueExpr, sourceExpr) pair `mayResolveTo`
+ *              emits, projected with file path + line numbers for both
+ *              endpoints. The negative-fixture integration test uses this
+ *              to make per-fixture pinned assertions: for each known
+ *              use-site (file, line) the test confirms `mayResolveTo`
+ *              does NOT join through to the unreachable literal line.
+ *              See plan §4.1 — this is the per-fixture pinned assertion
+ *              that the original aggregate-only ≤60 guard was missing.
+ * @kind table
+ * @id js/tsq/valueflow/negative-use-site-resolutions
+ */
+
+import tsq::valueflow
+import tsq::base
+import tsq::expressions
+import tsq::variables
+import tsq::calls
+import tsq::functions
+import tsq::symbols
+
+from ASTNode v, ASTNode s
+where mayResolveTo(v, s)
+select
+  v.getFile().getPath() as "valuePath",
+  v.getStartLine() as "valueLine",
+  s.getFile().getPath() as "sourcePath",
+  s.getStartLine() as "sourceLine"

--- a/testdata/queries/v2/valueflow/resolves_to_function_direct.ql
+++ b/testdata/queries/v2/valueflow/resolves_to_function_direct.ql
@@ -1,0 +1,26 @@
+/**
+ * @name resolvesToFunctionDirect — direct exercise
+ * @description Exercises the `resolvesToFunctionDirect(callee, fnId)`
+ *              derived helper from `tsq_valueflow.qll`. The Phase A bridge
+ *              ships this predicate so PR3 can rewrite the easy
+ *              `resolveToObjectExpr*` branches in `tsq_react.qll` onto it;
+ *              shipping it untested means a slot-swap bug in
+ *              `FunctionSymbol(sym, fnId)` would land silently and only
+ *              surface in PR3. This query gives the integration test a
+ *              direct call site so any regression here lights up
+ *              immediately.
+ * @kind table
+ * @id js/tsq/valueflow/resolves-to-function-direct
+ */
+
+import tsq::valueflow
+import tsq::base
+import tsq::expressions
+import tsq::variables
+import tsq::calls
+import tsq::functions
+import tsq::symbols
+
+from int callee, int fnId
+where resolvesToFunctionDirect(callee, fnId)
+select callee as "callee", fnId as "fnId"

--- a/valueflow_integration_test.go
+++ b/valueflow_integration_test.go
@@ -241,9 +241,10 @@ func TestValueflow_NegativeFixtureNoLeakage(t *testing.T) {
 	rs := runValueflowQuery(t, "testdata/queries/v2/valueflow/all_mayResolveTo.ql",
 		"testdata/projects/valueflow-negative")
 
-	// Loose upper bound: 3 fixture files × ~10 expected rows each (identity
-	// literals + 1 depth-1 var-init each) = ~30. A genuine recursion bug
-	// would multiply this by the per-fixture symbol count.
+	// Defence-in-depth: aggregate row count must stay bounded. 3 fixture
+	// files × ~10 expected rows each (identity literals + depth-1 var-init)
+	// = ~30. A genuine recursion bug would multiply this by the per-fixture
+	// symbol count.
 	const upperBound = 60
 	if len(rs.Rows) > upperBound {
 		t.Errorf("valueflow-negative fixture emitted %d mayResolveTo rows (expected ≤ %d). "+
@@ -252,16 +253,102 @@ func TestValueflow_NegativeFixtureNoLeakage(t *testing.T) {
 			len(rs.Rows), upperBound)
 	}
 	t.Logf("valueflow-negative mayResolveTo row count: %d (upper bound %d)", len(rs.Rows), upperBound)
+
+	// Per-fixture pinned assertions (plan §4.1). Run the location-projected
+	// probe and confirm no row joins a known use-site at line `useLine` to
+	// the unreachable literal at `forbiddenSourceLine`. These are the
+	// signatures of the Phase A out-of-scope shapes (two-hop var, spread,
+	// alias-base field write — the last is documented as a possible
+	// over-approximation; see the fixture comment in
+	// field_write_aliased_base.ts for context).
+	probe := runValueflowQuery(t,
+		"testdata/queries/v2/valueflow/negative_use_site_resolutions.ql",
+		"testdata/projects/valueflow-negative")
+
+	type forbidden struct {
+		fileSuffix          string // matched as suffix on path so test is repo-root agnostic
+		useLine             int64  // line of the use-site expression
+		forbiddenSourceLine int64  // line of the unreachable literal
+		shape               string // human label for the failure message
+	}
+	cases := []forbidden{
+		// two_hop_var.ts:  const b = { k: 1 };  (line 5, literal)
+		//                  const a = b;          (line 6)
+		//                  const r = use(a);     (line 8, use-site `a`)
+		// Phase A must NOT resolve `a` (line 8) to the literal `{ k: 1 }`
+		// (line 5) — that requires recursive var-init traversal.
+		{"two_hop_var.ts", 8, 5, "two-hop var indirection (a → b → {k:1})"},
+
+		// spread_carrier.ts: const base = { k: 1 };  (line 5, literal)
+		//                    const o = { ...base }; (line 6, spread)
+		//                    const r = o.k;         (line 7, use-site)
+		// Phase A must NOT resolve `o.k` (line 7) to `1` (line 5) — spread
+		// is unmodelled.
+		{"spread_carrier.ts", 7, 5, "object-literal spread (o.k → ...base → 1)"},
+	}
+	// Note: field_write_aliased_base.ts is intentionally NOT pinned. Its
+	// own fixture comment flags that whether `o` and `o2` collapse to the
+	// same baseSym is extractor-dependent; if they do, Phase A's
+	// no-alias-tracking field-read branch will resolve through, and that's
+	// recorded as a known v1 over-approximation rather than a leak.
+
+	for _, fc := range cases {
+		fc := fc
+		t.Run(fc.fileSuffix, func(t *testing.T) {
+			leaks := 0
+			for _, row := range probe.Rows {
+				if len(row) < 4 {
+					continue
+				}
+				vpv, ok1 := row[0].(eval.StrVal)
+				vlv, ok2 := row[1].(eval.IntVal)
+				spv, ok3 := row[2].(eval.StrVal)
+				slv, ok4 := row[3].(eval.IntVal)
+				if !ok1 || !ok2 || !ok3 || !ok4 {
+					continue
+				}
+				vp, vl, sp, sl := vpv.V, vlv.V, spv.V, slv.V
+				if !endsWith(vp, fc.fileSuffix) || !endsWith(sp, fc.fileSuffix) {
+					continue
+				}
+				if vl == fc.useLine && sl == fc.forbiddenSourceLine {
+					leaks++
+					t.Errorf("Phase A leak: mayResolveTo row %s:%d → %s:%d "+
+						"(shape: %s). Phase A must not resolve through this step; "+
+						"if a branch was made recursive this is the regression site.",
+						vp, vl, sp, sl, fc.shape)
+				}
+			}
+			t.Logf("%s: 0-leak assertion held (use-line %d ↛ source-line %d, shape: %s; %d total leak rows)",
+				fc.fileSuffix, fc.useLine, fc.forbiddenSourceLine, fc.shape, leaks)
+		})
+	}
+}
+
+// endsWith is a small dependency-free suffix check so the negative-fixture
+// test is repo-root-agnostic (CI may extract from absolute paths).
+func endsWith(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
 }
 
 // TestValueflow_RowCountBudget enforces the row-count budget gate from plan
 // §2.7: `mayResolveTo` aggregate row count is bounded by N × ExprValueSource.
-// Per the plan, on Mastodon the union sits at ~10^5–10^6 rows against an
-// ExprValueSource population of ~10^5–5*10^5. Conservative ratio cap: 10x.
 //
-// On the small valueflow-base fixture this is decorative; the gate exists
-// to break CI loud and early when the same predicate is re-run against
-// larger fixtures (full-ts-project, react-usestate-context-alias-r3).
+// Two thresholds are in play:
+//
+//   - Small-fixture local guard: 3.0×. Observed ratios on the four small
+//     fixtures here sit between 1.08× and 1.85×; a 5× regression would
+//     pass a 10× cap silently, so the small-fixture gate is tightened to
+//     3.0× and a regression rules out routine drift while still leaving
+//     headroom for fixture growth.
+//   - Mastodon-scale gate: 10.0× — appropriate when this test is re-run
+//     against the larger fixtures (full-ts-project,
+//     react-usestate-context-alias-r3) where per-symbol fan-out is denser
+//     and Phase A's union sits at ~10^5–10^6 rows over an ExprValueSource
+//     population of ~10^5–5*10^5.
+//
+// When wiring the larger fixtures in a follow-up, hoist `cap` into the
+// fixture struct so each fixture carries its own threshold.
 func TestValueflow_RowCountBudget(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping extraction-heavy integration test in short mode")
@@ -288,14 +375,62 @@ func TestValueflow_RowCountBudget(t *testing.T) {
 			}
 			t.Logf("fixture=%s ExprValueSource=%d mayResolveTo=%d ratio=%.2f",
 				fixture, evsCount, len(rs.Rows), ratio)
-			if evsCount > 0 && ratio > 10.0 {
-				t.Errorf("budget gate: mayResolveTo (%d) > 10x ExprValueSource (%d) — ratio %.2f. "+
+			// Small-fixture cap. See doc above for the 10× Mastodon-scale
+			// threshold that applies once larger fixtures are wired in.
+			const smallFixtureRatioCap = 3.0
+			if evsCount > 0 && ratio > smallFixtureRatioCap {
+				t.Errorf("budget gate: mayResolveTo (%d) > %.1fx ExprValueSource (%d) — ratio %.2f. "+
 					"Phase A union should not balloon multiplicatively over the EDB base; "+
-					"investigate per-branch row counts via the branch_*.ql queries.",
-					len(rs.Rows), evsCount, ratio)
+					"investigate per-branch row counts via the branch_*.ql queries. "+
+					"(10× is the Mastodon-scale threshold; this 3× gate is the small-fixture local guard.)",
+					len(rs.Rows), smallFixtureRatioCap, evsCount, ratio)
 			}
 		})
 	}
+}
+
+// TestValueflow_ResolvesToFunctionDirect exercises the
+// `resolvesToFunctionDirect(callee, fnId)` derived helper in
+// `bridge/tsq_valueflow.qll`. The helper is the Phase A surface PR3 will
+// consume to rewrite `tsq_react.qll`'s easy `resolveToObjectExpr*` branches
+// onto value-flow. Shipping it without a direct test means a slot-swap bug
+// in the `FunctionSymbol(sym, fnId)` wiring would land silently and only
+// surface when PR3 lands; this test catches it at PR2 boundary.
+//
+// Fixture: `const cb = () => 42; const r = cb();` — the use-site `cb` in
+// `cb()` is the callee, and the arrow-function init is both the
+// ExprValueSource (var-init branch resolves through to it) and the
+// FunctionSymbol target. The two must agree on the function node id.
+func TestValueflow_ResolvesToFunctionDirect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping extraction-heavy integration test in short mode")
+	}
+	rs := runValueflowQuery(t,
+		"testdata/queries/v2/valueflow/resolves_to_function_direct.ql",
+		"testdata/projects/valueflow-fnref")
+	if len(rs.Rows) == 0 {
+		t.Fatal("resolvesToFunctionDirect returned 0 rows on valueflow-fnref " +
+			"fixture; either the FunctionSymbol/sourceExpr equality wiring is " +
+			"broken or the var-init branch regressed. Each row should bind " +
+			"(useExprId, arrowFnNodeId).")
+	}
+	// Every row must be a (callee, fnId) IntVal pair where fnId is non-zero
+	// (a real node id). Defensive shape check guards against a future schema
+	// drift that would silently land null/zero ids and pass the count check.
+	for i, row := range rs.Rows {
+		if len(row) != 2 {
+			t.Fatalf("row %d: expected arity 2, got %d", i, len(row))
+		}
+		c, ok1 := row[0].(eval.IntVal)
+		f, ok2 := row[1].(eval.IntVal)
+		if !ok1 || !ok2 {
+			t.Fatalf("row %d: expected (IntVal, IntVal), got (%T, %T)", i, row[0], row[1])
+		}
+		if c.V == 0 || f.V == 0 {
+			t.Errorf("row %d: zero node id (callee=%d fnId=%d) — schema drift suspected", i, c.V, f.V)
+		}
+	}
+	t.Logf("resolvesToFunctionDirect: %d row(s) on valueflow-fnref", len(rs.Rows))
 }
 
 // TestValueflow_IntegrationOnReactFixture is the smoke test that

--- a/valueflow_integration_test.go
+++ b/valueflow_integration_test.go
@@ -1,0 +1,318 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Gjdoalfnrxu/tsq/bridge"
+	extractrules "github.com/Gjdoalfnrxu/tsq/extract/rules"
+	"github.com/Gjdoalfnrxu/tsq/extract/schema"
+	"github.com/Gjdoalfnrxu/tsq/ql/desugar"
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+	"github.com/Gjdoalfnrxu/tsq/ql/parse"
+	"github.com/Gjdoalfnrxu/tsq/ql/plan"
+	"github.com/Gjdoalfnrxu/tsq/ql/resolve"
+)
+
+// runValueflowQuery is a thin wrapper that runs a QL query through the full
+// pipeline (parse → resolve → desugar → merge system rules → estimate+plan
+// → eval) against the in-memory fact DB. The setstate-context integration
+// tests use a similar shape; we duplicate it here to keep the value-flow
+// test self-contained and to make the planner-cap visible at one site (so a
+// future row-count blow-up surfaces as a cap-hit, not a silent OOM).
+func runValueflowQuery(t *testing.T, queryFile, fixtureDir string) *eval.ResultSet {
+	t.Helper()
+	factDB := extractProject(t, fixtureDir)
+
+	src, err := os.ReadFile(queryFile)
+	if err != nil {
+		t.Fatalf("read query: %v", err)
+	}
+
+	bridgeFiles := bridge.LoadBridge()
+	importLoader := makeBridgeImportLoader(bridgeFiles)
+
+	p := parse.NewParser(string(src), queryFile)
+	mod, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	resolved, err := resolve.Resolve(mod, importLoader)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(resolved.Errors) > 0 {
+		t.Fatalf("resolve errors: %v", resolved.Errors)
+	}
+	prog, dsErrors := desugar.Desugar(resolved)
+	if len(dsErrors) > 0 {
+		t.Fatalf("desugar: %v", dsErrors)
+	}
+	prog = extractrules.MergeSystemRules(prog, extractrules.AllSystemRules())
+
+	hints := make(map[string]int, len(schema.Registry))
+	for _, def := range schema.Registry {
+		if r := factDB.Relation(def.Name); r != nil {
+			hints[def.Name] = r.Tuples()
+		}
+	}
+
+	const cap = 200_000
+
+	baseRels, err := eval.LoadBaseRelations(factDB)
+	if err != nil {
+		t.Fatalf("load base relations: %v", err)
+	}
+	execPlan, planErrs := plan.EstimateAndPlan(
+		prog,
+		hints,
+		cap,
+		eval.MakeEstimatorHook(baseRels),
+		plan.Plan,
+	)
+	if len(planErrs) > 0 {
+		t.Fatalf("plan: %v", planErrs)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rs, err := eval.Evaluate(
+		ctx,
+		execPlan,
+		baseRels,
+		eval.WithMaxBindingsPerRule(cap),
+		eval.WithSizeHints(hints),
+	)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	return rs
+}
+
+// TestValueflow_AllBranchesFireOnBase asserts that every Phase A branch of
+// `mayResolveTo` returns at least one row when the value-flow base fixture
+// is extracted. Each fixture file targets one branch; if the branch returns
+// 0 rows, either the fixture stopped exercising the shape or the QL rule
+// regressed.
+//
+// Plan §4.1 design intent: the per-branch fixtures are hand-checkable. This
+// test checks the lower-bound cardinality contract (≥1 per branch); the
+// `TestValueflow_UnionMatchesSumOfBranches` test below checks the union
+// shape (no disjunction-poisoning #166 regression).
+func TestValueflow_AllBranchesFireOnBase(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping extraction-heavy integration test in short mode")
+	}
+
+	branches := []struct {
+		name      string
+		queryFile string
+	}{
+		{"base", "testdata/queries/v2/valueflow/branch_base.ql"},
+		{"var_init", "testdata/queries/v2/valueflow/branch_var_init.ql"},
+		{"assign", "testdata/queries/v2/valueflow/branch_assign.ql"},
+		{"param_bind", "testdata/queries/v2/valueflow/branch_param_bind.ql"},
+		{"field_read", "testdata/queries/v2/valueflow/branch_field_read.ql"},
+		{"object_field", "testdata/queries/v2/valueflow/branch_object_field.ql"},
+	}
+
+	for _, b := range branches {
+		b := b
+		t.Run(b.name, func(t *testing.T) {
+			rs := runValueflowQuery(t, b.queryFile, "testdata/projects/valueflow-base")
+			if len(rs.Rows) == 0 {
+				t.Fatalf("branch %q returned 0 rows on valueflow-base fixture; "+
+					"either the fixture lost coverage of this branch or the QL rule regressed",
+					b.name)
+			}
+			t.Logf("branch %q: %d rows", b.name, len(rs.Rows))
+		})
+	}
+}
+
+// TestValueflow_UnionMatchesSumOfBranches is the disjunction-poisoning
+// regression guard from plan §7.5. It calls `mayResolveTo` (the union) and
+// each of the 6 named branches separately, then asserts:
+//
+//   - mayResolveTo row count ≤ sum of branch row counts (no spurious rows)
+//   - mayResolveTo row count ≥ max of branch row counts (no missing rows)
+//   - every (v, s) pair that appears in some branch also appears in the union
+//
+// The union is a set union (Datalog semantics dedupe), so it can be smaller
+// than the sum when branches overlap (e.g. a value-source identifier whose
+// own VarDecl init is the same expression node — rare in practice). It must
+// never be smaller than the largest single branch's contribution. If it is,
+// that's the #166 binding-loss signature: a per-branch literal returns rows
+// in isolation but disappears under disjunction.
+func TestValueflow_UnionMatchesSumOfBranches(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping extraction-heavy integration test in short mode")
+	}
+
+	branches := []string{
+		"testdata/queries/v2/valueflow/branch_base.ql",
+		"testdata/queries/v2/valueflow/branch_var_init.ql",
+		"testdata/queries/v2/valueflow/branch_assign.ql",
+		"testdata/queries/v2/valueflow/branch_param_bind.ql",
+		"testdata/queries/v2/valueflow/branch_field_read.ql",
+		"testdata/queries/v2/valueflow/branch_object_field.ql",
+	}
+
+	branchPairs := make(map[string]bool)
+	maxBranch := 0
+	sumBranches := 0
+	for _, q := range branches {
+		rs := runValueflowQuery(t, q, "testdata/projects/valueflow-base")
+		n := len(rs.Rows)
+		sumBranches += n
+		if n > maxBranch {
+			maxBranch = n
+		}
+		for _, row := range rs.Rows {
+			if len(row) >= 2 {
+				branchPairs[fmt.Sprintf("%v|%v", row[0], row[1])] = true
+			}
+		}
+	}
+
+	unionRS := runValueflowQuery(t, "testdata/queries/v2/valueflow/all_mayResolveTo.ql", "testdata/projects/valueflow-base")
+	unionPairs := make(map[string]bool)
+	for _, row := range unionRS.Rows {
+		if len(row) >= 2 {
+			unionPairs[fmt.Sprintf("%v|%v", row[0], row[1])] = true
+		}
+	}
+
+	t.Logf("branch totals: sum=%d max=%d ; union=%d (deduped=%d)",
+		sumBranches, maxBranch, len(unionRS.Rows), len(unionPairs))
+
+	if len(unionPairs) < maxBranch {
+		t.Fatalf("disjunction-poisoning regression suspected: union=%d < max single branch=%d. "+
+			"Per-branch literals return rows in isolation but disappear under `or`-of-calls. "+
+			"This is the bug #166 signature — escalate to the planner team rather than rewriting "+
+			"the value-flow rules.", len(unionPairs), maxBranch)
+	}
+	if len(unionPairs) > sumBranches {
+		t.Fatalf("union (%d) > sum of branches (%d) — impossible under set semantics; "+
+			"indicates a corrupted result set or a bug in the eval engine", len(unionPairs), sumBranches)
+	}
+	for p := range branchPairs {
+		if !unionPairs[p] {
+			t.Errorf("branch result missing from union: %s — disjunction-poisoning suspect", p)
+		}
+	}
+}
+
+// TestValueflow_NegativeFixtureNoLeakage asserts the negative fixture does
+// NOT produce `mayResolveTo` rows for the patterns Phase A explicitly
+// excludes (two-hop var indirection, object spread, aliased field write).
+//
+// Acceptance: union row count is permitted to be > 0 — the negative
+// fixture also contains the value-source literals themselves (identity
+// branch fires for every literal), and `const` initialisers exercise the
+// var-init branch trivially. What matters is that the use-site
+// expressions (`use(a)`, `o.k`, `o.cb()`) do NOT join through to the
+// underlying value-source.
+//
+// This test guards against accidental recursive-leakage: if a future edit
+// turns one of the named branches recursive (e.g. mayResolveToVarInit
+// referencing mayResolveTo internally), the two-hop var fixture would
+// start resolving and this test catches it.
+//
+// The check is structural rather than a hard "0 rows" assertion because:
+//   - identity rows are expected (literals are value-sources of themselves)
+//   - var-init rows are expected for the depth-1 hop (`const b = {...}` →
+//     b's var-init fires; this is legitimate)
+//   - what must NOT happen is that the use-site expression on the OTHER
+//     side of the unsupported step resolves to the literal.
+//
+// We assert the negative property by snapshotting the row count and
+// comparing against an upper bound derived from per-branch fixture
+// expectations. If a real recursion bug fires, the count balloons.
+func TestValueflow_NegativeFixtureNoLeakage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping extraction-heavy integration test in short mode")
+	}
+
+	rs := runValueflowQuery(t, "testdata/queries/v2/valueflow/all_mayResolveTo.ql",
+		"testdata/projects/valueflow-negative")
+
+	// Loose upper bound: 3 fixture files × ~10 expected rows each (identity
+	// literals + 1 depth-1 var-init each) = ~30. A genuine recursion bug
+	// would multiply this by the per-fixture symbol count.
+	const upperBound = 60
+	if len(rs.Rows) > upperBound {
+		t.Errorf("valueflow-negative fixture emitted %d mayResolveTo rows (expected ≤ %d). "+
+			"This is the recursion-leakage signature: a depth-1 rule has started "+
+			"chaining through itself. Check that no branch body references mayResolveTo.",
+			len(rs.Rows), upperBound)
+	}
+	t.Logf("valueflow-negative mayResolveTo row count: %d (upper bound %d)", len(rs.Rows), upperBound)
+}
+
+// TestValueflow_RowCountBudget enforces the row-count budget gate from plan
+// §2.7: `mayResolveTo` aggregate row count is bounded by N × ExprValueSource.
+// Per the plan, on Mastodon the union sits at ~10^5–10^6 rows against an
+// ExprValueSource population of ~10^5–5*10^5. Conservative ratio cap: 10x.
+//
+// On the small valueflow-base fixture this is decorative; the gate exists
+// to break CI loud and early when the same predicate is re-run against
+// larger fixtures (full-ts-project, react-usestate-context-alias-r3).
+func TestValueflow_RowCountBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping extraction-heavy integration test in short mode")
+	}
+
+	fixtures := []string{
+		"testdata/projects/valueflow-base",
+		"testdata/projects/valueflow-negative",
+		"testdata/projects/react-usestate",
+		"testdata/projects/react-usestate-context-alias",
+	}
+	for _, fixture := range fixtures {
+		fixture := fixture
+		t.Run(fixture, func(t *testing.T) {
+			factDB := extractProject(t, fixture)
+			evsCount := 0
+			if r := factDB.Relation("ExprValueSource"); r != nil {
+				evsCount = r.Tuples()
+			}
+			rs := runValueflowQuery(t, "testdata/queries/v2/valueflow/all_mayResolveTo.ql", fixture)
+			ratio := 0.0
+			if evsCount > 0 {
+				ratio = float64(len(rs.Rows)) / float64(evsCount)
+			}
+			t.Logf("fixture=%s ExprValueSource=%d mayResolveTo=%d ratio=%.2f",
+				fixture, evsCount, len(rs.Rows), ratio)
+			if evsCount > 0 && ratio > 10.0 {
+				t.Errorf("budget gate: mayResolveTo (%d) > 10x ExprValueSource (%d) — ratio %.2f. "+
+					"Phase A union should not balloon multiplicatively over the EDB base; "+
+					"investigate per-branch row counts via the branch_*.ql queries.",
+					len(rs.Rows), evsCount, ratio)
+			}
+		})
+	}
+}
+
+// TestValueflow_IntegrationOnReactFixture is the smoke test that
+// `mayResolveTo` runs end-to-end on a realistic React fixture without
+// blowing the planner cap. The react-usestate-context-alias fixture is
+// the same one the bridge's setStateUpdaterCallsOtherSetStateThroughContext
+// predicate exercises; PR4 of Phase A will rewrite the bridge's easy
+// resolveToObjectExpr branches onto mayResolveTo, and this test ensures
+// the union runs cleanly first.
+func TestValueflow_IntegrationOnReactFixture(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping extraction-heavy integration test in short mode")
+	}
+	rs := runValueflowQuery(t, "testdata/queries/v2/valueflow/all_mayResolveTo.ql",
+		"testdata/projects/react-usestate-context-alias")
+	if len(rs.Rows) == 0 {
+		t.Fatal("expected mayResolveTo to return at least one row on react-usestate-context-alias")
+	}
+	t.Logf("react-usestate-context-alias mayResolveTo: %d rows", len(rs.Rows))
+}


### PR DESCRIPTION
Phase A PR2 of the value-flow layer. Implements the non-recursive
`mayResolveTo` predicate per `docs/design/valueflow-phase-a-plan.md` §2,
on top of PR1 (extractor base relations) merged at `51b81ae`.

## Summary

Adds `bridge/tsq_valueflow.qll` exposing six named branch predicates
unioned by an `or`-of-calls top-level disjunction, plus the
`resolvesToFunctionDirect` derived helper:

- `mayResolveToBase` — identity on `ExprValueSource`
- `mayResolveToVarInit` — sym whose `VarDecl` init is a value-source
- `mayResolveToAssign` — sym whose `AssignExpr` rhs is a value-source
- `mayResolveToParamBind` — sym is a parameter; arg at call site is a value-source
- `mayResolveToFieldRead` — `FieldRead` of a field whose any `FieldWrite` is a value-source
- `mayResolveToObjectField` — `FieldRead` through a `VarDecl`-bound object literal

Every branch consumes only EDB / extractor-grounded relations. No branch
body references `mayResolveTo` itself — the planner's existing
non-recursive sizing path handles cardinality without recursive-IDB work.

The `or`-of-named-calls top-level shape sidesteps disjunction-poisoning
bug #166 by construction: every union arm is a call to a separate IDB
head, so the planner's disjunction rewrite never sees a multi-branch
literal-disjunction inside a single rule body.

Phase A explicitly does NOT cover (per plan §6): recursion, two-hop var
indirection, spread, JSX-wrapper unwrap, call-return composition,
destructure-source, cross-module, method/inheritance, type-driven,
effect/Proxy, await, `as` cast, depth bound. Those are Phase C.

## Test results

Per-branch coverage on `valueflow-base` fixture (six TS files, one per
branch):

| Branch | Rows |
|---|---|
| base (identity) | 26 |
| var_init | 11 |
| assign | 3 |
| param_bind | 1 |
| field_read | 2 |
| object_field | 3 |
| Union (mayResolveTo) | 46 |

Union = 46 = sum of branches (no overlap on this fixture). Max single
branch = 26. The #166 disjunction-poisoning guard (union < max-branch)
does not fire.

Row-count budget gate (`mayResolveTo` / `ExprValueSource` ≤ 10x):

| Fixture | ExprValueSource | mayResolveTo | Ratio |
|---|---|---|---|
| valueflow-base | 26 | 46 | 1.77 |
| valueflow-negative | 13 | 24 | 1.85 |
| react-usestate | 26 | 38 | 1.46 |
| react-usestate-context-alias | 38 | 41 | 1.08 |

Negative fixture (two-hop var, spread carrier, aliased field write):
`mayResolveTo` returns 24 rows total (identity + depth-1 var-init only),
well under the 60-row leakage upper bound. No leakage of unsupported
recursive cases.

End-to-end smoke: `mayResolveTo` runs on `react-usestate-context-alias`
(41 rows) without blowing the 200k planner cap.

## Files

New:
- `bridge/tsq_valueflow.qll` — 6 named branches + union + helper.
  First predicate-only bridge file (no class wrappers — by design).
- `testdata/projects/valueflow-base/` — six minimal fixtures.
- `testdata/projects/valueflow-negative/` — three negative fixtures.
- `testdata/queries/v2/valueflow/` — seven QL queries.
- `valueflow_integration_test.go` — five integration tests.

Touched:
- `bridge/embed.go`, `bridge/embed_test.go` — register new `.qll`.
- `bridge/bridge_test.go` — predicate-only file allowlist for the
  structural-presence test.
- `integration_test.go::makeBridgeImportLoader` — `tsq::valueflow` path.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages green, including the four new
      `TestValueflow_*` integration tests
- [x] `go test ./bridge/...` — manifest, embed, and structural tests pass
- [x] PR1 budget gate (`extract/rules/valueflow_budget_test.go`) still
      passes with the new QL consumer in scope

## Deviations from plan

- Plan calls the file `ql/system/valueflow.qll`. The repo has no
  `ql/system/` directory; bridge `.qll` files live in `bridge/`. Placed
  the new file there as `bridge/tsq_valueflow.qll`, consistent with the
  existing layout.
- Plan §2.7 wraps the base case as `mayResolveToBase` for the union;
  §2.1 shows the base case directly as `mayResolveTo`. Implemented as
  §2.7 — necessary for the `or`-of-calls discipline.

## Open questions

- Union dedup ratio is exactly 1.0 on these tiny fixtures (sum =
  union). Mastodon and large React corpora may show substantial dedup
  worth instrumenting before PR3 (the bridge migration).
- `resolvesToFunctionDirect` has no dedicated test — first real
  consumer is PR3, which will add one.