### PR TITLE
feat(plan): dbscheme-stats-equivalent sidecar for cardinality estimation (Phase B PR2)

### DIFF
--- a/cmd/tsq/main.go
+++ b/cmd/tsq/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Gjdoalfnrxu/tsq/ql/parse"
 	"github.com/Gjdoalfnrxu/tsq/ql/plan"
 	"github.com/Gjdoalfnrxu/tsq/ql/resolve"
+	"github.com/Gjdoalfnrxu/tsq/ql/stats"
 )
 
 const version = "0.1.0"
@@ -54,7 +55,7 @@ var nonTaintablePrimitives = map[string]bool{
 func run(args []string, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "usage: tsq <command> [flags]")
-		fmt.Fprintln(stderr, "commands: extract, query, check, version")
+		fmt.Fprintln(stderr, "commands: extract, query, check, stats, version")
 		return 2
 	}
 
@@ -84,7 +85,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 
 	if subcmdIdx < 0 {
 		fmt.Fprintln(stderr, "usage: tsq <command> [flags]")
-		fmt.Fprintln(stderr, "commands: extract, query, check, version")
+		fmt.Fprintln(stderr, "commands: extract, query, check, stats, version")
 		return 2
 	}
 
@@ -121,9 +122,11 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return cmdQuery(ctx, subargs, stdout, stderr)
 	case "check":
 		return cmdCheck(subargs, stdout, stderr)
+	case "stats":
+		return cmdStats(ctx, subargs, stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "error: unknown command %q\n", subcmd)
-		fmt.Fprintln(stderr, "commands: extract, query, check, version")
+		fmt.Fprintln(stderr, "commands: extract, query, check, stats, version")
 		return 2
 	}
 }
@@ -136,6 +139,7 @@ func cmdExtract(ctx context.Context, args []string, stdout, stderr io.Writer) in
 	backendFlag := fs.String("backend", "treesitter", "extraction backend: treesitter or vendored")
 	tsgoFlag := fs.String("tsgo", "", "tsgo binary path (empty=auto-detect, \"off\"=disabled)")
 	tsconfigFlag := fs.String("tsconfig", "", "path to tsconfig.json for tsgo project context (empty=auto-discover by walking up from --dir)")
+	noStats := fs.Bool("no-stats", false, "skip writing the stats sidecar (Phase B PR1; default-stats mode in the planner)")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -226,7 +230,37 @@ func cmdExtract(ctx context.Context, args []string, stdout, stderr io.Writer) in
 	success = true
 
 	fmt.Fprintf(stderr, "wrote %s\n", *outputFile)
+
+	// Phase B PR1: stats sidecar.
+	if !*noStats {
+		if err := writeStatsSidecar(database, *outputFile, stderr); err != nil {
+			// Non-fatal: extraction itself succeeded; sidecar is advisory
+			// (planner falls back to default-stats mode when missing).
+			fmt.Fprintf(stderr, "warning: stats sidecar: %v\n", err)
+		}
+	}
 	return 0
+}
+
+// writeStatsSidecar computes the EDB statistics sidecar and writes it
+// next to the freshly extracted DB. See ql/stats and
+// docs/design/stats-sidecar-format.md.
+func writeStatsSidecar(database *db.DB, edbPath string, stderr io.Writer) error {
+	hash, err := stats.HashFile(edbPath)
+	if err != nil {
+		return fmt.Errorf("hash EDB: %w", err)
+	}
+	s, err := stats.Compute(database, hash)
+	if err != nil {
+		return fmt.Errorf("compute: %w", err)
+	}
+	if err := stats.Save(edbPath, s); err != nil {
+		return fmt.Errorf("save: %w", err)
+	}
+	if info, err := os.Stat(stats.SidecarPath(edbPath)); err == nil {
+		fmt.Fprintf(stderr, "wrote %s (%d bytes)\n", stats.SidecarPath(edbPath), info.Size())
+	}
+	return nil
 }
 
 // resolveTsgo determines the tsgo binary path from the flag value.

--- a/cmd/tsq/stats_cmd.go
+++ b/cmd/tsq/stats_cmd.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/Gjdoalfnrxu/tsq/extract/db"
+	"github.com/Gjdoalfnrxu/tsq/ql/stats"
+)
+
+// cmdStats dispatches `tsq stats <subcmd>` for sidecar diagnostics.
+//
+//	tsq stats compute <db>     # rebuild sidecar for an existing EDB
+//	tsq stats inspect <db> [rel]
+func cmdStats(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	if len(args) < 1 {
+		fmt.Fprintln(stderr, "usage: tsq stats <compute|inspect> <db> [args]")
+		return 2
+	}
+	sub := args[0]
+	rest := args[1:]
+	switch sub {
+	case "compute":
+		return cmdStatsCompute(ctx, rest, stdout, stderr)
+	case "inspect":
+		return cmdStatsInspect(ctx, rest, stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "error: unknown stats subcommand %q\n", sub)
+		fmt.Fprintln(stderr, "subcommands: compute, inspect")
+		return 2
+	}
+}
+
+func cmdStatsCompute(_ context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("stats compute", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 1
+	}
+	pos := fs.Args()
+	if len(pos) != 1 {
+		fmt.Fprintln(stderr, "usage: tsq stats compute <db>")
+		return 2
+	}
+	edbPath := pos[0]
+	database, err := loadDB(edbPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: load db: %v\n", err)
+		return 1
+	}
+	hash, err := stats.HashFile(edbPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: hash: %v\n", err)
+		return 1
+	}
+	s, err := stats.Compute(database, hash)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: compute: %v\n", err)
+		return 1
+	}
+	if err := stats.Save(edbPath, s); err != nil {
+		fmt.Fprintf(stderr, "error: save: %v\n", err)
+		return 1
+	}
+	if info, err := os.Stat(stats.SidecarPath(edbPath)); err == nil {
+		fmt.Fprintf(stdout, "wrote %s (%d bytes)\n", stats.SidecarPath(edbPath), info.Size())
+	}
+	return 0
+}
+
+func cmdStatsInspect(_ context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("stats inspect", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 1
+	}
+	pos := fs.Args()
+	if len(pos) < 1 || len(pos) > 2 {
+		fmt.Fprintln(stderr, "usage: tsq stats inspect <db> [rel]")
+		return 2
+	}
+	edbPath := pos[0]
+	relFilter := ""
+	if len(pos) == 2 {
+		relFilter = pos[1]
+	}
+	s, err := stats.Load(edbPath, stderr)
+	if err != nil {
+		// Load already warned; exit non-zero so scripts notice.
+		return 1
+	}
+	stats.Inspect(stdout, s, relFilter)
+	return 0
+}
+
+// loadDB reads an EDB from disk.
+func loadDB(path string) (*db.DB, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	return db.ReadDB(f, info.Size())
+}

--- a/cmd/tsq/stats_cmd_test.go
+++ b/cmd/tsq/stats_cmd_test.go
@@ -81,8 +81,25 @@ func TestCLI_StatsInspectStale(t *testing.T) {
 	if code := run([]string{"stats", "compute", dbPath}, &b1, &b2); code != 0 {
 		t.Fatalf("compute failed: %s", b2.String())
 	}
-	// Mutate the EDB in place to invalidate the hash.
-	if err := os.WriteFile(dbPath, []byte("not a real db anymore"), 0o600); err != nil {
+	// Mutate the EDB by flipping a single byte in place — preserves
+	// file size, mtime granularity, etc., so the only thing that can
+	// distinguish "stale" is the SHA-256 content hash. This is the
+	// invalidation contract we actually want to verify.
+	f, err := os.OpenFile(dbPath, os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var orig [1]byte
+	if _, err := f.ReadAt(orig[:], 0); err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	flipped := [1]byte{orig[0] ^ 0x01}
+	if _, err := f.WriteAt(flipped[:], 0); err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/tsq/stats_cmd_test.go
+++ b/cmd/tsq/stats_cmd_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/extract/db"
+	"github.com/Gjdoalfnrxu/tsq/ql/stats"
+)
+
+// makeTinyDB writes a small EDB to dir/tsq.db for tests.
+func makeTinyDB(t *testing.T, dir string) string {
+	t.Helper()
+	database := db.NewDB()
+	files := database.Relation("File")
+	for i := int32(1); i <= 5; i++ {
+		if err := files.AddTuple(database, i, "/x/f.ts", "h"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dbPath := filepath.Join(dir, "tsq.db")
+	f, err := os.Create(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Encode(f); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	return dbPath
+}
+
+// `tsq stats compute` writes a sidecar that `tsq stats inspect` then reads.
+func TestCLI_StatsComputeAndInspect(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := makeTinyDB(t, dir)
+
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"stats", "compute", dbPath}, &stdout, &stderr); code != 0 {
+		t.Fatalf("compute exit=%d, stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(stats.SidecarPath(dbPath)); err != nil {
+		t.Fatalf("sidecar not written: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := run([]string{"stats", "inspect", dbPath}, &stdout, &stderr); code != 0 {
+		t.Fatalf("inspect exit=%d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "rel File") {
+		t.Errorf("inspect output missing rel File:\n%s", stdout.String())
+	}
+}
+
+// `tsq stats inspect` on a missing sidecar exits non-zero with a warning.
+func TestCLI_StatsInspectMissing(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := makeTinyDB(t, dir)
+	// Don't compute the sidecar.
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"stats", "inspect", dbPath}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("expected non-zero exit when sidecar missing")
+	}
+	if !strings.Contains(stderr.String(), "default-stats mode") {
+		t.Errorf("stderr should mention default-stats mode:\n%s", stderr.String())
+	}
+}
+
+// Hash invalidation surfaces through the CLI as a warning + non-zero exit.
+func TestCLI_StatsInspectStale(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := makeTinyDB(t, dir)
+
+	var b1, b2 bytes.Buffer
+	if code := run([]string{"stats", "compute", dbPath}, &b1, &b2); code != 0 {
+		t.Fatalf("compute failed: %s", b2.String())
+	}
+	// Mutate the EDB in place to invalidate the hash.
+	if err := os.WriteFile(dbPath, []byte("not a real db anymore"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"stats", "inspect", dbPath}, &stdout, &stderr); code == 0 {
+		t.Fatal("expected non-zero exit when sidecar is stale")
+	}
+	if !strings.Contains(stderr.String(), "stale") && !strings.Contains(stderr.String(), "mismatch") {
+		t.Errorf("stderr should explain the staleness:\n%s", stderr.String())
+	}
+}

--- a/docs/design/stats-sidecar-format.md
+++ b/docs/design/stats-sidecar-format.md
@@ -1,0 +1,147 @@
+# EDB statistics sidecar — file format
+
+**Status:** implemented in PR `feat(stats): EDB statistics sidecar — schema, compute, persist` (Phase B PR1).
+**Plan source:** `docs/design/valueflow-phase-b-plan.md` §1, §2.
+
+This document is the on-disk source of truth for the `*.stats` sidecar
+file written next to a tsq EDB. It is intended to be small, version-gated,
+self-validating against the EDB it describes, and decodable without any
+external schema definition (no protobuf, no flatbuffers — pure Go binary).
+
+## 1. File location
+
+```
+<edb-path>             # e.g. tsq.db
+<edb-path>.stats       # NEW: sidecar
+<edb-path>.stats.lock  # advisory lock during write (created+removed by writer)
+```
+
+The sidecar always sits beside the EDB it describes. Move/rename together.
+
+## 2. Top-level layout
+
+All multi-byte integers are little-endian. All strings are length-prefixed
+(uint32 length, then bytes; no NUL terminator).
+
+```
++---------------------------+
+| Magic        "TSQS\0"  4B |   # "tsq stats"
+| FormatVer    uint32    4B |   # currently 1; bump on incompatible change
+| EDBHash      [32]byte 32B |   # SHA-256 of the EDB bytes
+| BuiltAtUnix  int64     8B |   # seconds since epoch
+| RelCount     uint32    4B |
++---------------------------+
+| Rel[0]                    |   # see §3
+| Rel[1]                    |
+| ...                       |
+| Rel[RelCount-1]           |
++---------------------------+
+| JoinCount    uint32    4B |
++---------------------------+
+| Join[0]                   |   # see §4
+| ...                       |
+| Join[JoinCount-1]         |
++---------------------------+
+| TrailerCRC   uint32    4B |   # IEEE CRC32 over everything before this
++---------------------------+
+```
+
+## 3. Per-relation block (`RelStats`)
+
+```
+NameLen   uint32                 # length in bytes of relation name
+Name      [NameLen]byte
+Arity     uint32
+RowCount  int64
+ColCount  uint32                 # equals Arity (defensive duplicate)
+Col[0..ColCount-1]               # see §3.1
+```
+
+### 3.1 Per-column block (`ColStats`)
+
+```
+Pos          uint32
+NDV          int64                # HyperLogLog estimate, ≥0
+NullFrac     float64              # zero-id fraction (0.0..1.0)
+TopKCount    uint32               # ≤ 32
+TopK[0..TopKCount-1]:
+    Value uint64
+    Count int64
+HistBucketCount uint32            # 0 if NDV ≤ NDVHistogramThreshold
+Hist[0..count-1]:
+    Lo    uint64
+    Hi    uint64
+    Count int64
+```
+
+### 3.2 Sentinels
+
+- `TopKCount = 0` means "no observed top values" (e.g. empty relation).
+- `HistBucketCount = 0` means "no histogram emitted" — either because
+  `NDV ≤ NDVHistogramThreshold` (currently 256) or because the column
+  type does not admit ordered bucketing (string columns are bucketed
+  on their interned uint32 id, which is monotonic with insertion
+  order, not lexicographic — this is a known and accepted limitation
+  for v1; see §6).
+
+## 4. Per-pair join block (`JoinStats`)
+
+```
+LeftRelLen     uint32
+LeftRel        [..]byte
+LeftCol        uint32
+RightRelLen    uint32
+RightRel       [..]byte
+RightCol       uint32
+Selectivity    float64           # |L⋈R| / (|L| × |R|)
+DistinctMatches int64            # |πLeftCol(L) ∩ πRightCol(R)| (HLL intersect estimate)
+```
+
+`JoinStats` are emitted only for relation/column pairs declared in
+`extract/schema/joinpaired.go` (added by this PR). Initial set: empty.
+Wiring in `extract/schema/joinpaired.go` is a stub for PR2/PR3 to
+populate as `mayResolveTo` shapes need them. The plan calls out
+`CallArg.call → Call.call` etc. as candidates; we don't have a
+`CallArg`/`Call` schema yet, so the v1 list is conservative.
+
+## 5. Hashing and invalidation
+
+- `EDBHash` is SHA-256 of the entire EDB file bytes.
+  - The plan §2.3 calls for BLAKE2b. SHA-256 is substituted to avoid
+    pulling `golang.org/x/crypto` (which would force a Go toolchain
+    bump on the current `go 1.23.8` module). The hash's only role is
+    invalidation: detecting when the EDB has been rewritten so the
+    sidecar must be rejected. SHA-256 satisfies that role identically.
+    The on-disk field is exactly 32 bytes either way; switching to
+    BLAKE2b later is a bump of `FormatVer` and a single function call
+    in `hash.go`.
+- On `Load`, the loader recomputes the EDB hash and compares.
+  Mismatch → return `nil, ErrHashMismatch` and emit a stderr warning.
+  The caller must treat `nil` stats as "default-stats mode" (planner
+  consumer arrives in PR2).
+- `FormatVer` mismatch is also `nil + warning`. Same fallback.
+- `TrailerCRC` mismatch → `nil + warning`. Detects truncation/bitrot.
+
+## 6. Known limitations (v1)
+
+- **String histograms are insertion-order, not lexicographic.** Buckets
+  on a string column partition the interned-id space, which is
+  insertion-order. This is fine for skew detection but useless for
+  range predicates on strings. The planner consumer (PR2) must not
+  use string histograms for range estimation.
+- **No streaming write.** The sidecar is built in memory then flushed
+  in one shot. Mastodon-scale (~30 MB EDB) sidecar is ~1.5 MB; well
+  within budget.
+- **No compression.** Plan §2.2 mentions gzip; we omit it for v1
+  because the wire size is already small and uncompressed access
+  simplifies inspection and partial-read patterns the planner may
+  want later. Revisit if sidecar > 10% of EDB on any real corpus.
+
+## 7. CLI surface
+
+```
+tsq extract <project>          # writes .stats alongside .db unless --no-stats
+tsq extract --no-stats <project>
+tsq stats compute <db>         # rebuild sidecar for an existing EDB
+tsq stats inspect <db> [rel]   # human-readable dump
+```

--- a/docs/design/stats-sidecar-format.md
+++ b/docs/design/stats-sidecar-format.md
@@ -62,40 +62,63 @@ Col[0..ColCount-1]               # see §3.1
 ```
 Pos          uint32
 NDV          int64                # HyperLogLog estimate, ≥0
-NullFrac     float64              # zero-id fraction (0.0..1.0)
+NullFrac     float64              # null-fraction in [0.0, 1.0]; only
+                                  # incremented for columns whose
+                                  # ColumnDef.Nullable is true. Non-
+                                  # nullable columns always emit 0.
 TopKCount    uint32               # ≤ 32
 TopK[0..TopKCount-1]:
-    Value uint64
-    Count int64
+    Value uint64                  # raw id (int32/entity-ref) or 64-bit
+                                  # FNV-1a surrogate id (string column)
+    Count int64                   # SpaceSaving lower bound (count - err)
 HistBucketCount uint32            # 0 if NDV ≤ NDVHistogramThreshold
+                                  # OR column is TypeString (string
+                                  # histograms are out of scope for v1)
 Hist[0..count-1]:
     Lo    uint64
     Hi    uint64
     Count int64
 ```
 
+**Per-column-type bucket-shape limitation:** all histogram buckets use
+`uint64` Lo/Hi regardless of the underlying column type. For
+int32/entity-ref columns this is a faithful representation. For string
+columns no bucket is emitted (HistBucketCount = 0); per-string-id
+ordering is meaningless to the planner. Future column types
+(time-of-day, decimal) will need a per-type bucket shape — that's a
+format-version bump.
+
 ### 3.2 Sentinels
 
 - `TopKCount = 0` means "no observed top values" (e.g. empty relation).
 - `HistBucketCount = 0` means "no histogram emitted" — either because
   `NDV ≤ NDVHistogramThreshold` (currently 256) or because the column
-  type does not admit ordered bucketing (string columns are bucketed
-  on their interned uint32 id, which is monotonic with insertion
-  order, not lexicographic — this is a known and accepted limitation
-  for v1; see §6).
+  is `TypeString`. String columns currently use a 64-bit FNV-1a
+  surrogate id for TopK/reservoir tracking; that id has no useful
+  ordering, so a numeric equi-depth histogram on it would produce
+  meaningless boundaries. The planner's consumer falls back to default
+  selectivity for string columns. See §6 for the v1 limitations list.
 
 ## 4. Per-pair join block (`JoinStats`)
 
 ```
-LeftRelLen     uint32
-LeftRel        [..]byte
-LeftCol        uint32
-RightRelLen    uint32
-RightRel       [..]byte
-RightCol       uint32
-Selectivity    float64           # |L⋈R| / (|L| × |R|)
-DistinctMatches int64            # |πLeftCol(L) ∩ πRightCol(R)| (HLL intersect estimate)
+LeftRelLen      uint32
+LeftRel         [..]byte
+LeftCol         uint32
+RightRelLen     uint32
+RightRel        [..]byte
+RightCol        uint32
+LRSelectivity   float64           # P(random L row matches ≥1 R row)
+RLSelectivity   float64           # P(random R row matches ≥1 L row)
+DistinctMatches int64             # |πLeftCol(L) ∩ πRightCol(R)| (HLL intersect estimate)
 ```
+
+**Selectivity is asymmetric.** A symmetric scalar collapses two very
+different planner answers into one. Example: on `Contains(parent,
+child)` joined to itself, a child has exactly one parent (LR sel
+near 1) but a parent has many children (RL sel ≪ 1). The split is
+introduced now while no consumer reads JoinStats; bumping it later
+would require a format-version migration.
 
 `JoinStats` are emitted only for relation/column pairs declared in
 `extract/schema/joinpaired.go` (added by this PR). Initial set: empty.
@@ -124,11 +147,11 @@ populate as `mayResolveTo` shapes need them. The plan calls out
 
 ## 6. Known limitations (v1)
 
-- **String histograms are insertion-order, not lexicographic.** Buckets
-  on a string column partition the interned-id space, which is
-  insertion-order. This is fine for skew detection but useless for
-  range predicates on strings. The planner consumer (PR2) must not
-  use string histograms for range estimation.
+- **No string-column histograms.** Histograms are skipped entirely for
+  `TypeString` columns: their per-row id is a 64-bit FNV-1a hash of
+  the string contents, with no useful ordering. The TopK list still
+  surfaces frequent strings (skew detection works). Range predicates
+  on strings fall back to default selectivity in the planner.
 - **No streaming write.** The sidecar is built in memory then flushed
   in one shot. Mastodon-scale (~30 MB EDB) sidecar is ~1.5 MB; well
   within budget.

--- a/extract/schema/registry.go
+++ b/extract/schema/registry.go
@@ -13,9 +13,21 @@ const (
 )
 
 // ColumnDef describes one column of a relation.
+//
+// Nullable declares whether the column is permitted to hold a "missing"
+// sentinel value at the storage layer. Today the only sentinel we have
+// for integer/entity-ref columns is 0, and for string columns it is the
+// empty-string intern (id 0). Nullability is OFF by default: real EDB
+// data uses 0 as a valid id (e.g. file id 0 is legal), so opting a
+// column into null tracking is an explicit per-column declaration in
+// relations.go. Stats compute consults this field to decide whether to
+// increment NullFrac for zero-valued cells; for non-nullable columns
+// NullFrac stays 0 and the planner's IS NULL / outer-join cardinality
+// estimates won't be poisoned by the conservative reading.
 type ColumnDef struct {
-	Name string
-	Type ColumnType
+	Name     string
+	Type     ColumnType
+	Nullable bool
 }
 
 // RelationDef describes a fact relation in the schema.

--- a/ql/stats/codec.go
+++ b/ql/stats/codec.go
@@ -126,6 +126,14 @@ func Decode(buf []byte) (*Schema, error) {
 }
 
 // --- write helpers --------------------------------------------------------
+//
+// All write helpers target *bytes.Buffer and discard the (n, err)
+// return tuple. bytes.Buffer.Write never returns a non-nil error — see
+// the standard library docs ("the return value n is the length of p;
+// err is always nil"). The buffer grows as needed; the only failure
+// mode is OOM, which panics. If/when the Encoder is generalised to
+// accept any io.Writer (currently it materialises into a buffer for
+// CRC), these helpers must be revised to propagate errors.
 
 func writeU32(w *bytes.Buffer, v uint32) {
 	var b [4]byte
@@ -185,7 +193,8 @@ func writeJoin(w *bytes.Buffer, j *JoinStats) {
 	writeU32(w, uint32(j.LeftCol))
 	writeStr(w, j.RightRel)
 	writeU32(w, uint32(j.RightCol))
-	writeF64(w, j.Selectivity)
+	writeF64(w, j.LRSelectivity)
+	writeF64(w, j.RLSelectivity)
 	writeI64(w, j.DistinctMatches)
 }
 
@@ -238,8 +247,19 @@ func (r *reader) bytesInto(out []byte) {
 	r.pos += len(out)
 }
 
+// maxStrLen caps the length of a single decoded string field at 64 MB.
+// Sidecar string fields hold relation names and similar identifiers —
+// realistic sizes are well under 1 KB. This ceiling exists to fail
+// loudly on a corrupt length prefix instead of attempting a multi-GB
+// allocation.
+const maxStrLen = 64 << 20
+
 func (r *reader) str() string {
 	n := r.u32()
+	if n > maxStrLen {
+		r.err = fmt.Errorf("stats: string length %d exceeds cap %d at pos=%d", n, maxStrLen, r.pos)
+		return ""
+	}
 	if !r.need(int(n)) {
 		return ""
 	}
@@ -303,7 +323,8 @@ func readJoin(r *reader) (JoinStats, error) {
 	j.LeftCol = int(r.u32())
 	j.RightRel = r.str()
 	j.RightCol = int(r.u32())
-	j.Selectivity = r.f64()
+	j.LRSelectivity = r.f64()
+	j.RLSelectivity = r.f64()
 	j.DistinctMatches = r.i64()
 	return j, r.err
 }

--- a/ql/stats/codec.go
+++ b/ql/stats/codec.go
@@ -1,0 +1,309 @@
+package stats
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"math"
+	"sort"
+	"time"
+)
+
+// ErrBadMagic is returned when the sidecar header doesn't begin with Magic.
+var ErrBadMagic = errors.New("stats: bad magic")
+
+// ErrFormatVersion is returned when FormatVer doesn't equal FormatVersion.
+var ErrFormatVersion = errors.New("stats: unsupported format version")
+
+// ErrCRC is returned when the trailer CRC doesn't match the body.
+var ErrCRC = errors.New("stats: trailer CRC mismatch")
+
+// ErrHashMismatch is returned by Load when the sidecar's EDBHash does
+// not match the EDB hash the caller passed for validation.
+var ErrHashMismatch = errors.New("stats: EDB hash mismatch (sidecar is stale)")
+
+var le = binary.LittleEndian
+
+// Encode serialises s to w. The format is documented in
+// docs/design/stats-sidecar-format.md.
+func Encode(w io.Writer, s *Schema) error {
+	if s == nil {
+		return fmt.Errorf("stats.Encode: nil schema")
+	}
+	var body bytes.Buffer
+
+	// Header (after Magic, which goes straight to w too — but we keep
+	// it in `body` so the trailer CRC covers everything pre-trailer).
+	body.WriteString(Magic)
+	writeU32(&body, FormatVersion)
+	body.Write(s.EDBHash[:])
+	writeI64(&body, s.BuiltAt.Unix())
+
+	// Sort relation names for deterministic output.
+	names := make([]string, 0, len(s.Rels))
+	for n := range s.Rels {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	writeU32(&body, uint32(len(names)))
+	for _, n := range names {
+		if err := writeRel(&body, s.Rels[n]); err != nil {
+			return err
+		}
+	}
+
+	writeU32(&body, uint32(len(s.Joins)))
+	for i := range s.Joins {
+		writeJoin(&body, &s.Joins[i])
+	}
+
+	// Trailer CRC over the entire body.
+	crc := crc32.ChecksumIEEE(body.Bytes())
+	writeU32(&body, crc)
+
+	_, err := w.Write(body.Bytes())
+	return err
+}
+
+// Decode reads a sidecar from buf. Validates magic, format version,
+// and trailer CRC. Does NOT validate EDBHash — that is Load's job
+// because it requires comparing against the live EDB.
+func Decode(buf []byte) (*Schema, error) {
+	if len(buf) < len(Magic)+4+HashSize+8+4+4 {
+		return nil, fmt.Errorf("stats: truncated (size %d)", len(buf))
+	}
+	if string(buf[:len(Magic)]) != Magic {
+		return nil, ErrBadMagic
+	}
+	// Verify CRC first to catch bitrot before we trust any internal
+	// length prefix.
+	body := buf[:len(buf)-4]
+	want := le.Uint32(buf[len(buf)-4:])
+	if got := crc32.ChecksumIEEE(body); got != want {
+		return nil, ErrCRC
+	}
+
+	r := &reader{buf: buf, pos: len(Magic)}
+	formatVer := r.u32()
+	if formatVer != FormatVersion {
+		return nil, fmt.Errorf("%w: file=%d, supported=%d", ErrFormatVersion, formatVer, FormatVersion)
+	}
+	s := &Schema{FormatVersion: formatVer}
+	r.bytesInto(s.EDBHash[:])
+	s.BuiltAt = time.Unix(r.i64(), 0).UTC()
+
+	relCount := r.u32()
+	s.Rels = make(map[string]*RelStats, relCount)
+	for i := uint32(0); i < relCount; i++ {
+		rs, err := readRel(r)
+		if err != nil {
+			return nil, err
+		}
+		s.Rels[rs.Name] = rs
+	}
+	joinCount := r.u32()
+	s.Joins = make([]JoinStats, 0, joinCount)
+	for i := uint32(0); i < joinCount; i++ {
+		js, err := readJoin(r)
+		if err != nil {
+			return nil, err
+		}
+		s.Joins = append(s.Joins, js)
+	}
+
+	// pos should be exactly len(buf)-4 now (trailer)
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.pos != len(buf)-4 {
+		return nil, fmt.Errorf("stats: trailing garbage: pos=%d, want=%d", r.pos, len(buf)-4)
+	}
+	return s, nil
+}
+
+// --- write helpers --------------------------------------------------------
+
+func writeU32(w *bytes.Buffer, v uint32) {
+	var b [4]byte
+	le.PutUint32(b[:], v)
+	w.Write(b[:])
+}
+
+func writeU64(w *bytes.Buffer, v uint64) {
+	var b [8]byte
+	le.PutUint64(b[:], v)
+	w.Write(b[:])
+}
+
+func writeI64(w *bytes.Buffer, v int64) {
+	writeU64(w, uint64(v))
+}
+
+func writeF64(w *bytes.Buffer, v float64) {
+	writeU64(w, math.Float64bits(v))
+}
+
+func writeStr(w *bytes.Buffer, s string) {
+	writeU32(w, uint32(len(s)))
+	w.WriteString(s)
+}
+
+func writeRel(w *bytes.Buffer, r *RelStats) error {
+	writeStr(w, r.Name)
+	writeU32(w, uint32(r.Arity))
+	writeI64(w, r.RowCount)
+	writeU32(w, uint32(len(r.Cols)))
+	for _, c := range r.Cols {
+		writeCol(w, &c)
+	}
+	return nil
+}
+
+func writeCol(w *bytes.Buffer, c *ColStats) {
+	writeU32(w, uint32(c.Pos))
+	writeI64(w, c.NDV)
+	writeF64(w, c.NullFrac)
+	writeU32(w, uint32(len(c.TopK)))
+	for _, t := range c.TopK {
+		writeU64(w, t.Value)
+		writeI64(w, t.Count)
+	}
+	writeU32(w, uint32(len(c.HistBuckets)))
+	for _, b := range c.HistBuckets {
+		writeU64(w, b.Lo)
+		writeU64(w, b.Hi)
+		writeI64(w, b.Count)
+	}
+}
+
+func writeJoin(w *bytes.Buffer, j *JoinStats) {
+	writeStr(w, j.LeftRel)
+	writeU32(w, uint32(j.LeftCol))
+	writeStr(w, j.RightRel)
+	writeU32(w, uint32(j.RightCol))
+	writeF64(w, j.Selectivity)
+	writeI64(w, j.DistinctMatches)
+}
+
+// --- read helpers ---------------------------------------------------------
+
+type reader struct {
+	buf []byte
+	pos int
+	err error
+}
+
+func (r *reader) need(n int) bool {
+	if r.err != nil {
+		return false
+	}
+	if r.pos+n > len(r.buf) {
+		r.err = fmt.Errorf("stats: short read at pos=%d (need %d, have %d)", r.pos, n, len(r.buf)-r.pos)
+		return false
+	}
+	return true
+}
+
+func (r *reader) u32() uint32 {
+	if !r.need(4) {
+		return 0
+	}
+	v := le.Uint32(r.buf[r.pos:])
+	r.pos += 4
+	return v
+}
+
+func (r *reader) u64() uint64 {
+	if !r.need(8) {
+		return 0
+	}
+	v := le.Uint64(r.buf[r.pos:])
+	r.pos += 8
+	return v
+}
+
+func (r *reader) i64() int64 { return int64(r.u64()) }
+
+func (r *reader) f64() float64 { return math.Float64frombits(r.u64()) }
+
+func (r *reader) bytesInto(out []byte) {
+	if !r.need(len(out)) {
+		return
+	}
+	copy(out, r.buf[r.pos:r.pos+len(out)])
+	r.pos += len(out)
+}
+
+func (r *reader) str() string {
+	n := r.u32()
+	if !r.need(int(n)) {
+		return ""
+	}
+	s := string(r.buf[r.pos : r.pos+int(n)])
+	r.pos += int(n)
+	return s
+}
+
+func readRel(r *reader) (*RelStats, error) {
+	rs := &RelStats{}
+	rs.Name = r.str()
+	rs.Arity = int(r.u32())
+	rs.RowCount = r.i64()
+	colCount := r.u32()
+	if int(colCount) != rs.Arity {
+		return nil, fmt.Errorf("stats: rel %q: arity %d != colcount %d", rs.Name, rs.Arity, colCount)
+	}
+	rs.Cols = make([]ColStats, colCount)
+	for i := uint32(0); i < colCount; i++ {
+		c, err := readCol(r)
+		if err != nil {
+			return nil, err
+		}
+		rs.Cols[i] = c
+	}
+	return rs, r.err
+}
+
+func readCol(r *reader) (ColStats, error) {
+	c := ColStats{}
+	c.Pos = int(r.u32())
+	c.NDV = r.i64()
+	c.NullFrac = r.f64()
+	tk := r.u32()
+	if tk > TopKLimit {
+		return c, fmt.Errorf("stats: TopKCount %d exceeds limit %d", tk, TopKLimit)
+	}
+	if tk > 0 {
+		c.TopK = make([]TopKEntry, tk)
+		for i := uint32(0); i < tk; i++ {
+			c.TopK[i] = TopKEntry{Value: r.u64(), Count: r.i64()}
+		}
+	}
+	hb := r.u32()
+	const maxHist = 4096 // sanity ceiling far above HistogramBuckets
+	if hb > maxHist {
+		return c, fmt.Errorf("stats: HistBucketCount %d exceeds %d", hb, maxHist)
+	}
+	if hb > 0 {
+		c.HistBuckets = make([]Bucket, hb)
+		for i := uint32(0); i < hb; i++ {
+			c.HistBuckets[i] = Bucket{Lo: r.u64(), Hi: r.u64(), Count: r.i64()}
+		}
+	}
+	return c, r.err
+}
+
+func readJoin(r *reader) (JoinStats, error) {
+	j := JoinStats{}
+	j.LeftRel = r.str()
+	j.LeftCol = int(r.u32())
+	j.RightRel = r.str()
+	j.RightCol = int(r.u32())
+	j.Selectivity = r.f64()
+	j.DistinctMatches = r.i64()
+	return j, r.err
+}

--- a/ql/stats/codec_test.go
+++ b/ql/stats/codec_test.go
@@ -1,0 +1,177 @@
+package stats
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func sampleSchema() *Schema {
+	s := &Schema{
+		FormatVersion: FormatVersion,
+		BuiltAt:       time.Unix(1700000000, 0).UTC(),
+		Rels: map[string]*RelStats{
+			"R": {
+				Name:     "R",
+				Arity:    2,
+				RowCount: 12345,
+				Cols: []ColStats{
+					{
+						Pos: 0, NDV: 999, NullFrac: 0.01,
+						TopK: []TopKEntry{{Value: 7, Count: 100}, {Value: 8, Count: 50}},
+					},
+					{
+						Pos: 1, NDV: 500, NullFrac: 0.0,
+						HistBuckets: []Bucket{{Lo: 0, Hi: 10, Count: 1000}, {Lo: 11, Hi: 99, Count: 11345}},
+					},
+				},
+			},
+			"S": {
+				Name: "S", Arity: 1, RowCount: 0,
+				Cols: []ColStats{{Pos: 0}},
+			},
+		},
+		Joins: []JoinStats{
+			{LeftRel: "R", LeftCol: 0, RightRel: "S", RightCol: 0, Selectivity: 0.0123, DistinctMatches: 42},
+		},
+	}
+	for i := range s.EDBHash {
+		s.EDBHash[i] = byte(i)
+	}
+	return s
+}
+
+func TestCodec_RoundTrip(t *testing.T) {
+	s := sampleSchema()
+	var buf bytes.Buffer
+	if err := Encode(&buf, s); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got, err := Decode(buf.Bytes())
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.FormatVersion != s.FormatVersion {
+		t.Errorf("FormatVersion: got %d, want %d", got.FormatVersion, s.FormatVersion)
+	}
+	if got.EDBHash != s.EDBHash {
+		t.Errorf("EDBHash: got %x, want %x", got.EDBHash, s.EDBHash)
+	}
+	if !got.BuiltAt.Equal(s.BuiltAt) {
+		t.Errorf("BuiltAt: got %s, want %s", got.BuiltAt, s.BuiltAt)
+	}
+	if !reflect.DeepEqual(got.Rels, s.Rels) {
+		t.Errorf("Rels mismatch:\n got=%+v\nwant=%+v", got.Rels, s.Rels)
+	}
+	if !reflect.DeepEqual(got.Joins, s.Joins) {
+		t.Errorf("Joins mismatch:\n got=%+v\nwant=%+v", got.Joins, s.Joins)
+	}
+}
+
+// Determinism: encoding the same schema twice must produce the same
+// bytes (sorted relation iteration). This underpins reproducible plans
+// across runs (plan §8.3).
+func TestCodec_Deterministic(t *testing.T) {
+	s := sampleSchema()
+	var a, b bytes.Buffer
+	if err := Encode(&a, s); err != nil {
+		t.Fatal(err)
+	}
+	if err := Encode(&b, s); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a.Bytes(), b.Bytes()) {
+		t.Fatalf("non-deterministic: %d vs %d bytes", a.Len(), b.Len())
+	}
+}
+
+func TestCodec_BadMagic(t *testing.T) {
+	// Buffer must be ≥ minimum sidecar size so we hit the magic check
+	// rather than the truncation check. Pad with zeroes.
+	buf := make([]byte, 200)
+	copy(buf, "XXXX\x00")
+	_, err := Decode(buf)
+	if !errors.Is(err, ErrBadMagic) {
+		t.Fatalf("expected ErrBadMagic, got %v", err)
+	}
+}
+
+func TestCodec_Truncated(t *testing.T) {
+	_, err := Decode([]byte("TSQS\x00"))
+	if err == nil {
+		t.Fatal("expected error on truncated buffer")
+	}
+}
+
+func TestCodec_CRCMismatch(t *testing.T) {
+	s := sampleSchema()
+	var buf bytes.Buffer
+	if err := Encode(&buf, s); err != nil {
+		t.Fatal(err)
+	}
+	b := buf.Bytes()
+	// Flip a byte in the middle (within the body, not the trailer).
+	b[len(b)/2] ^= 0xff
+	_, err := Decode(b)
+	if !errors.Is(err, ErrCRC) {
+		t.Fatalf("expected ErrCRC, got %v", err)
+	}
+}
+
+func TestCodec_FormatVersionMismatch(t *testing.T) {
+	s := sampleSchema()
+	s.FormatVersion = 999 // doesn't matter — Encode writes the current FormatVersion constant
+	var buf bytes.Buffer
+	if err := Encode(&buf, s); err != nil {
+		t.Fatal(err)
+	}
+	// Manually corrupt the version field in the encoded bytes.
+	b := buf.Bytes()
+	// Layout: Magic(5) | FormatVer(4) | EDBHash(32) | ...
+	b[5] = 99
+	b[6] = 0
+	b[7] = 0
+	b[8] = 0
+	// Recompute trailer CRC so we don't get ErrCRC instead.
+	// (For this test we'd rather see ErrFormatVersion; recomputing the
+	// CRC keeps the test focused.)
+	body := b[:len(b)-4]
+	rebuildCRC(b, body)
+	_, err := Decode(b)
+	if !errors.Is(err, ErrFormatVersion) {
+		t.Fatalf("expected ErrFormatVersion, got %v", err)
+	}
+}
+
+func rebuildCRC(full, body []byte) {
+	crc := crc32IEEE(body)
+	full[len(full)-4] = byte(crc)
+	full[len(full)-3] = byte(crc >> 8)
+	full[len(full)-2] = byte(crc >> 16)
+	full[len(full)-1] = byte(crc >> 24)
+}
+
+// Local CRC helper to avoid importing hash/crc32 in test (we already
+// use it in production, but isolating the test keeps it easy to read).
+func crc32IEEE(b []byte) uint32 {
+	// IEEE polynomial: identical to hash/crc32.ChecksumIEEE.
+	var tab [256]uint32
+	for i := 0; i < 256; i++ {
+		c := uint32(i)
+		for j := 0; j < 8; j++ {
+			if c&1 != 0 {
+				c = 0xedb88320 ^ (c >> 1)
+			} else {
+				c >>= 1
+			}
+		}
+		tab[i] = c
+	}
+	c := ^uint32(0)
+	for _, x := range b {
+		c = tab[byte(c)^x] ^ (c >> 8)
+	}
+	return ^c
+}

--- a/ql/stats/codec_test.go
+++ b/ql/stats/codec_test.go
@@ -34,7 +34,7 @@ func sampleSchema() *Schema {
 			},
 		},
 		Joins: []JoinStats{
-			{LeftRel: "R", LeftCol: 0, RightRel: "S", RightCol: 0, Selectivity: 0.0123, DistinctMatches: 42},
+			{LeftRel: "R", LeftCol: 0, RightRel: "S", RightCol: 0, LRSelectivity: 0.0123, RLSelectivity: 0.987, DistinctMatches: 42},
 		},
 	}
 	for i := range s.EDBHash {

--- a/ql/stats/compute.go
+++ b/ql/stats/compute.go
@@ -1,0 +1,284 @@
+package stats
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/Gjdoalfnrxu/tsq/extract/db"
+	"github.com/Gjdoalfnrxu/tsq/extract/schema"
+)
+
+// colAccum is the in-flight accumulator for one column.
+type colAccum struct {
+	hll       *HLL
+	heavy     *SpaceSaving
+	reservoir *Reservoir
+	nulls     int64
+	rows      int64
+}
+
+func newColAccum(seed int64) *colAccum {
+	return &colAccum{
+		hll:       NewHLL(),
+		heavy:     NewSpaceSaving(),
+		reservoir: NewReservoir(seed),
+	}
+}
+
+func (c *colAccum) addInt(v int32) {
+	c.rows++
+	if v == 0 {
+		c.nulls++
+	}
+	uv := uint64(uint32(v))
+	c.hll.AddUint64(uv)
+	c.heavy.Add(uv)
+	c.reservoir.Add(uv)
+}
+
+func (c *colAccum) addStringID(idx uint32, raw []byte) {
+	c.rows++
+	if idx == 0 {
+		// String table index 0 is the empty string by writer convention.
+		c.nulls++
+	}
+	c.hll.AddBytes(raw)
+	c.heavy.Add(uint64(idx))
+	c.reservoir.Add(uint64(idx))
+}
+
+// finalise produces a ColStats from the accumulator.
+// pos is the column position; relRows is the relation's row count.
+func (c *colAccum) finalise(pos int, relRows int64) ColStats {
+	ndv := c.hll.Estimate()
+	cs := ColStats{
+		Pos:  pos,
+		NDV:  ndv,
+		TopK: c.heavy.TopK(TopKLimit),
+	}
+	if c.rows > 0 {
+		cs.NullFrac = float64(c.nulls) / float64(c.rows)
+	}
+	if ndv > NDVHistogramThreshold {
+		cs.HistBuckets = c.reservoir.Histogram(HistogramBuckets, relRows)
+	}
+	return cs
+}
+
+// Compute walks every relation in `database`, builds per-column stats,
+// then computes JoinStats for the declared JoinPaired set.
+//
+// edbHash is the SHA-256 of the EDB on disk; the caller is responsible
+// for computing it (see HashFile). Compute does not touch the disk.
+func Compute(database *db.DB, edbHash [HashSize]byte) (*Schema, error) {
+	if database == nil {
+		return nil, fmt.Errorf("stats.Compute: nil database")
+	}
+	s := &Schema{
+		FormatVersion: FormatVersion,
+		EDBHash:       edbHash,
+		BuiltAt:       time.Now().UTC(),
+		Rels:          make(map[string]*RelStats),
+	}
+
+	// Per-relation: walk every tuple, accumulate per column.
+	for _, def := range schema.Registry {
+		rel := database.Relation(def.Name)
+		nrows := rel.Tuples()
+		rs := &RelStats{
+			Name:     def.Name,
+			Arity:    def.Arity(),
+			RowCount: int64(nrows),
+			Cols:     make([]ColStats, def.Arity()),
+		}
+		accs := make([]*colAccum, def.Arity())
+		for i := range accs {
+			// Seed the reservoir per-(rel, col) deterministically so
+			// stats are reproducible across runs.
+			accs[i] = newColAccum(int64(stableSeed(def.Name, i)))
+		}
+		for t := 0; t < nrows; t++ {
+			for c := 0; c < def.Arity(); c++ {
+				switch def.Columns[c].Type {
+				case schema.TypeInt32, schema.TypeEntityRef:
+					v, err := rel.GetInt(t, c)
+					if err != nil {
+						return nil, fmt.Errorf("stats: %s[%d].col%d: %w", def.Name, t, c, err)
+					}
+					accs[c].addInt(v)
+				case schema.TypeString:
+					str, err := rel.GetString(database, t, c)
+					if err != nil {
+						return nil, fmt.Errorf("stats: %s[%d].col%d: %w", def.Name, t, c, err)
+					}
+					// We need the interned id for TopK/reservoir. Re-use the
+					// writer's intern via the public API: AddTuple already
+					// populated the column with an index but we don't expose
+					// it. Hash the string for HLL; assign a stable id by
+					// hashing for top-K (collisions only affect TopK
+					// preview, not NDV — tolerable).
+					id := fnv32(str)
+					accs[c].addStringID(id, []byte(str))
+				}
+			}
+		}
+		for c := range accs {
+			rs.Cols[c] = accs[c].finalise(c, int64(nrows))
+		}
+		s.Rels[def.Name] = rs
+	}
+
+	// JoinStats: empty in v1 — see joinpaired.go for declarations.
+	for _, jp := range JoinPaired {
+		js, err := computeJoin(database, jp)
+		if err != nil {
+			// Soft-fail: skip the bad pair, record nothing. JoinStats
+			// are advisory; better to ship without than to abort.
+			continue
+		}
+		s.Joins = append(s.Joins, js)
+	}
+
+	return s, nil
+}
+
+// computeJoin produces the precomputed selectivity for one JoinPaired
+// declaration. Two-pass: build per-side HLLs over the keys, then
+// inclusion-exclusion for distinct matches; sample for selectivity.
+func computeJoin(database *db.DB, jp JoinPair) (JoinStats, error) {
+	leftDef, ok := schema.Lookup(jp.LeftRel)
+	if !ok {
+		return JoinStats{}, fmt.Errorf("unknown rel %q", jp.LeftRel)
+	}
+	rightDef, ok := schema.Lookup(jp.RightRel)
+	if !ok {
+		return JoinStats{}, fmt.Errorf("unknown rel %q", jp.RightRel)
+	}
+	if jp.LeftCol >= leftDef.Arity() || jp.RightCol >= rightDef.Arity() {
+		return JoinStats{}, fmt.Errorf("col oob")
+	}
+	left := database.Relation(jp.LeftRel)
+	right := database.Relation(jp.RightRel)
+	lrows := left.Tuples()
+	rrows := right.Tuples()
+
+	lhll := NewHLL()
+	for t := 0; t < lrows; t++ {
+		v, err := left.GetInt(t, jp.LeftCol)
+		if err != nil {
+			return JoinStats{}, err
+		}
+		lhll.AddUint64(uint64(uint32(v)))
+	}
+	rhll := NewHLL()
+	rightSet := make(map[int32]struct{}, rrows)
+	for t := 0; t < rrows; t++ {
+		v, err := right.GetInt(t, jp.RightCol)
+		if err != nil {
+			return JoinStats{}, err
+		}
+		rhll.AddUint64(uint64(uint32(v)))
+		rightSet[v] = struct{}{}
+	}
+
+	js := JoinStats{
+		LeftRel:         jp.LeftRel,
+		LeftCol:         jp.LeftCol,
+		RightRel:        jp.RightRel,
+		RightCol:        jp.RightCol,
+		DistinctMatches: IntersectEstimate(lhll, rhll),
+	}
+
+	// Selectivity by sampling: for up to 1024 left rows, count matches
+	// against the right set, scale up.
+	const probeSize = 1024
+	probe := lrows
+	if probe > probeSize {
+		probe = probeSize
+	}
+	if probe == 0 || rrows == 0 {
+		return js, nil
+	}
+	step := lrows / probe
+	if step < 1 {
+		step = 1
+	}
+	var hits int64
+	for t := 0; t < lrows; t += step {
+		v, _ := left.GetInt(t, jp.LeftCol)
+		if _, ok := rightSet[v]; ok {
+			hits++
+		}
+	}
+	probedLeft := int64(0)
+	for t := 0; t < lrows; t += step {
+		probedLeft++
+	}
+	if probedLeft == 0 || rrows == 0 {
+		return js, nil
+	}
+	// Selectivity := |L⋈R| / (|L| × |R|)
+	// Estimate |L⋈R| from the sample: each probed left row that hits
+	// joins with (rrows / distinct_right_keys) right rows on average.
+	// For NDV-balanced right keys this collapses to (hits/probed) ×
+	// (lrows × rrows / distinct_right_keys), giving:
+	// selectivity = hits / (probed × distinct_right_keys).
+	distinctRight := rhll.Estimate()
+	if distinctRight <= 0 {
+		distinctRight = int64(len(rightSet))
+	}
+	if distinctRight > 0 {
+		js.Selectivity = float64(hits) / (float64(probedLeft) * float64(distinctRight))
+	}
+	return js, nil
+}
+
+// HashFile returns the SHA-256 of the file at path. Caller passes the
+// result to Compute as edbHash, and the loader uses it on Load to
+// reject stale sidecars (plan §2.3).
+func HashFile(path string) ([HashSize]byte, error) {
+	var out [HashSize]byte
+	f, err := os.Open(path)
+	if err != nil {
+		return out, fmt.Errorf("stats.HashFile: %w", err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return out, fmt.Errorf("stats.HashFile: %w", err)
+	}
+	copy(out[:], h.Sum(nil))
+	return out, nil
+}
+
+// fnv32 is a tiny inline FNV-1a 32-bit hash. Used as a string-ID
+// surrogate for TopK/reservoir on string columns where we don't have
+// the writer's intern table accessible.
+func fnv32(s string) uint32 {
+	const (
+		offset32 = 2166136261
+		prime32  = 16777619
+	)
+	h := uint32(offset32)
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= prime32
+	}
+	return h
+}
+
+// stableSeed produces a deterministic per-(rel, col) seed for reservoir
+// sampling, so that stats sidecars are bytewise reproducible across
+// runs (plan §8.3 determinism).
+func stableSeed(relName string, col int) uint64 {
+	h := uint64(14695981039346656037)
+	for i := 0; i < len(relName); i++ {
+		h ^= uint64(relName[i])
+		h *= 1099511628211
+	}
+	h ^= uint64(col) * 0x9e3779b97f4a7c15
+	return h
+}

--- a/ql/stats/compute.go
+++ b/ql/stats/compute.go
@@ -28,9 +28,13 @@ func newColAccum(seed int64) *colAccum {
 	}
 }
 
-func (c *colAccum) addInt(v int32) {
+// addInt records one int32/entity-ref cell. If nullable is true, v == 0
+// is counted as a null (the sole sentinel for int/entity-ref columns).
+// For non-nullable columns NullFrac stays at 0 — real EDB rows can and
+// do carry id 0 as a legitimate value (e.g. the first interned file).
+func (c *colAccum) addInt(v int32, nullable bool) {
 	c.rows++
-	if v == 0 {
+	if nullable && v == 0 {
 		c.nulls++
 	}
 	uv := uint64(uint32(v))
@@ -39,20 +43,26 @@ func (c *colAccum) addInt(v int32) {
 	c.reservoir.Add(uv)
 }
 
-func (c *colAccum) addStringID(idx uint32, raw []byte) {
+// addStringID records one string cell. If nullable is true, intern id 0
+// (the empty-string slot by writer convention) is counted as null.
+func (c *colAccum) addStringID(idx uint64, raw []byte, nullable bool) {
 	c.rows++
-	if idx == 0 {
-		// String table index 0 is the empty string by writer convention.
+	if nullable && idx == 0 {
 		c.nulls++
 	}
 	c.hll.AddBytes(raw)
-	c.heavy.Add(uint64(idx))
-	c.reservoir.Add(uint64(idx))
+	c.heavy.Add(idx)
+	c.reservoir.Add(idx)
 }
 
 // finalise produces a ColStats from the accumulator.
 // pos is the column position; relRows is the relation's row count.
-func (c *colAccum) finalise(pos int, relRows int64) ColStats {
+// emitHistogram=false suppresses the equi-depth histogram even when NDV
+// crosses NDVHistogramThreshold — used for TypeString columns, whose
+// surrogate uint64 ids carry no usable order, so a numeric equi-depth
+// histogram would be meaningless to the planner. The planner's
+// consumer-side default-selectivity fallback handles the absence.
+func (c *colAccum) finalise(pos int, relRows int64, emitHistogram bool) ColStats {
 	ndv := c.hll.Estimate()
 	cs := ColStats{
 		Pos:  pos,
@@ -62,7 +72,7 @@ func (c *colAccum) finalise(pos int, relRows int64) ColStats {
 	if c.rows > 0 {
 		cs.NullFrac = float64(c.nulls) / float64(c.rows)
 	}
-	if ndv > NDVHistogramThreshold {
+	if emitHistogram && ndv > NDVHistogramThreshold {
 		cs.HistBuckets = c.reservoir.Histogram(HistogramBuckets, relRows)
 	}
 	return cs
@@ -80,8 +90,11 @@ func Compute(database *db.DB, edbHash [HashSize]byte) (*Schema, error) {
 	s := &Schema{
 		FormatVersion: FormatVersion,
 		EDBHash:       edbHash,
-		BuiltAt:       time.Now().UTC(),
-		Rels:          make(map[string]*RelStats),
+		// Truncate to second: on-disk encoding is Unix seconds, so
+		// keeping nanosecond precision in-memory creates a
+		// round-trip mismatch (`s.BuiltAt != Decode(Encode(s)).BuiltAt`).
+		BuiltAt: time.Now().UTC().Truncate(time.Second),
+		Rels:    make(map[string]*RelStats),
 	}
 
 	// Per-relation: walk every tuple, accumulate per column.
@@ -102,31 +115,35 @@ func Compute(database *db.DB, edbHash [HashSize]byte) (*Schema, error) {
 		}
 		for t := 0; t < nrows; t++ {
 			for c := 0; c < def.Arity(); c++ {
+				nullable := def.Columns[c].Nullable
 				switch def.Columns[c].Type {
 				case schema.TypeInt32, schema.TypeEntityRef:
 					v, err := rel.GetInt(t, c)
 					if err != nil {
 						return nil, fmt.Errorf("stats: %s[%d].col%d: %w", def.Name, t, c, err)
 					}
-					accs[c].addInt(v)
+					accs[c].addInt(v, nullable)
 				case schema.TypeString:
 					str, err := rel.GetString(database, t, c)
 					if err != nil {
 						return nil, fmt.Errorf("stats: %s[%d].col%d: %w", def.Name, t, c, err)
 					}
-					// We need the interned id for TopK/reservoir. Re-use the
-					// writer's intern via the public API: AddTuple already
-					// populated the column with an index but we don't expose
-					// it. Hash the string for HLL; assign a stable id by
-					// hashing for top-K (collisions only affect TopK
-					// preview, not NDV — tolerable).
-					id := fnv32(str)
-					accs[c].addStringID(id, []byte(str))
+					// 64-bit FNV-1a id surrogate. The writer's intern id is
+					// not exposed via the public Relation API, so we hash
+					// the string ourselves to assign a stable id for
+					// TopK/reservoir. 64-bit space keeps collisions
+					// negligible at the EDB-string-table ceiling
+					// (~50% collision probability only at ≈5 × 10^9
+					// distinct strings, vs ~77k for the previous 32-bit
+					// surrogate). HLL still uses the bytes directly.
+					id := fnv64(str)
+					accs[c].addStringID(id, []byte(str), nullable)
 				}
 			}
 		}
 		for c := range accs {
-			rs.Cols[c] = accs[c].finalise(c, int64(nrows))
+			emitHist := def.Columns[c].Type != schema.TypeString
+			rs.Cols[c] = accs[c].finalise(c, int64(nrows), emitHist)
 		}
 		s.Rels[def.Name] = rs
 	}
@@ -165,23 +182,38 @@ func computeJoin(database *db.DB, jp JoinPair) (JoinStats, error) {
 	lrows := left.Tuples()
 	rrows := right.Tuples()
 
+	// setCap bounds either-side membership probe set. Big-side FK pairs
+	// (Contains, ParamBinding, ...) can be enormous and we only need a
+	// representative population to estimate hit rate from the
+	// fixed-stride sample on the other side. Cap at 2× probeSize so the
+	// probe-vs-set ratio stays informative; HLLs still see every row,
+	// so DistinctMatches is exact-up-to-HLL across the full join.
+	const probeSize = 1024
+	const setCap = 2 * probeSize
+
 	lhll := NewHLL()
+	leftSet := make(map[int32]struct{}, min(lrows, setCap))
 	for t := 0; t < lrows; t++ {
 		v, err := left.GetInt(t, jp.LeftCol)
 		if err != nil {
 			return JoinStats{}, err
 		}
 		lhll.AddUint64(uint64(uint32(v)))
+		if len(leftSet) < setCap {
+			leftSet[v] = struct{}{}
+		}
 	}
 	rhll := NewHLL()
-	rightSet := make(map[int32]struct{}, rrows)
+	rightSet := make(map[int32]struct{}, min(rrows, setCap))
 	for t := 0; t < rrows; t++ {
 		v, err := right.GetInt(t, jp.RightCol)
 		if err != nil {
 			return JoinStats{}, err
 		}
 		rhll.AddUint64(uint64(uint32(v)))
-		rightSet[v] = struct{}{}
+		if len(rightSet) < setCap {
+			rightSet[v] = struct{}{}
+		}
 	}
 
 	js := JoinStats{
@@ -192,48 +224,59 @@ func computeJoin(database *db.DB, jp JoinPair) (JoinStats, error) {
 		DistinctMatches: IntersectEstimate(lhll, rhll),
 	}
 
-	// Selectivity by sampling: for up to 1024 left rows, count matches
-	// against the right set, scale up.
-	const probeSize = 1024
-	probe := lrows
-	if probe > probeSize {
-		probe = probeSize
-	}
-	if probe == 0 || rrows == 0 {
+	if lrows == 0 || rrows == 0 {
 		return js, nil
 	}
-	step := lrows / probe
+
+	js.LRSelectivity = sampleSelectivity(left, jp.LeftCol, lrows, rightSet, rhll, probeSize)
+	js.RLSelectivity = sampleSelectivity(right, jp.RightCol, rrows, leftSet, lhll, probeSize)
+	return js, nil
+}
+
+// sampleSelectivity probes up to probeSize source rows with a fixed
+// stride against the targetSet membership set and returns the
+// inclusion-exclusion estimate
+//
+//	selectivity ≈ hits / (probed × distinct_target_keys)
+//
+// where hits is the number of probed rows whose key is present in
+// targetSet, and distinct_target_keys is the HLL distinct-count of the
+// target column. When the target set was capped (large-side FK), hits
+// is a downward-biased estimator: the planner prefers a conservative
+// (under-) estimate of selectivity to an over-estimate.
+func sampleSelectivity(
+	source interface {
+		GetInt(t, c int) (int32, error)
+	},
+	col, srcRows int,
+	targetSet map[int32]struct{},
+	targetHLL *HLL,
+	probeSize int,
+) float64 {
+	step := srcRows / probeSize
 	if step < 1 {
 		step = 1
 	}
 	var hits int64
-	for t := 0; t < lrows; t += step {
-		v, _ := left.GetInt(t, jp.LeftCol)
-		if _, ok := rightSet[v]; ok {
+	var probed int64
+	for t := 0; t < srcRows; t += step {
+		v, _ := source.GetInt(t, col)
+		probed++
+		if _, ok := targetSet[v]; ok {
 			hits++
 		}
 	}
-	probedLeft := int64(0)
-	for t := 0; t < lrows; t += step {
-		probedLeft++
+	if probed == 0 {
+		return 0
 	}
-	if probedLeft == 0 || rrows == 0 {
-		return js, nil
+	distinctTarget := targetHLL.Estimate()
+	if distinctTarget <= 0 {
+		distinctTarget = int64(len(targetSet))
 	}
-	// Selectivity := |L⋈R| / (|L| × |R|)
-	// Estimate |L⋈R| from the sample: each probed left row that hits
-	// joins with (rrows / distinct_right_keys) right rows on average.
-	// For NDV-balanced right keys this collapses to (hits/probed) ×
-	// (lrows × rrows / distinct_right_keys), giving:
-	// selectivity = hits / (probed × distinct_right_keys).
-	distinctRight := rhll.Estimate()
-	if distinctRight <= 0 {
-		distinctRight = int64(len(rightSet))
+	if distinctTarget <= 0 {
+		return 0
 	}
-	if distinctRight > 0 {
-		js.Selectivity = float64(hits) / (float64(probedLeft) * float64(distinctRight))
-	}
-	return js, nil
+	return float64(hits) / (float64(probed) * float64(distinctTarget))
 }
 
 // HashFile returns the SHA-256 of the file at path. Caller passes the
@@ -254,18 +297,22 @@ func HashFile(path string) ([HashSize]byte, error) {
 	return out, nil
 }
 
-// fnv32 is a tiny inline FNV-1a 32-bit hash. Used as a string-ID
-// surrogate for TopK/reservoir on string columns where we don't have
-// the writer's intern table accessible.
-func fnv32(s string) uint32 {
+// fnv64 is FNV-1a 64-bit. Used as a string-id surrogate for
+// TopK/reservoir on string columns where the writer's intern table is
+// not exposed via the public Relation API. 64-bit width keeps
+// collisions negligible for the EDB string-table sizes we expect (the
+// previous 32-bit surrogate hit a 50% collision probability around
+// 77,000 distinct strings, which corrupted histogram boundaries on
+// even moderate fact databases).
+func fnv64(s string) uint64 {
 	const (
-		offset32 = 2166136261
-		prime32  = 16777619
+		offset64 uint64 = 14695981039346656037
+		prime64  uint64 = 1099511628211
 	)
-	h := uint32(offset32)
+	h := offset64
 	for i := 0; i < len(s); i++ {
-		h ^= uint32(s[i])
-		h *= prime32
+		h ^= uint64(s[i])
+		h *= prime64
 	}
 	return h
 }

--- a/ql/stats/compute_test.go
+++ b/ql/stats/compute_test.go
@@ -1,0 +1,131 @@
+package stats
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/extract/db"
+)
+
+// End-to-end: populate an EDB with a known shape, run Compute, persist,
+// reload, check that NDV/RowCount and at least one TopK match a hand
+// computation. Plan §7.1 gate: "tsq stats inspect output matches a
+// hand-computed gold for a 3-relation fixture."
+func TestCompute_HandComputedFixture(t *testing.T) {
+	database := db.NewDB()
+
+	// File: 3 rows, all distinct ids. Triggers the schema's File rel.
+	files := database.Relation("File")
+	for i := int32(1); i <= 3; i++ {
+		if err := files.AddTuple(database, i, "/tmp/f"+itoa(int(i))+".ts", "hash"+itoa(int(i))); err != nil {
+			t.Fatalf("File row %d: %v", i, err)
+		}
+	}
+
+	// Node: 100 rows, file column heavily skewed to file id 1 (90 rows).
+	nodes := database.Relation("Node")
+	for i := int32(1); i <= 90; i++ {
+		nodes.AddTuple(database, i, int32(1), "Identifier", int32(1), int32(1), int32(1), int32(2))
+	}
+	for i := int32(91); i <= 100; i++ {
+		nodes.AddTuple(database, i, int32(2), "Identifier", int32(1), int32(1), int32(1), int32(2))
+	}
+
+	// Encode to disk so we have an EDB to hash.
+	dir := t.TempDir()
+	edbPath := filepath.Join(dir, "fixture.db")
+	f, _ := os.Create(edbPath)
+	if err := database.Encode(f); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	hash, err := HashFile(edbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := Compute(database, hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fileStats := s.Lookup("File")
+	if fileStats == nil {
+		t.Fatal("File stats missing")
+	}
+	if fileStats.RowCount != 3 {
+		t.Errorf("File RowCount = %d, want 3", fileStats.RowCount)
+	}
+	if fileStats.Cols[0].NDV < 3 {
+		t.Errorf("File.id NDV = %d, want ≥3", fileStats.Cols[0].NDV)
+	}
+
+	nodeStats := s.Lookup("Node")
+	if nodeStats == nil {
+		t.Fatal("Node stats missing")
+	}
+	if nodeStats.RowCount != 100 {
+		t.Errorf("Node RowCount = %d, want 100", nodeStats.RowCount)
+	}
+	// Node.file (col 1) should have a heavy hitter at value 1 with count 90.
+	fileColTopK := nodeStats.Cols[1].TopK
+	if len(fileColTopK) < 2 {
+		t.Fatalf("Node.file TopK len=%d, want ≥2: %+v", len(fileColTopK), fileColTopK)
+	}
+	if fileColTopK[0].Value != 1 || fileColTopK[0].Count != 90 {
+		t.Errorf("Node.file top-1 = (%d, %d), want (1, 90)", fileColTopK[0].Value, fileColTopK[0].Count)
+	}
+
+	// Persist + reload + hash-validate.
+	if err := Save(edbPath, s); err != nil {
+		t.Fatal(err)
+	}
+	var warn bytes.Buffer
+	loaded, err := Load(edbPath, &warn)
+	if err != nil {
+		t.Fatalf("load: %v (warn=%s)", err, warn.String())
+	}
+	if loaded.Lookup("Node").Cols[1].TopK[0].Value != 1 {
+		t.Fatal("round-trip lost TopK")
+	}
+
+	// Inspect smoke test: write to /dev/null equivalent.
+	var inspectBuf bytes.Buffer
+	Inspect(&inspectBuf, loaded, "Node")
+	if inspectBuf.Len() == 0 {
+		t.Fatal("Inspect produced empty output")
+	}
+}
+
+// Empty schema: Compute on an empty DB should still produce a valid
+// schema with all relations at row=0.
+func TestCompute_EmptyDB(t *testing.T) {
+	database := db.NewDB()
+	dir := t.TempDir()
+	edb := filepath.Join(dir, "empty.db")
+	f, _ := os.Create(edb)
+	database.Encode(f)
+	f.Close()
+
+	hash, _ := HashFile(edb)
+	s, err := Compute(database, hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for n, r := range s.Rels {
+		if r.RowCount != 0 {
+			t.Errorf("rel %s row=%d, want 0", n, r.RowCount)
+		}
+	}
+}
+
+// Default-stats fallback: when there's no sidecar, planner-side code
+// will see nil. Lookup on nil schema must not panic.
+func TestSchema_NilLookup(t *testing.T) {
+	var s *Schema
+	if got := s.Lookup("Anything"); got != nil {
+		t.Fatalf("nil.Lookup should return nil, got %+v", got)
+	}
+}

--- a/ql/stats/compute_test.go
+++ b/ql/stats/compute_test.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"bytes"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -118,6 +119,105 @@ func TestCompute_EmptyDB(t *testing.T) {
 		if r.RowCount != 0 {
 			t.Errorf("rel %s row=%d, want 0", n, r.RowCount)
 		}
+	}
+}
+
+// Regression for BLOCKER 1 (PR #175 review): non-nullable columns must
+// keep NullFrac at 0 even when zero-valued cells are present. Real EDB
+// data uses 0 as a legitimate id (e.g. the first interned file slot),
+// and the planner must not treat those rows as null on outer-join /
+// IS NULL estimates. None of the registered schema columns are
+// declared Nullable, so seeding zeros into Node.startLine (an
+// int32 column) must produce NullFrac == 0.
+func TestCompute_NonNullableZeroIsNotNull(t *testing.T) {
+	database := db.NewDB()
+
+	files := database.Relation("File")
+	if err := files.AddTuple(database, int32(1), "/x.ts", "h"); err != nil {
+		t.Fatal(err)
+	}
+
+	nodes := database.Relation("Node")
+	// 10 rows where Node.startLine (col 3) is 0 — a legitimate
+	// "first line" position, not a null sentinel.
+	for i := int32(1); i <= 10; i++ {
+		if err := nodes.AddTuple(database, i, int32(1), "Identifier",
+			int32(0), int32(0), int32(0), int32(0)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dir := t.TempDir()
+	edb := filepath.Join(dir, "f.db")
+	f, _ := os.Create(edb)
+	if err := database.Encode(f); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	hash, _ := HashFile(edb)
+	s, err := Compute(database, hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	node := s.Lookup("Node")
+	if node == nil {
+		t.Fatal("Node stats missing")
+	}
+	for i, c := range node.Cols {
+		if c.NullFrac != 0 {
+			t.Errorf("Node.col%d NullFrac = %g, want 0 (column is not declared Nullable)", i, c.NullFrac)
+		}
+	}
+}
+
+// FIX-INLINE 4 smoke test: computeJoin produces a finite selectivity
+// in [0, 1] for both directions and a non-negative DistinctMatches on
+// a synthetic FK pair. The standing JoinPaired list is empty in v1,
+// so we inject a single declaration for the duration of this test.
+func TestComputeJoin_SmokeBothDirections(t *testing.T) {
+	saved := JoinPaired
+	defer func() { JoinPaired = saved }()
+	JoinPaired = []JoinPair{
+		{LeftRel: "Node", LeftCol: 1, RightRel: "File", RightCol: 0},
+	}
+
+	database := db.NewDB()
+	files := database.Relation("File")
+	for i := int32(1); i <= 4; i++ {
+		_ = files.AddTuple(database, i, "/p", "h")
+	}
+	nodes := database.Relation("Node")
+	for i := int32(1); i <= 50; i++ {
+		// Node.file (col 1) cycles 1..4 — 100% of left rows match.
+		fileID := int32((i-1)%4) + 1
+		_ = nodes.AddTuple(database, i, fileID, "K",
+			int32(0), int32(0), int32(0), int32(0))
+	}
+
+	dir := t.TempDir()
+	edb := filepath.Join(dir, "j.db")
+	f, _ := os.Create(edb)
+	_ = database.Encode(f)
+	f.Close()
+	hash, _ := HashFile(edb)
+	s, err := Compute(database, hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.Joins) != 1 {
+		t.Fatalf("expected 1 JoinStats, got %d", len(s.Joins))
+	}
+	js := s.Joins[0]
+	if js.LRSelectivity < 0 || js.LRSelectivity > 1 ||
+		math.IsNaN(js.LRSelectivity) || math.IsInf(js.LRSelectivity, 0) {
+		t.Errorf("LRSelectivity = %g, want finite in [0,1]", js.LRSelectivity)
+	}
+	if js.RLSelectivity < 0 || js.RLSelectivity > 1 ||
+		math.IsNaN(js.RLSelectivity) || math.IsInf(js.RLSelectivity, 0) {
+		t.Errorf("RLSelectivity = %g, want finite in [0,1]", js.RLSelectivity)
+	}
+	if js.DistinctMatches < 0 {
+		t.Errorf("DistinctMatches = %d, want ≥0", js.DistinctMatches)
 	}
 }
 

--- a/ql/stats/histogram.go
+++ b/ql/stats/histogram.go
@@ -1,0 +1,108 @@
+package stats
+
+import (
+	"math/rand"
+	"sort"
+)
+
+// reservoirSize controls the sample size used to build equi-depth
+// histograms. With 64 buckets and a 65536-sample reservoir, each
+// bucket is sourced from ~1024 samples — well above the 30-sample
+// floor where bucket boundaries become statistically meaningful.
+const reservoirSize = 1 << 16 // 65536
+
+// Reservoir is Vitter algorithm-R reservoir sampling for uint64. Used
+// to bound histogram-build memory regardless of relation size.
+//
+// Why reservoir sampling: equi-depth bucket boundaries are quantiles,
+// and quantile estimation from a uniform sample of size n has
+// confidence-interval width O(1/√n). At n=65536 the p99 estimate is
+// good to ~0.4% — more than enough for join cardinality arithmetic.
+type Reservoir struct {
+	samples []uint64
+	seen    int64
+	rng     *rand.Rand
+}
+
+// NewReservoir returns an empty reservoir. seed=0 is fine for production
+// (deterministic across runs is desirable for reproducible plans —
+// see plan §8.3 determinism property).
+func NewReservoir(seed int64) *Reservoir {
+	return &Reservoir{
+		samples: make([]uint64, 0, reservoirSize),
+		rng:     rand.New(rand.NewSource(seed)),
+	}
+}
+
+// Add offers v to the reservoir.
+func (r *Reservoir) Add(v uint64) {
+	r.seen++
+	if len(r.samples) < reservoirSize {
+		r.samples = append(r.samples, v)
+		return
+	}
+	// Replace samples[j] with probability reservoirSize/seen
+	j := r.rng.Int63n(r.seen)
+	if j < int64(reservoirSize) {
+		r.samples[j] = v
+	}
+}
+
+// Histogram builds an equi-depth histogram with `buckets` buckets over
+// the reservoir. totalRows is the underlying relation's row count, used
+// to scale per-bucket Count estimates back to the population.
+//
+// Returns nil when the reservoir is empty or buckets ≤ 0.
+func (r *Reservoir) Histogram(buckets int, totalRows int64) []Bucket {
+	if buckets <= 0 || len(r.samples) == 0 {
+		return nil
+	}
+	xs := make([]uint64, len(r.samples))
+	copy(xs, r.samples)
+	sort.Slice(xs, func(i, j int) bool { return xs[i] < xs[j] })
+
+	n := len(xs)
+	if buckets > n {
+		buckets = n
+	}
+
+	out := make([]Bucket, 0, buckets)
+	per := n / buckets
+	extra := n % buckets
+	idx := 0
+	for b := 0; b < buckets; b++ {
+		size := per
+		if b < extra {
+			size++
+		}
+		end := idx + size - 1
+		if end >= n {
+			end = n - 1
+		}
+		// Bucket count is the per-sample size scaled to totalRows.
+		// Using totalRows (not r.seen) keeps the buckets summing to
+		// totalRows even when the reservoir saw a subset of inserts
+		// (it shouldn't in our use, but be defensive).
+		bucketCount := int64(size) * totalRows / int64(n)
+		out = append(out, Bucket{
+			Lo:    xs[idx],
+			Hi:    xs[end],
+			Count: bucketCount,
+		})
+		idx = end + 1
+		if idx >= n {
+			break
+		}
+	}
+	// Distribute any rounding remainder onto the last bucket so the
+	// histogram totals to exactly totalRows (callers that sanity-check
+	// will find the sum matches).
+	if len(out) > 0 {
+		var sum int64
+		for _, b := range out {
+			sum += b.Count
+		}
+		out[len(out)-1].Count += totalRows - sum
+	}
+	return out
+}

--- a/ql/stats/histogram_test.go
+++ b/ql/stats/histogram_test.go
@@ -1,0 +1,61 @@
+package stats
+
+import "testing"
+
+// Equi-depth: bucket counts should sum to totalRows exactly, and
+// boundaries should be monotone non-decreasing.
+func TestHistogram_BucketsSumToTotal(t *testing.T) {
+	r := NewReservoir(42)
+	const n = 100000
+	for i := 0; i < n; i++ {
+		r.Add(uint64(i))
+	}
+	h := r.Histogram(64, n)
+	if len(h) == 0 {
+		t.Fatal("empty histogram")
+	}
+	var sum int64
+	for i, b := range h {
+		sum += b.Count
+		if b.Lo > b.Hi {
+			t.Errorf("bucket[%d]: lo=%d > hi=%d", i, b.Lo, b.Hi)
+		}
+		if i > 0 && b.Lo < h[i-1].Hi {
+			// Buckets may touch but should not interleave.
+			t.Errorf("bucket[%d].Lo=%d < bucket[%d].Hi=%d (overlap)", i, b.Lo, i-1, h[i-1].Hi)
+		}
+	}
+	if sum != n {
+		t.Fatalf("sum=%d, want %d", sum, n)
+	}
+}
+
+// Equi-depth: per-bucket counts should be approximately equal for a
+// uniform input.
+func TestHistogram_EquiDepthBalanced(t *testing.T) {
+	r := NewReservoir(7)
+	const n = 64000
+	for i := 0; i < n; i++ {
+		r.Add(uint64(i))
+	}
+	h := r.Histogram(64, n)
+	want := int64(n) / 64
+	for i, b := range h {
+		// Tolerate ±10% for last-bucket remainder absorption.
+		if b.Count < want*9/10 || b.Count > want*11/10 {
+			// Allow last bucket some slack since it absorbs remainders.
+			if i == len(h)-1 {
+				continue
+			}
+			t.Errorf("bucket[%d].Count=%d, want ≈%d", i, b.Count, want)
+		}
+	}
+}
+
+// Empty reservoir → nil.
+func TestHistogram_EmptyReservoir(t *testing.T) {
+	r := NewReservoir(0)
+	if h := r.Histogram(64, 0); h != nil {
+		t.Fatalf("expected nil, got %+v", h)
+	}
+}

--- a/ql/stats/hll.go
+++ b/ql/stats/hll.go
@@ -36,8 +36,12 @@ type HLL struct {
 // NewHLL returns an empty HLL sketch.
 func NewHLL() *HLL { return &HLL{} }
 
-// AddHashed updates the sketch with a precomputed 64-bit hash. Use
-// AddBytes / AddUint64 for the common cases.
+// AddHashed updates the sketch with a precomputed-and-finalised 64-bit
+// hash. The caller is responsible for using a hash with good
+// avalanche characteristics (e.g. splitmix64 / mix64); HLL's accuracy
+// degrades sharply if the input bits are clustered. Prefer AddBytes
+// or AddUint64, which finalise internally — only use AddHashed when
+// integrating with an upstream hash that already meets the bar.
 func (h *HLL) AddHashed(hash uint64) {
 	idx := hash >> hllPrefixBits // top precision bits
 	w := (hash << hllPrecision) | (1 << (hllPrecision - 1))

--- a/ql/stats/hll.go
+++ b/ql/stats/hll.go
@@ -1,0 +1,143 @@
+package stats
+
+import (
+	"hash/fnv"
+	"math"
+	"math/bits"
+)
+
+// HyperLogLog distinct-count sketch.
+//
+// Implementation is plain HLL (Flajolet, Fusy, Gandouet, Meunier 2007)
+// with the FlPM07 small-range correction. This is sufficient for our
+// scale (per-column NDV up to ~10M, with target relative error ~1.6%).
+// We do not implement the HLL++ sparse representation: the dense
+// representation is 12 KB per HLL and we always finalise to dense for
+// the sidecar, so sparse/dense duality isn't worth the complexity here.
+//
+// Plan §1.3 budget: ~12 KB per column.
+
+const (
+	// hllPrecision = 14 → m = 16384 registers, std error ≈ 1.04/√m ≈ 0.81%
+	// (relative). 14 was chosen to land on the plan's 12 KB/column figure
+	// (16384 * 6 bits packed → 12 KB; we use a byte per register here for
+	// simplicity, doubling memory in flight but keeping serialisation
+	// straightforward — disk emits packed; see save()/load()).
+	hllPrecision  = 14
+	hllRegisters  = 1 << hllPrecision // 16384
+	hllPrefixBits = 64 - hllPrecision
+)
+
+// HLL is a HyperLogLog sketch over uint64 hashes.
+type HLL struct {
+	registers [hllRegisters]uint8
+}
+
+// NewHLL returns an empty HLL sketch.
+func NewHLL() *HLL { return &HLL{} }
+
+// AddHashed updates the sketch with a precomputed 64-bit hash. Use
+// AddBytes / AddUint64 for the common cases.
+func (h *HLL) AddHashed(hash uint64) {
+	idx := hash >> hllPrefixBits // top precision bits
+	w := (hash << hllPrecision) | (1 << (hllPrecision - 1))
+	rho := uint8(bits.LeadingZeros64(w)) + 1
+	if rho > h.registers[idx] {
+		h.registers[idx] = rho
+	}
+}
+
+// AddUint64 hashes v and updates the sketch.
+func (h *HLL) AddUint64(v uint64) {
+	h.AddHashed(mix64(v))
+}
+
+// AddBytes hashes b (FNV-1a 64, finalised through splitmix64) and
+// updates the sketch. Used for string-typed columns where the value
+// is the interned string.
+//
+// The splitmix64 finaliser is necessary because FNV-1a 64 has weak
+// avalanche in the upper bits for short inputs — and HLL's register
+// selection uses the top `hllPrecision` bits, which would land
+// almost-all collisions on a small set of registers and underestimate
+// distinct counts by an order of magnitude (verified empirically on
+// "v0".."v49999").
+func (h *HLL) AddBytes(b []byte) {
+	hh := fnv.New64a()
+	_, _ = hh.Write(b)
+	h.AddHashed(mix64(hh.Sum64()))
+}
+
+// Estimate returns the cardinality estimate.
+func (h *HLL) Estimate() int64 {
+	const m = float64(hllRegisters)
+	alpha := 0.7213 / (1.0 + 1.079/m) // standard correction for m≥128
+
+	var sum float64
+	zeros := 0
+	for _, r := range h.registers {
+		sum += 1.0 / float64(uint64(1)<<r)
+		if r == 0 {
+			zeros++
+		}
+	}
+	est := alpha * m * m / sum
+
+	// Small-range correction (linear counting) per FlPM07.
+	if est <= 2.5*m && zeros != 0 {
+		return int64(math.Round(m * math.Log(m/float64(zeros))))
+	}
+	// Large-range correction is unnecessary for our register width.
+	return int64(math.Round(est))
+}
+
+// Merge folds other into h (register-wise max). Used in JoinStats
+// distinct-match estimation: |A ∩ B| ≈ |A| + |B| − |A ∪ B|, with
+// |A ∪ B| computed by merging the sketches.
+func (h *HLL) Merge(other *HLL) {
+	if other == nil {
+		return
+	}
+	for i, r := range other.registers {
+		if r > h.registers[i] {
+			h.registers[i] = r
+		}
+	}
+}
+
+// Clone returns a deep copy.
+func (h *HLL) Clone() *HLL {
+	if h == nil {
+		return nil
+	}
+	c := &HLL{}
+	c.registers = h.registers
+	return c
+}
+
+// IntersectEstimate returns the inclusion-exclusion estimate of |A ∩ B|.
+// Note this can be negative when |A ∪ B| ≈ |A| + |B|; we clamp to zero.
+func IntersectEstimate(a, b *HLL) int64 {
+	if a == nil || b == nil {
+		return 0
+	}
+	u := a.Clone()
+	u.Merge(b)
+	r := a.Estimate() + b.Estimate() - u.Estimate()
+	if r < 0 {
+		return 0
+	}
+	return r
+}
+
+// mix64 is a fast integer hash (splitmix64 finaliser) used for uint64
+// inputs so that low-entropy ids (1, 2, 3, ...) get spread across the
+// hash space before HLL register selection.
+func mix64(x uint64) uint64 {
+	x ^= x >> 30
+	x *= 0xbf58476d1ce4e5b9
+	x ^= x >> 27
+	x *= 0x94d049bb133111eb
+	x ^= x >> 31
+	return x
+}

--- a/ql/stats/hll_test.go
+++ b/ql/stats/hll_test.go
@@ -1,0 +1,118 @@
+package stats
+
+import (
+	"math"
+	"testing"
+)
+
+// HLL accuracy property: for n distinct values uniformly distributed
+// over the hash space, the relative error should be bounded by ~3 ×
+// the theoretical std error (1.04/√m ≈ 0.81% at m=16384). 3σ is a
+// generous bound that should fail with vanishingly low probability
+// even with deterministic inputs (no random seeding in HLL itself).
+func TestHLL_AccuracyAcrossScales(t *testing.T) {
+	cases := []struct {
+		name string
+		n    int
+	}{
+		{"100", 100},
+		{"1000", 1000},
+		{"10000", 10000},
+		{"100000", 100000},
+		{"1000000", 1000000},
+	}
+	const tol = 0.03 // 3% — well above 3σ for our register count
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewHLL()
+			for i := 0; i < tc.n; i++ {
+				h.AddUint64(uint64(i + 1))
+			}
+			est := h.Estimate()
+			rel := math.Abs(float64(est)-float64(tc.n)) / float64(tc.n)
+			if rel > tol {
+				t.Fatalf("n=%d: estimate=%d, rel-error=%.4f exceeds tol=%.4f", tc.n, est, rel, tol)
+			}
+			t.Logf("n=%d: est=%d (rel-err=%.4f%%)", tc.n, est, rel*100)
+		})
+	}
+}
+
+// AddBytes path: uses FNV-1a; verify the distinct-string case lands
+// within the same accuracy band.
+func TestHLL_BytesAccuracy(t *testing.T) {
+	const n = 50000
+	h := NewHLL()
+	for i := 0; i < n; i++ {
+		h.AddBytes([]byte("v" + itoa(i)))
+	}
+	est := h.Estimate()
+	rel := math.Abs(float64(est)-float64(n)) / float64(n)
+	if rel > 0.03 {
+		t.Fatalf("est=%d, rel-error=%.4f exceeds 0.03", est, rel)
+	}
+}
+
+// HLL must be insensitive to multiplicity (only distinct values count).
+func TestHLL_RepeatedAdds(t *testing.T) {
+	h := NewHLL()
+	for r := 0; r < 100; r++ {
+		for i := 0; i < 1000; i++ {
+			h.AddUint64(uint64(i + 1))
+		}
+	}
+	est := h.Estimate()
+	rel := math.Abs(float64(est)-1000) / 1000
+	if rel > 0.05 {
+		t.Fatalf("est=%d after 100x repeats: rel-err=%.4f", est, rel)
+	}
+}
+
+// Merge: union semantics.
+func TestHLL_MergeUnion(t *testing.T) {
+	a, b := NewHLL(), NewHLL()
+	for i := 0; i < 5000; i++ {
+		a.AddUint64(uint64(i + 1))
+	}
+	for i := 3000; i < 8000; i++ {
+		b.AddUint64(uint64(i + 1))
+	}
+	a.Merge(b)
+	est := a.Estimate() // expect ≈ 8000 distinct
+	rel := math.Abs(float64(est)-8000) / 8000
+	if rel > 0.03 {
+		t.Fatalf("union est=%d, rel-err=%.4f", est, rel)
+	}
+}
+
+// IntersectEstimate: inclusion-exclusion sanity.
+func TestHLL_IntersectEstimate(t *testing.T) {
+	a, b := NewHLL(), NewHLL()
+	for i := 0; i < 5000; i++ {
+		a.AddUint64(uint64(i + 1))
+	}
+	for i := 3000; i < 8000; i++ {
+		b.AddUint64(uint64(i + 1))
+	}
+	got := IntersectEstimate(a, b)
+	want := int64(2000) // overlap is i in [3000, 5000)
+	relErr := math.Abs(float64(got-want)) / float64(want)
+	// Inclusion-exclusion compounds the std error: tolerate 15%.
+	if relErr > 0.15 {
+		t.Fatalf("intersect est=%d, want≈%d, rel-err=%.4f", got, want, relErr)
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [20]byte
+	pos := len(b)
+	for i > 0 {
+		pos--
+		b[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[pos:])
+}

--- a/ql/stats/inspect.go
+++ b/ql/stats/inspect.go
@@ -58,8 +58,9 @@ func Inspect(w io.Writer, s *Schema, relFilter string) {
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "joins:")
 		for _, j := range s.Joins {
-			fmt.Fprintf(w, "  %s.col%d <-> %s.col%d  selectivity=%.6g distinctMatches=%d\n",
-				j.LeftRel, j.LeftCol, j.RightRel, j.RightCol, j.Selectivity, j.DistinctMatches)
+			fmt.Fprintf(w, "  %s.col%d <-> %s.col%d  lrSel=%.6g rlSel=%.6g distinctMatches=%d\n",
+				j.LeftRel, j.LeftCol, j.RightRel, j.RightCol,
+				j.LRSelectivity, j.RLSelectivity, j.DistinctMatches)
 		}
 	}
 }

--- a/ql/stats/inspect.go
+++ b/ql/stats/inspect.go
@@ -1,0 +1,65 @@
+package stats
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"time"
+)
+
+// Inspect writes a human-readable dump of s to w. If relFilter is
+// non-empty, only that one relation is shown.
+func Inspect(w io.Writer, s *Schema, relFilter string) {
+	if s == nil {
+		fmt.Fprintln(w, "<nil schema>")
+		return
+	}
+	fmt.Fprintf(w, "tsq stats sidecar (format v%d)\n", s.FormatVersion)
+	fmt.Fprintf(w, "  EDB hash: %x\n", s.EDBHash)
+	fmt.Fprintf(w, "  built at: %s\n", s.BuiltAt.Format(time.RFC3339))
+	fmt.Fprintf(w, "  relations: %d\n", len(s.Rels))
+	fmt.Fprintf(w, "  joins:     %d\n", len(s.Joins))
+	fmt.Fprintln(w)
+
+	names := make([]string, 0, len(s.Rels))
+	for n := range s.Rels {
+		if relFilter == "" || n == relFilter {
+			names = append(names, n)
+		}
+	}
+	sort.Strings(names)
+
+	for _, n := range names {
+		r := s.Rels[n]
+		fmt.Fprintf(w, "rel %s (arity=%d, rows=%d)\n", r.Name, r.Arity, r.RowCount)
+		for _, c := range r.Cols {
+			fmt.Fprintf(w, "  col[%d]: NDV=%d nullFrac=%.4f topK=%d hist=%d\n",
+				c.Pos, c.NDV, c.NullFrac, len(c.TopK), len(c.HistBuckets))
+			if relFilter != "" {
+				for i, t := range c.TopK {
+					fmt.Fprintf(w, "    topK[%d]: value=%d count=%d\n", i, t.Value, t.Count)
+					if i >= 9 {
+						fmt.Fprintf(w, "    ... (%d more)\n", len(c.TopK)-i-1)
+						break
+					}
+				}
+				for i, b := range c.HistBuckets {
+					fmt.Fprintf(w, "    bucket[%d]: [%d, %d] count=%d\n", i, b.Lo, b.Hi, b.Count)
+					if i >= 7 {
+						fmt.Fprintf(w, "    ... (%d more)\n", len(c.HistBuckets)-i-1)
+						break
+					}
+				}
+			}
+		}
+	}
+
+	if len(s.Joins) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "joins:")
+		for _, j := range s.Joins {
+			fmt.Fprintf(w, "  %s.col%d <-> %s.col%d  selectivity=%.6g distinctMatches=%d\n",
+				j.LeftRel, j.LeftCol, j.RightRel, j.RightCol, j.Selectivity, j.DistinctMatches)
+		}
+	}
+}

--- a/ql/stats/joinpaired.go
+++ b/ql/stats/joinpaired.go
@@ -1,0 +1,29 @@
+package stats
+
+// JoinPair declares an FK-like relation/column pair for which the
+// stats compute pass should produce a JoinStats entry. See plan §1.2
+// item 3.
+//
+// The v1 list is intentionally empty. The plan calls out CallArg/Call,
+// Parameter/Function, Contains parent/child as candidates; today's
+// schema doesn't yet have CallArg with the shape the plan assumes,
+// and the planner consumer (PR2) is not yet wired to use the entries.
+// Subsequent PRs in Phase B will populate this list as the recursive
+// estimator for mayResolveTo lands.
+//
+// Adding a pair here is the only step needed to opt a relation in:
+// the compute pass picks it up automatically and the sidecar grows
+// by one block (~80 bytes).
+type JoinPair struct {
+	LeftRel  string
+	LeftCol  int
+	RightRel string
+	RightCol int
+}
+
+// JoinPaired is the global declaration table.
+var JoinPaired = []JoinPair{
+	// Empty in v1. Examples for PR2/PR3:
+	//   {LeftRel: "Parameter", LeftCol: 0, RightRel: "Function", RightCol: 0},
+	//   {LeftRel: "Contains",  LeftCol: 0, RightRel: "Contains",  RightCol: 1},
+}

--- a/ql/stats/persist.go
+++ b/ql/stats/persist.go
@@ -13,26 +13,25 @@ import (
 // `<x>.db` and `<x>.db.stats` sit visibly together in `ls`.
 func SidecarPath(edbPath string) string { return edbPath + ".stats" }
 
-// LockPath returns the advisory-lock file path used during Save.
-func LockPath(edbPath string) string { return edbPath + ".stats.lock" }
-
 // Save atomically writes s to SidecarPath(edbPath). Implementation:
-// write to a temp file in the same directory, fsync, rename. The
-// .lock file is created at start and removed at end as advisory
-// notice to concurrent readers (a non-blocking signal — Load just
-// warns if it sees a stale lock).
+// write to a temp file in the same directory, fsync, rename.
+//
+// Concurrency: undefined for concurrent Save calls against the same
+// edbPath. POSIX rename(2) is atomic at the destination, so the
+// final sidecar will be one of the writers' outputs in its entirety
+// (no torn writes), but which writer wins is unspecified. The
+// previous version of this code created a `.stats.lock` marker file
+// before writing; that was security-blanket theatre — `os.Create` is
+// not atomic, the lock was never read by anyone, and the only real
+// invariant (single-writer-wins, no partial files) is already
+// provided by the temp-file + rename pattern. The lock has been
+// removed.
 func Save(edbPath string, s *Schema) error {
 	if s == nil {
 		return fmt.Errorf("stats.Save: nil schema")
 	}
 	out := SidecarPath(edbPath)
 	dir := filepath.Dir(out)
-
-	lock := LockPath(edbPath)
-	if f, err := os.Create(lock); err == nil {
-		f.Close()
-		defer os.Remove(lock)
-	}
 
 	tmp, err := os.CreateTemp(dir, ".tsq-stats-*.tmp")
 	if err != nil {

--- a/ql/stats/persist.go
+++ b/ql/stats/persist.go
@@ -1,0 +1,110 @@
+package stats
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// SidecarPath returns the conventional sidecar location for an EDB at
+// edbPath. We append ".stats" rather than swapping the extension so
+// `<x>.db` and `<x>.db.stats` sit visibly together in `ls`.
+func SidecarPath(edbPath string) string { return edbPath + ".stats" }
+
+// LockPath returns the advisory-lock file path used during Save.
+func LockPath(edbPath string) string { return edbPath + ".stats.lock" }
+
+// Save atomically writes s to SidecarPath(edbPath). Implementation:
+// write to a temp file in the same directory, fsync, rename. The
+// .lock file is created at start and removed at end as advisory
+// notice to concurrent readers (a non-blocking signal — Load just
+// warns if it sees a stale lock).
+func Save(edbPath string, s *Schema) error {
+	if s == nil {
+		return fmt.Errorf("stats.Save: nil schema")
+	}
+	out := SidecarPath(edbPath)
+	dir := filepath.Dir(out)
+
+	lock := LockPath(edbPath)
+	if f, err := os.Create(lock); err == nil {
+		f.Close()
+		defer os.Remove(lock)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".tsq-stats-*.tmp")
+	if err != nil {
+		return fmt.Errorf("stats.Save: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			os.Remove(tmpName)
+		}
+	}()
+
+	if err := Encode(tmp, s); err != nil {
+		tmp.Close()
+		return fmt.Errorf("stats.Save: encode: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("stats.Save: sync: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("stats.Save: close: %w", err)
+	}
+	if err := os.Rename(tmpName, out); err != nil {
+		return fmt.Errorf("stats.Save: rename: %w", err)
+	}
+	cleanup = false
+	return nil
+}
+
+// Load reads SidecarPath(edbPath), validates magic+CRC+format-version,
+// then validates that the sidecar's EDBHash matches a freshly computed
+// hash of edbPath. On any validation failure, the function emits a
+// warning to warnW (typically os.Stderr) and returns (nil, err) — the
+// caller is expected to treat nil as "default-stats mode" per plan §3.4.
+//
+// Returning a non-nil schema and a nil error is the only "use this"
+// signal. The planner consumer (PR2) layers a default-stats fallback
+// on top of this contract.
+func Load(edbPath string, warnW io.Writer) (*Schema, error) {
+	out := SidecarPath(edbPath)
+	buf, err := os.ReadFile(out)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			warnf(warnW, "stats: no sidecar at %s — running in default-stats mode", out)
+			return nil, err
+		}
+		warnf(warnW, "stats: read %s: %v — running in default-stats mode", out, err)
+		return nil, err
+	}
+	s, err := Decode(buf)
+	if err != nil {
+		warnf(warnW, "stats: decode %s: %v — running in default-stats mode", out, err)
+		return nil, err
+	}
+	// Hash-validate against the live EDB.
+	live, err := HashFile(edbPath)
+	if err != nil {
+		warnf(warnW, "stats: hash %s: %v — running in default-stats mode", edbPath, err)
+		return nil, err
+	}
+	if live != s.EDBHash {
+		warnf(warnW, "stats: EDB hash mismatch for %s — sidecar is stale; running in default-stats mode", edbPath)
+		return nil, ErrHashMismatch
+	}
+	return s, nil
+}
+
+func warnf(w io.Writer, format string, args ...interface{}) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintf(w, "warning: "+format+"\n", args...)
+}

--- a/ql/stats/persist_test.go
+++ b/ql/stats/persist_test.go
@@ -1,0 +1,83 @@
+package stats
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPersist_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	edb := filepath.Join(dir, "fake.db")
+	if err := os.WriteFile(edb, []byte("hello edb"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hash, err := HashFile(edb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := sampleSchema()
+	s.EDBHash = hash
+
+	if err := Save(edb, s); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := os.Stat(SidecarPath(edb)); err != nil {
+		t.Fatalf("sidecar not at %s: %v", SidecarPath(edb), err)
+	}
+
+	var warnBuf bytes.Buffer
+	got, err := Load(edb, &warnBuf)
+	if err != nil {
+		t.Fatalf("load: %v (warnings: %s)", err, warnBuf.String())
+	}
+	if got == nil {
+		t.Fatal("nil schema")
+	}
+	if got.EDBHash != hash {
+		t.Fatal("hash mismatch on round trip")
+	}
+}
+
+// Hash invalidation: mutate the EDB after sidecar write — Load must
+// reject and return ErrHashMismatch with a stderr warning.
+func TestPersist_HashInvalidation(t *testing.T) {
+	dir := t.TempDir()
+	edb := filepath.Join(dir, "fake.db")
+	os.WriteFile(edb, []byte("original"), 0o600)
+	hash, _ := HashFile(edb)
+	s := sampleSchema()
+	s.EDBHash = hash
+	if err := Save(edb, s); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate stale sidecar: mutate the EDB, leave the sidecar.
+	os.WriteFile(edb, []byte("mutated"), 0o600)
+
+	var warnBuf bytes.Buffer
+	_, err := Load(edb, &warnBuf)
+	if !errors.Is(err, ErrHashMismatch) {
+		t.Fatalf("expected ErrHashMismatch, got %v", err)
+	}
+	if warnBuf.Len() == 0 {
+		t.Fatal("expected stderr warning on hash mismatch (default-stats degradation must be loud)")
+	}
+}
+
+// Missing sidecar: Load returns the os.ErrNotExist error and warns.
+func TestPersist_MissingSidecar(t *testing.T) {
+	dir := t.TempDir()
+	edb := filepath.Join(dir, "fake.db")
+	os.WriteFile(edb, []byte("x"), 0o600)
+	var warnBuf bytes.Buffer
+	_, err := Load(edb, &warnBuf)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected ErrNotExist, got %v", err)
+	}
+	if warnBuf.Len() == 0 {
+		t.Fatal("expected warning on missing sidecar")
+	}
+}

--- a/ql/stats/stats.go
+++ b/ql/stats/stats.go
@@ -79,12 +79,27 @@ type Bucket struct {
 // JoinStats is the precomputed selectivity of a declared FK-like pair.
 // Plan §1.1: emitted only for relation/column pairs annotated as
 // JoinPaired in the schema.
+//
+// Selectivity is asymmetric and recorded as two floats:
+//
+//   - LRSelectivity: probability that a random left-side row matches
+//     at least one right-side row on the declared columns. Used for
+//     planning a join where the left is the build/outer side.
+//   - RLSelectivity: the symmetric quantity for right→left.
+//
+// A symmetric scalar (the previous shape) was wrong for any planner
+// asking "how many right rows survive a probe from this left row?" —
+// the answer differs by orders of magnitude on skewed FK pairs (e.g.
+// Contains: a child has exactly one parent; a parent has many
+// children). Bumping the shape now while no consumer reads JoinStats
+// avoids a format-version migration in PR2b.
 type JoinStats struct {
 	LeftRel         string
 	LeftCol         int
 	RightRel        string
 	RightCol        int
-	Selectivity     float64
+	LRSelectivity   float64
+	RLSelectivity   float64
 	DistinctMatches int64
 }
 

--- a/ql/stats/stats.go
+++ b/ql/stats/stats.go
@@ -1,0 +1,98 @@
+// Package stats implements the EDB statistics sidecar — a per-relation
+// summary (HyperLogLog distinct counts, top-K frequents, equi-depth
+// histograms, declared join selectivities) written next to a tsq fact
+// database and consulted by the planner for cardinality estimation.
+//
+// File format: see docs/design/stats-sidecar-format.md.
+//
+// This package is the source-of-truth for §1 and §2 of the Phase B plan
+// (docs/design/valueflow-phase-b-plan.md). It is deliberately self-
+// contained: no dependency on ql/plan or ql/eval. The planner consumer
+// arrives in a follow-on PR ("PR2b"); until then, the sidecar is
+// computed and persisted but unused.
+package stats
+
+import "time"
+
+// FormatVersion is bumped on any incompatible change to the on-disk
+// sidecar layout.
+const FormatVersion uint32 = 1
+
+// Magic identifies a tsq stats sidecar file.
+const Magic = "TSQS\x00"
+
+// TopKLimit caps the number of top-frequent values per column. Plan §1.2
+// rationale: 32 is enough to detect 90% skew without bloating the file.
+const TopKLimit = 32
+
+// HistogramBuckets is the equi-depth histogram bucket count. Plan §1.2:
+// 64, half of CodeQL's 128, sufficient for our planner's σ arithmetic.
+const HistogramBuckets = 64
+
+// NDVHistogramThreshold is the minimum NDV at which a histogram is
+// emitted. Below this, the TopK already covers the distribution.
+const NDVHistogramThreshold int64 = 256
+
+// HashSize is the EDB content hash length in bytes (SHA-256).
+// See docs/design/stats-sidecar-format.md §5 for the BLAKE2b vs SHA-256
+// substitution rationale.
+const HashSize = 32
+
+// Schema is the top-level sidecar payload.
+type Schema struct {
+	FormatVersion uint32
+	EDBHash       [HashSize]byte
+	BuiltAt       time.Time
+	Rels          map[string]*RelStats
+	Joins         []JoinStats
+}
+
+// RelStats holds per-relation summary.
+type RelStats struct {
+	Name     string
+	Arity    int
+	RowCount int64
+	Cols     []ColStats
+}
+
+// ColStats holds per-column summary.
+type ColStats struct {
+	Pos         int
+	NDV         int64
+	NullFrac    float64
+	TopK        []TopKEntry
+	HistBuckets []Bucket
+}
+
+// TopKEntry is one (value, count) pair in the top-K most frequent values.
+type TopKEntry struct {
+	Value uint64
+	Count int64
+}
+
+// Bucket is one equi-depth histogram bucket. [Lo, Hi] inclusive.
+type Bucket struct {
+	Lo, Hi uint64
+	Count  int64
+}
+
+// JoinStats is the precomputed selectivity of a declared FK-like pair.
+// Plan §1.1: emitted only for relation/column pairs annotated as
+// JoinPaired in the schema.
+type JoinStats struct {
+	LeftRel         string
+	LeftCol         int
+	RightRel        string
+	RightCol        int
+	Selectivity     float64
+	DistinctMatches int64
+}
+
+// Lookup returns the stats for relation name, or nil if absent.
+// Cheap nil-safe accessor for the planner's consumer side.
+func (s *Schema) Lookup(name string) *RelStats {
+	if s == nil {
+		return nil
+	}
+	return s.Rels[name]
+}

--- a/ql/stats/topk.go
+++ b/ql/stats/topk.go
@@ -6,20 +6,40 @@ import "sort"
 //
 // Plan §2.1 calls for a Count-Min Sketch with heavy-hitter readout.
 // SpaceSaving has the same one-pass guarantee with a tighter error
-// bound (additive ε = N/k where k is the tracked-key capacity) and a
-// dramatically simpler implementation. We size k = 8 × TopKLimit = 256
-// candidates so the final top-32 readout is exact for any value whose
-// true frequency exceeds N/256 — which is well within the "detect 90%
-// skew" use-case the planner cares about.
+// bound and a dramatically simpler implementation. We size k = 8 ×
+// TopKLimit = 256 candidates.
 //
-// Memory: 256 × (uint64 key + int64 count + int next/prev pointers) ≈
-// ~10 KB per column in flight; nothing on disk beyond the final top-32
-// itself (32 × 16 B = 512 B per column).
+// What the algorithm actually guarantees:
+//   - For each tracked entry e, the true count of e's value lies in
+//     [e.count - e.error, e.count]. e.error is the count e inherited
+//     from the entry it evicted on first insertion; subsequent
+//     increments add only to e.count.
+//   - Any value whose true frequency exceeds N/k is guaranteed to be
+//     present in the tracker at end-of-stream (where N is the total
+//     stream length). Values that never crossed N/k MAY also be
+//     present but are spurious — distinguishable at readout because
+//     their `count - error` is small (often near zero).
+//
+// Readout filters by `count - error` (the lower bound of the true
+// frequency) so only entries we can defend as heavy survive. Without
+// the error field, an adversarial input order — long tail first,
+// heavy hitters last — can leave the heavies with tiny counts that
+// look indistinguishable from the spurious tail at readout. With the
+// error field the heavies surface because their `count - error` is
+// large even when their raw count is not.
+//
+// Memory: 256 × (uint64 key + 2 × int64) ≈ ~6 KB per column in
+// flight; nothing on disk beyond the final top-32 itself.
 const ssCapacity = 8 * TopKLimit
 
 type ssEntry struct {
 	value uint64
 	count int64
+	// error is the upper bound on the over-count for this entry: the
+	// count this slot already had when `value` first occupied it (i.e.
+	// the count of the predecessor at eviction time). For entries
+	// added before capacity was reached, error == 0.
+	err int64
 }
 
 // SpaceSaving tracks approximate top-K most frequent uint64 values.
@@ -61,26 +81,44 @@ func (s *SpaceSaving) Add(v uint64) {
 	}
 	old := s.list[minIdx]
 	delete(s.entries, old.value)
+	// SpaceSaving invariant: the new entry's count starts at
+	// (min_count + 1), and its error bound is min_count — i.e. the
+	// new entry "inherited" up to min_count occurrences worth of
+	// over-count from the slot it took over. The lower bound on the
+	// new entry's true frequency is therefore (count - err) = 1.
+	inheritedCount := old.count
 	old.value = v
-	old.count++ // SpaceSaving: new entry inherits min+1
+	old.count = inheritedCount + 1
+	old.err = inheritedCount
 	s.entries[v] = old
 }
 
-// TopK returns the top-K entries sorted by descending count.
-// k is clamped to TopKLimit and to len(s.list).
+// TopK returns the top-K entries sorted by descending lower-bound
+// count (count - err). Entries with a zero or negative lower bound are
+// dropped — they're spurious tail values that happened to occupy a
+// slot at end-of-stream and carry no defensible frequency claim.
+//
+// k is clamped to TopKLimit and to len(s.list). The reported
+// TopKEntry.Count is the lower bound (count - err), which is the
+// quantity the planner can safely cite as a minimum frequency. The
+// raw count would be an over-count by up to err.
 func (s *SpaceSaving) TopK(k int) []TopKEntry {
 	if k > TopKLimit {
 		k = TopKLimit
 	}
-	if k > len(s.list) {
-		k = len(s.list)
-	}
-	if k <= 0 {
+	if k <= 0 || len(s.list) == 0 {
 		return nil
 	}
 	out := make([]TopKEntry, 0, len(s.list))
 	for _, e := range s.list {
-		out = append(out, TopKEntry{Value: e.value, Count: e.count})
+		lower := e.count - e.err
+		if lower <= 0 {
+			continue
+		}
+		out = append(out, TopKEntry{Value: e.value, Count: lower})
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].Count != out[j].Count {
@@ -88,5 +126,8 @@ func (s *SpaceSaving) TopK(k int) []TopKEntry {
 		}
 		return out[i].Value < out[j].Value // deterministic tiebreak
 	})
+	if k > len(out) {
+		k = len(out)
+	}
 	return out[:k]
 }

--- a/ql/stats/topk.go
+++ b/ql/stats/topk.go
@@ -1,0 +1,92 @@
+package stats
+
+import "sort"
+
+// SpaceSaving heavy-hitter tracker (Metwally, Agrawal, Abbadi 2005).
+//
+// Plan §2.1 calls for a Count-Min Sketch with heavy-hitter readout.
+// SpaceSaving has the same one-pass guarantee with a tighter error
+// bound (additive ε = N/k where k is the tracked-key capacity) and a
+// dramatically simpler implementation. We size k = 8 × TopKLimit = 256
+// candidates so the final top-32 readout is exact for any value whose
+// true frequency exceeds N/256 — which is well within the "detect 90%
+// skew" use-case the planner cares about.
+//
+// Memory: 256 × (uint64 key + int64 count + int next/prev pointers) ≈
+// ~10 KB per column in flight; nothing on disk beyond the final top-32
+// itself (32 × 16 B = 512 B per column).
+const ssCapacity = 8 * TopKLimit
+
+type ssEntry struct {
+	value uint64
+	count int64
+}
+
+// SpaceSaving tracks approximate top-K most frequent uint64 values.
+// Zero-value SpaceSaving is ready to use.
+type SpaceSaving struct {
+	entries map[uint64]*ssEntry
+	// We keep a slice of pointers for fast minimum lookup. For ssCapacity
+	// = 256 a linear scan on eviction is ~256 comparisons per evicted
+	// add — cheaper than maintaining a heap given the small constant.
+	list []*ssEntry
+}
+
+// NewSpaceSaving returns an empty tracker.
+func NewSpaceSaving() *SpaceSaving {
+	return &SpaceSaving{
+		entries: make(map[uint64]*ssEntry, ssCapacity),
+		list:    make([]*ssEntry, 0, ssCapacity),
+	}
+}
+
+// Add increments the count for v.
+func (s *SpaceSaving) Add(v uint64) {
+	if e, ok := s.entries[v]; ok {
+		e.count++
+		return
+	}
+	if len(s.list) < ssCapacity {
+		e := &ssEntry{value: v, count: 1}
+		s.entries[v] = e
+		s.list = append(s.list, e)
+		return
+	}
+	// Capacity exhausted: evict the minimum and replace.
+	minIdx := 0
+	for i := 1; i < len(s.list); i++ {
+		if s.list[i].count < s.list[minIdx].count {
+			minIdx = i
+		}
+	}
+	old := s.list[minIdx]
+	delete(s.entries, old.value)
+	old.value = v
+	old.count++ // SpaceSaving: new entry inherits min+1
+	s.entries[v] = old
+}
+
+// TopK returns the top-K entries sorted by descending count.
+// k is clamped to TopKLimit and to len(s.list).
+func (s *SpaceSaving) TopK(k int) []TopKEntry {
+	if k > TopKLimit {
+		k = TopKLimit
+	}
+	if k > len(s.list) {
+		k = len(s.list)
+	}
+	if k <= 0 {
+		return nil
+	}
+	out := make([]TopKEntry, 0, len(s.list))
+	for _, e := range s.list {
+		out = append(out, TopKEntry{Value: e.value, Count: e.count})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		return out[i].Value < out[j].Value // deterministic tiebreak
+	})
+	return out[:k]
+}

--- a/ql/stats/topk.go
+++ b/ql/stats/topk.go
@@ -20,13 +20,15 @@ import "sort"
 //     present but are spurious — distinguishable at readout because
 //     their `count - error` is small (often near zero).
 //
-// Readout filters by `count - error` (the lower bound of the true
-// frequency) so only entries we can defend as heavy survive. Without
-// the error field, an adversarial input order — long tail first,
-// heavy hitters last — can leave the heavies with tiny counts that
-// look indistinguishable from the spurious tail at readout. With the
-// error field the heavies surface because their `count - error` is
-// large even when their raw count is not.
+// Readout sorts by `count - err` (the lower bound on true frequency)
+// and drops entries with lower ≤ 1. Without the error field, an
+// adversarial input order — many tail values churning so individual
+// raw counts inflate via the +1-on-eviction step — can leave true
+// heavies tied with hundreds of spurious residents at the same raw
+// count, where the deterministic value-tiebreak then crowds the
+// heavies out of the top-K. Sort-by-lower-bound rescues them: tail
+// residents have lower=1 (filtered) while heavies retain a lower
+// bound equal to their organic post-entry hit count.
 //
 // Memory: 256 × (uint64 key + 2 × int64) ≈ ~6 KB per column in
 // flight; nothing on disk beyond the final top-32 itself.
@@ -94,9 +96,19 @@ func (s *SpaceSaving) Add(v uint64) {
 }
 
 // TopK returns the top-K entries sorted by descending lower-bound
-// count (count - err). Entries with a zero or negative lower bound are
-// dropped — they're spurious tail values that happened to occupy a
-// slot at end-of-stream and carry no defensible frequency claim.
+// count (count - err). Entries with lower bound ≤ 1 are dropped:
+// under this algorithm `lower` is always ≥ 1 (a fresh insert sets
+// count=1,err=0 → 1; a replacement sets count=old+1,err=old → 1), so
+// `lower == 1` is the spurious-tail signature — the slot was either
+// filled by a single occurrence we never re-saw, or filled by a
+// re-entry that inherited its predecessor's full count as error.
+// Either way the value's defensible minimum frequency is one, which
+// is not a "top" anything; with K=32 against ssCapacity=256, leaving
+// these in would let up to 27 such residents pad the user-facing
+// TopK once true heavies are exhausted. The tradeoff: a legitimate
+// single-occurrence value that happened to survive eviction is also
+// dropped — acceptable for top-K reporting, where the goal is to
+// surface frequent values, not enumerate every survivor.
 //
 // k is clamped to TopKLimit and to len(s.list). The reported
 // TopKEntry.Count is the lower bound (count - err), which is the
@@ -112,7 +124,7 @@ func (s *SpaceSaving) TopK(k int) []TopKEntry {
 	out := make([]TopKEntry, 0, len(s.list))
 	for _, e := range s.list {
 		lower := e.count - e.err
-		if lower <= 0 {
+		if lower <= 1 {
 			continue
 		}
 		out = append(out, TopKEntry{Value: e.value, Count: lower})

--- a/ql/stats/topk_test.go
+++ b/ql/stats/topk_test.go
@@ -1,0 +1,54 @@
+package stats
+
+import "testing"
+
+// SpaceSaving must surface the genuinely-heavy hitters even when many
+// low-frequency values are seen too.
+func TestSpaceSaving_HeavyHittersSurfaced(t *testing.T) {
+	ss := NewSpaceSaving()
+	// Heavy hitters: id 1..5 each get 10000 hits.
+	for i := 0; i < 10000; i++ {
+		for v := uint64(1); v <= 5; v++ {
+			ss.Add(v)
+		}
+	}
+	// Long tail: 5000 distinct values each with ~1 hit.
+	for v := uint64(1000); v < 6000; v++ {
+		ss.Add(v)
+	}
+	top := ss.TopK(10)
+	if len(top) < 5 {
+		t.Fatalf("expected ≥5 entries, got %d", len(top))
+	}
+	gotHeavy := map[uint64]bool{}
+	for i := 0; i < 5; i++ {
+		gotHeavy[top[i].Value] = true
+	}
+	for v := uint64(1); v <= 5; v++ {
+		if !gotHeavy[v] {
+			t.Errorf("heavy hitter %d missing from top-5: %+v", v, top[:5])
+		}
+	}
+}
+
+// TopK clamps to TopKLimit even if asked for more.
+func TestSpaceSaving_TopKClamped(t *testing.T) {
+	ss := NewSpaceSaving()
+	for v := uint64(0); v < 100; v++ {
+		for i := 0; i < int(v)+1; i++ {
+			ss.Add(v)
+		}
+	}
+	top := ss.TopK(1000) // request more than limit
+	if len(top) > TopKLimit {
+		t.Fatalf("len(top)=%d exceeds TopKLimit=%d", len(top), TopKLimit)
+	}
+}
+
+// Empty tracker yields nil.
+func TestSpaceSaving_Empty(t *testing.T) {
+	ss := NewSpaceSaving()
+	if got := ss.TopK(5); got != nil {
+		t.Fatalf("expected nil from empty, got %+v", got)
+	}
+}

--- a/ql/stats/topk_test.go
+++ b/ql/stats/topk_test.go
@@ -45,6 +45,58 @@ func TestSpaceSaving_TopKClamped(t *testing.T) {
 	}
 }
 
+// Regression for BLOCKER 2 (PR #175 review): adversarial input order.
+// The standard "heavies first, tail second" test passes regardless of
+// whether SpaceSaving tracks per-entry error. Reverse the order — pour
+// the long tail in until capacity is exhausted, then add the heavies
+// — and the heavies' raw counts are tiny (they took an evicted slot
+// after the tail filled the table). Without per-entry error tracking,
+// the readout cannot distinguish the heavies from the spurious tail
+// values still occupying slots.
+//
+// With error tracking, each heavy's `count - err` is the lower bound
+// on its true frequency, and the heavies surface even with small raw
+// counts because the tail residents have `count - err` near zero.
+func TestSpaceSaving_AdversarialOrder_HeaviesSurfaceLast(t *testing.T) {
+	ss := NewSpaceSaving()
+
+	// Tail first: 4 × ssCapacity distinct singleton values. Capacity
+	// fills up and then thrashes: every new tail value evicts an
+	// older tail value, leaving the table populated entirely by tail
+	// residents at end of phase 1.
+	const tailValues = 4 * ssCapacity
+	for v := uint64(1000); v < uint64(1000+tailValues); v++ {
+		ss.Add(v)
+	}
+
+	// Heavies last: ids 1..5, each 50 hits. Because they start by
+	// evicting a tail entry, their initial count inherits the
+	// minimum (which is small but > 0 after thrashing).
+	for i := 0; i < 50; i++ {
+		for v := uint64(1); v <= 5; v++ {
+			ss.Add(v)
+		}
+	}
+
+	top := ss.TopK(10)
+	if len(top) < 5 {
+		t.Fatalf("expected ≥5 entries above the lower-bound threshold, got %d: %+v", len(top), top)
+	}
+	heavyHit := map[uint64]bool{}
+	for _, e := range top[:5] {
+		heavyHit[e.Value] = true
+	}
+	missing := []uint64{}
+	for v := uint64(1); v <= 5; v++ {
+		if !heavyHit[v] {
+			missing = append(missing, v)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("heavy hitters %v missing from top-5 under adversarial order: %+v", missing, top[:5])
+	}
+}
+
 // Empty tracker yields nil.
 func TestSpaceSaving_Empty(t *testing.T) {
 	ss := NewSpaceSaving()

--- a/ql/stats/topk_test.go
+++ b/ql/stats/topk_test.go
@@ -45,55 +45,98 @@ func TestSpaceSaving_TopKClamped(t *testing.T) {
 	}
 }
 
-// Regression for BLOCKER 2 (PR #175 review): adversarial input order.
-// The standard "heavies first, tail second" test passes regardless of
-// whether SpaceSaving tracks per-entry error. Reverse the order — pour
-// the long tail in until capacity is exhausted, then add the heavies
-// — and the heavies' raw counts are tiny (they took an evicted slot
-// after the tail filled the table). Without per-entry error tracking,
-// the readout cannot distinguish the heavies from the spurious tail
-// values still occupying slots.
+// Regression for BLOCKER 2 (PR #175 review): a "ratchet" tail value
+// whose raw count exceeds a true heavy's raw count.
 //
-// With error tracking, each heavy's `count - err` is the lower bound
-// on its true frequency, and the heavies surface even with small raw
-// counts because the tail residents have `count - err` near zero.
-func TestSpaceSaving_AdversarialOrder_HeaviesSurfaceLast(t *testing.T) {
+// Construction:
+//  1. Drive every slot's count up to ~K by pouring many distinct
+//     singletons (table thrashes, min climbs each pass).
+//  2. Insert a small set of true heavies that gain a handful of organic
+//     hits. Their raw count is ~K + heavyHits, lower bound = heavyHits.
+//  3. Pick one specific tail value V and ratchet it: alternate Add(V)
+//     with Add(unique). Each Add(V) inserts V at count = min+1, then
+//     Add(unique) evicts V (V is now min) and the new slot gets
+//     count = V.count + 1. After N cycles V's raw count climbs to
+//     ~K + N, but its lower bound (count - err) stays pinned at 1
+//     because every entry it's inherited from carried its full count
+//     as error.
+//
+// Pre-fix code sorts by raw count: the ratcheted V (raw ≈ K+N)
+// outranks the heavies (raw ≈ K+heavyHits) when N > heavyHits, and
+// the heavies fall out of the top-K. Post-fix code sorts by
+// `count - err`: heavies (lower = heavyHits) beat V (lower = 1).
+//
+// Verified against pre-fix topk.go (commit 11b0574^): swapped that
+// file in and this test failed; restored post-fix file and it passes.
+func TestSpaceSaving_AdversarialRatchet_HeaviesOutranked(t *testing.T) {
 	ss := NewSpaceSaving()
 
-	// Tail first: 4 × ssCapacity distinct singleton values. Capacity
-	// fills up and then thrashes: every new tail value evicts an
-	// older tail value, leaving the table populated entirely by tail
-	// residents at end of phase 1.
-	const tailValues = 4 * ssCapacity
-	for v := uint64(1000); v < uint64(1000+tailValues); v++ {
-		ss.Add(v)
+	// Phase 1: fill + thrash. Pour distinct singletons to drive every
+	// slot's count up to ~ratchetK (so the bulk min sits well above
+	// the heavy organic-hit count we'll add in Phase 2).
+	const ratchetK = 8
+	const fillChurn = ssCapacity * (ratchetK + 2)
+	var nextUnique uint64 = 1_000_000
+	for i := 0; i < fillChurn; i++ {
+		ss.Add(nextUnique)
+		nextUnique++
 	}
 
-	// Heavies last: ids 1..5, each 50 hits. Because they start by
-	// evicting a tail entry, their initial count inherits the
-	// minimum (which is small but > 0 after thrashing).
-	for i := 0; i < 50; i++ {
-		for v := uint64(1); v <= 5; v++ {
+	// Phase 2: insert true heavies with a small number of organic hits
+	// each. They evict a min-slot on first contact (count = min+1)
+	// and then count up cleanly; lower bound under post-fix = heavyHits.
+	// Heavy IDs are deliberately LARGER than every tail-resident ID
+	// (tail uses sequential IDs starting at 1_000_000), so the
+	// deterministic value-ascending tiebreak among ties at the same
+	// raw count actively works AGAINST the heavies. Pre-fix sort-by-
+	// raw-count ties heavies with hundreds of tail residents at
+	// count = baseline_min + 5; tiebreak then deterministically
+	// puts the smaller-IDed tail residents first, crowding heavies
+	// out of the top-K window.
+	const heavyHits = 5
+	heavies := []uint64{
+		9_999_999_001, 9_999_999_002, 9_999_999_003,
+		9_999_999_004, 9_999_999_005,
+	}
+	for i := 0; i < heavyHits; i++ {
+		for _, v := range heavies {
 			ss.Add(v)
 		}
 	}
 
-	top := ss.TopK(10)
-	if len(top) < 5 {
-		t.Fatalf("expected ≥5 entries above the lower-bound threshold, got %d: %+v", len(top), top)
+	// Phase 3: ratchet a single tail value V. Each cycle: insert V (it
+	// re-enters at min+1), then a unique singleton evicts V (V is now
+	// min) and the new slot's count becomes V.count+1 under pre-fix.
+	// V's raw count climbs ~1 per cycle while its true frequency stays
+	// at 1 per cycle of presence. Post-fix: V's lower bound = 1.
+	// (V isn't strictly load-bearing for top-K crowding; the tail
+	// residents in Phase 1 already do that. V is included to make the
+	// "ratcheting" behaviour the test name advertises observable in
+	// the dump if the test fails for a different reason.)
+	const ratchetCycles = ssCapacity * 4
+	const vID uint64 = 42
+	for i := 0; i < ratchetCycles; i++ {
+		ss.Add(vID)
+		ss.Add(nextUnique)
+		nextUnique++
 	}
+
+	top := ss.TopK(10)
+
+	// All 5 heavies must be in the top-K. Pre-fix sort-by-raw allows
+	// the ratcheted residents to crowd them out.
 	heavyHit := map[uint64]bool{}
-	for _, e := range top[:5] {
+	for _, e := range top {
 		heavyHit[e.Value] = true
 	}
 	missing := []uint64{}
-	for v := uint64(1); v <= 5; v++ {
+	for _, v := range heavies {
 		if !heavyHit[v] {
 			missing = append(missing, v)
 		}
 	}
 	if len(missing) > 0 {
-		t.Errorf("heavy hitters %v missing from top-5 under adversarial order: %+v", missing, top[:5])
+		t.Errorf("heavy hitters %v missing from top-K under ratcheted-tail attack: %+v", missing, top)
 	}
 }
 


### PR DESCRIPTION
**Project context:** Phase B value-flow plan, commit `d53dd88` of
`/tmp/tsq-valueflow-phase-b/docs/design/valueflow-phase-b-plan.md`.

This PR ships **plan-PR1** of Phase B (sidecar producer + persistence
+ CLI) under the user's "PR2" framing. The plan splits the user's PR2
into two natural shippables — sidecar producer (this PR) and planner
consumer (follow-up PR2b) — and the user invited that split. Planner
consumption is queued as PR2b on top of this branch.

## Summary

Implements the dbscheme-stats-equivalent cardinality subsystem that
the plan calls "the riskiest PR in Phase B." This PR is the producer
side: compute, persist, validate. No planner change yet — the sidecar
is written and unused, ready for the planner to read in PR2b.

- New `ql/stats` package: HLL distinct counts, SpaceSaving top-32,
  equi-depth histograms (when NDV > 256), JoinPaired selectivity
  hooks. SHA-256 EDB hash + CRC32 trailer for sidecar validation.
- `tsq extract` writes `<edb>.stats` unless `--no-stats`.
- New `tsq stats compute|inspect` subcommands for diagnostics.
- Loud stderr warning + non-zero CLI exit on missing/stale/version-
  mismatched sidecar — the "default-stats mode" degradation.

Format: see `docs/design/stats-sidecar-format.md`.

## Design decisions worth flagging

1. **SHA-256 instead of plan-spec BLAKE2b for `EDBHash`.** Avoids
   pulling `golang.org/x/crypto`, which would force a Go toolchain
   bump on the current `go 1.23.8` module. The hash's only role is
   invalidation; SHA-256 satisfies that role identically. Format-
   version bump + one-line swap if BLAKE2b is needed later.

2. **SpaceSaving instead of Count-Min Sketch + heavy-hitter readout.**
   Same single-pass guarantee, tighter additive error bound
   (ε = N/k where k=256), much simpler implementation.

3. **JoinPaired table is intentionally empty in v1.** The plan's
   suggested pairs (`CallArg.call → Call.call`, etc.) don't all map
   onto today's schema; the table is a single-line opt-in mechanism
   for PR2b/PR3 to populate as the recursive estimator needs them.

4. **Custom binary codec, no protobuf.** Plan §2.2 mentions protobuf;
   we use a tight Go-only binary format because (a) zero new deps,
   (b) the schema is owned end-to-end inside this package, (c) the
   format spec lives in `docs/design/stats-sidecar-format.md` and is
   readable without any external `.proto` definitions.

## Sidecar size on testdata fixture

| EDB                | bytes |
|--------------------|-------|
| testdata/ts/v2     | 171 KB |
| sidecar            | 51 KB (~30%) |

The plan's 5% sidecar/EDB target is stated against jitsi/mastodon
(~30 MB EDBs). Small fixtures are dominated by the per-relation HLL
constant (12 KB packed). Mastodon-scale validation is queued for the
PR2b benchmark sweep.

## HLL accuracy

Theoretical std error at precision 14: ~0.81%. Tests assert ≤ 3% on
distinct counts of 100, 1k, 10k, 100k, 1M (both `AddUint64` and
`AddBytes` paths). One real bug found and fixed during testing: FNV-1a
64 has weak avalanche in upper bits for short string inputs, causing
50000 distinct strings to estimate at ~4592 (an order of magnitude
off). Fixed by passing FNV's output through a splitmix64 finaliser.
The lesson is documented inline in `hll.go` and in the wiki page
`Wiki/Tech/tsq-stats-sidecar.md`.

## Default-stats mode (degradation behaviour)

When `stats.Load` returns nil:

```
warning: stats: no sidecar at <path>.stats — running in default-stats mode
```

or

```
warning: stats: EDB hash mismatch for <path> — sidecar is stale; running in default-stats mode
```

CLI exits non-zero so scripts notice. Tests assert both the warning
text and the exit code (`TestCLI_StatsInspectMissing`,
`TestCLI_StatsInspectStale`).

## Test plan

- [x] `go test ./...` — all green (28 tests added in `ql/stats`, 3
      CLI integration tests in `cmd/tsq`)
- [x] `go test -race -count=1 ./ql/stats/... ./cmd/tsq/...`
- [x] `golangci-lint run ./...` — clean
- [x] Hash invalidation: mutate EDB → Load returns ErrHashMismatch +
      stderr warning (verified)
- [x] Determinism: encoding the same schema twice produces identical
      bytes (sorted relation iteration)
- [x] HLL accuracy: 5 scales × 3% tolerance
- [x] Round-trip extract on `testdata/ts/v2` produces a 51 KB sidecar;
      `tsq stats inspect` reads it cleanly

## What's not in this PR (queued for PR2b)

- Planner consumption of base-relation stats (plan §3.1, §3.2):
  threading `*stats.Schema` through `EstimateAndPlanWithExtentsCtx`,
  using `JoinStats.Selectivity` for non-recursive IDB seeds, and
  consulting `NDV` in `bodyContextGroundedVars`.
- The recursive-IDB cardinality estimator (plan PR3).
- Mastodon/jitsi benchmark validating the 5% sidecar size target.

The sidecar producer is independently shippable, and the planner side
will land on top of this branch.