### PR TITLE
refactor(bridge): migrate easy resolveToObjectExpr cases to mayResolveTo (Phase A PR3, with mayResolveTo wrapper extension)

### DIFF
--- a/bridge/tsq_react.qll
+++ b/bridge/tsq_react.qll
@@ -504,13 +504,36 @@ predicate jsxAttrValueObject(int valueAttrExpr, int objExpr) {
  *    ObjectLiteral. Covers `const obj = base; const base = {a};` patterns.
  */
 /**
- * Holds when `valueExpr` itself is the ObjectLiteral expression `objExpr`.
- * Split out as a named branch so the top-level `resolveToObjectExpr`
- * disjunction is an `or`-of-calls, sidestepping disjunction-poisoning bug
- * #166 that round-2 hit on `hookIndirection` and the through-context predicate.
+ * `mayResolveToObjectExpr(valueExpr, objExpr)` — the value-flow-driven
+ * "valueExpr resolves to an object literal expression" predicate.
+ *
+ * Phase A PR3 collapses two former hand-rolled branches onto this:
+ *   - `resolveToObjectExprDirect` (`valueExpr = objExpr`) is subsumed by
+ *     the §2.1 base branch of `mayResolveTo`: every object-literal node
+ *     emits `ExprValueSource(o, o)`, so `mayResolveToBase(o, o)` holds and
+ *     the `isObjectLiteralExpr(o)` filter selects only literals.
+ *   - `resolveToObjectExprVarD1` (identifier through a single VarDecl
+ *     hop, JsxExpression-wrapper-tolerant) is subsumed by the §2.2
+ *     var-init branch composed with PR3's `mayResolveToJsxWrapped`. The
+ *     wrapper variant unwraps a JsxExpression layer and re-runs the
+ *     six-branch core, so `<Provider value={X} />` where `X` is a
+ *     VarDecl-bound object literal flows through.
+ *
+ * The `isObjectLiteralExpr(objExpr)` filter narrows `mayResolveTo`'s
+ * value-source space (which also includes arrows, primitives, JSX
+ * elements, etc.) to object literals — matching the `resolveToObjectExpr*`
+ * family's contract that the second column is always an ObjectLiteral.
+ *
+ * Subsumption note (PR body §1): `mayResolveTo` also includes the §2.5
+ * field-read and §2.6 object-field branches, which can in principle
+ * resolve `<Provider value={o.f}>` to the field's value when `o.f` is
+ * itself an object literal. The R3/R4 fixtures don't exercise that shape,
+ * so the parity gate empirically holds. If a real codebase surfaces such
+ * a case, it's a precision gain over the deleted branches, not a
+ * regression.
  */
-predicate resolveToObjectExprDirect(int valueExpr, int objExpr) {
-    valueExpr = objExpr and
+predicate mayResolveToObjectExpr(int valueExpr, int objExpr) {
+    mayResolveTo(valueExpr, objExpr) and
     isObjectLiteralExpr(objExpr)
 }
 
@@ -519,25 +542,17 @@ predicate resolveToObjectExprDirect(int valueExpr, int objExpr) {
  * contains the ObjectLiteral expression `objExpr` — the canonical
  * `value={{ ... }}` shape where the JsxAttribute valueExpr column points
  * at the wrapper, not the inner Object.
+ *
+ * Plan-deferred (Phase C): kept verbatim because plan §3.1 only targets
+ * Direct + VarD1 in PR3. The wrapped-literal case is empirically covered
+ * by `mayResolveToObjectExpr` (mayResolveToJsxWrapped → mayResolveToBase
+ * fires when the inner is a literal), but until the parity gate proves
+ * subsumption on Mastodon-scale corpora we keep this branch explicit.
  */
 predicate resolveToObjectExprWrapped(int valueExpr, int objExpr) {
     Contains(valueExpr, objExpr) and
     isObjectLiteralExpr(objExpr) and
     valueExpr != objExpr
-}
-
-/**
- * Depth-1 variable indirection: `const X = { ... }; <Provider value={X} />`.
- * `valueExpr` may be the JsxExpression wrapper or the bare Identifier — we
- * tolerate both via the (eq or Contains) idiom.
- */
-predicate resolveToObjectExprVarD1(int valueExpr, int objExpr) {
-    exists(int identExpr, int sym, int varDecl |
-        (identExpr = valueExpr or Contains(valueExpr, identExpr)) and
-        ExprMayRef(identExpr, sym) and
-        VarDecl(varDecl, sym, objExpr, _) and
-        isObjectLiteralExpr(objExpr)
-    )
 }
 
 /**
@@ -644,11 +659,14 @@ predicate resolveToObjectExprHookReturn(int valueExpr, int objExpr) {
 }
 
 predicate resolveToObjectExpr(int valueExpr, int objExpr) {
-    resolveToObjectExprDirect(valueExpr, objExpr)
+    // PR3: Direct + VarD1 collapsed onto the value-flow layer via
+    // `mayResolveToObjectExpr`. The mayResolveTo union (PR3 amended)
+    // includes the JsxExpression-wrapper-tolerant variant, so VarD1's
+    // `(identExpr = valueExpr or Contains(...))` idiom is no longer
+    // needed at this level.
+    mayResolveToObjectExpr(valueExpr, objExpr)
     or
     resolveToObjectExprWrapped(valueExpr, objExpr)
-    or
-    resolveToObjectExprVarD1(valueExpr, objExpr)
     or
     resolveToObjectExprVarD2(valueExpr, objExpr)
     or

--- a/bridge/tsq_valueflow.qll
+++ b/bridge/tsq_valueflow.qll
@@ -191,8 +191,22 @@ predicate mayResolveToCore(int valueExpr, int sourceExpr) {
  * appears in v2 extraction.
  */
 predicate jsxExpressionUnwrap(int jsxExpr, int innerExpr) {
-    Node(jsxExpr, _, "JsxExpression", _, _, _, _) and
-    Contains(jsxExpr, innerExpr)
+    exists(string innerKind |
+        Node(jsxExpr, _, "JsxExpression", _, _, _, _) and
+        Contains(jsxExpr, innerExpr) and
+        Node(innerExpr, _, innerKind, _, _, _, _) and
+        // Punctuation-token guard. The walker emits Node rows for all direct
+        // children of JsxExpression including the brace tokens `{` and `}`
+        // (extract/walker.go enterNode is unconditional; tree-sitter's
+        // `Child(i)` iterates anonymous tokens too). Without this filter the
+        // unwrap binds 3× per JsxExpression rather than once. Currently inert
+        // downstream because brace tokens carry no ExprMayRef / ExprValueSource
+        // facts, so `mayResolveToCore(innerExpr, _)` never succeeds for them —
+        // but that's a fragile invariant. This filter makes the precision
+        // explicit at the unwrap rather than relying on downstream silence.
+        innerKind != "{" and
+        innerKind != "}"
+    )
 }
 
 /**

--- a/bridge/tsq_valueflow.qll
+++ b/bridge/tsq_valueflow.qll
@@ -141,25 +141,111 @@ predicate mayResolveToObjectField(int valueExpr, int sourceExpr) {
 }
 
 /**
- * Top-level union — `or`-of-calls.
+ * Six-branch core union (no JSX-wrapper handling).
  *
- * Each disjunct is a call to a separate named IDB head. This shape
- * sidesteps disjunction-poisoning bug #166 by construction: the planner's
- * disjunction rewrite never sees a multi-branch literal-disjunction inside
- * a single rule body, so the binding-loss case never fires. If a
- * regression appears here in the future (per-branch row count > 0 but
- * union row count = 0), that is the classic #166 signature — escalate to
- * the planner team rather than rewriting the value-flow rules. The
- * regression guard is `TestValueflow_UnionMatchesSumOfBranches` in
- * `valueflow_integration_test.go`.
+ * `or`-of-calls of the six §2.1–§2.6 branches. Lifted to a named predicate
+ * so `mayResolveToJsxWrapped` can dispatch into the core via a single call
+ * (instead of repeating the six branches under a wrapper-unwrapped
+ * `innerExpr` binding). This is the named-call discipline #166 wants —
+ * `mayResolveToJsxWrapped`'s body is a single call into another named
+ * head, never a literal disjunction.
+ *
+ * `mayResolveToCore` is value-expr-rooted: each branch joins
+ * `ExprMayRef(valueExpr, sym)` (or equivalent) directly on `valueExpr`. It
+ * does NOT tolerate JsxExpression wrappers — for `<Provider value={X} />`
+ * the JsxAttribute valueExpr is the JsxExpression `{X}` node, not `X`, so
+ * `ExprMayRef(jsxExpr, sym)` is empty. The wrapper-tolerant counterpart
+ * lives in `mayResolveToJsxWrapped` below; both feed the public
+ * `mayResolveTo` union.
  */
-predicate mayResolveTo(int valueExpr, int sourceExpr) {
+predicate mayResolveToCore(int valueExpr, int sourceExpr) {
     mayResolveToBase(valueExpr, sourceExpr)
     or mayResolveToVarInit(valueExpr, sourceExpr)
     or mayResolveToAssign(valueExpr, sourceExpr)
     or mayResolveToParamBind(valueExpr, sourceExpr)
     or mayResolveToFieldRead(valueExpr, sourceExpr)
     or mayResolveToObjectField(valueExpr, sourceExpr)
+}
+
+/**
+ * Helper — direct JsxExpression unwrap.
+ *
+ * `jsxExpr` is a `JsxExpression` AST node and `innerExpr` is its DIRECT
+ * child (per `Contains/2`, which stores immediate parent→child links — the
+ * extractor populates one `Contains(parent, child)` row per direct
+ * descent, not transitive closure).
+ *
+ * Constraining the unwrap to a single JsxExpression layer (vs. transitive
+ * `Contains`) preserves the bridge's existing `resolveToObjectExprVarD1`
+ * semantics: that predicate uses `(identExpr = valueExpr or
+ * Contains(valueExpr, identExpr))` where `Contains` is direct, and the
+ * canonical `<Provider value={X} />` shape has `X` as the JsxExpression's
+ * direct child. Walking arbitrary parent levels would over-approximate
+ * (e.g. unwrap `<Provider value={f({...})} />` and resolve through the
+ * inner spread — bridge precision intentionally stops there).
+ *
+ * `Node(jsxExpr, _, "JsxExpression", _, _, _, _)` matches both walker
+ * backends: walker.go emits the kind verbatim from tree-sitter
+ * `jsx_expression` (mapped in `extract/backend_treesitter.go`); walker_v2
+ * delegates JSX descent to the inner FactWalker so the same `Node` row
+ * appears in v2 extraction.
+ */
+predicate jsxExpressionUnwrap(int jsxExpr, int innerExpr) {
+    Node(jsxExpr, _, "JsxExpression", _, _, _, _) and
+    Contains(jsxExpr, innerExpr)
+}
+
+/**
+ * JSX-wrapper-tolerant branch — re-run the core union on the unwrapped
+ * inner expression.
+ *
+ * Body is a single named call into `mayResolveToCore`, preserving the
+ * `or`-of-calls discipline that sidesteps #166: at each top-level
+ * disjunction the planner sees only literal calls to named heads, never a
+ * multi-branch literal disjunction inside one rule body.
+ *
+ * Non-recursive: `mayResolveToCore` does NOT call back into
+ * `mayResolveTo` or `mayResolveToJsxWrapped`. The call graph is
+ *   mayResolveTo  →  { mayResolveToCore, mayResolveToJsxWrapped }
+ *   mayResolveToJsxWrapped  →  mayResolveToCore
+ *   mayResolveToCore  →  the six §2.1–§2.6 branches
+ *   six branches  →  EDB only
+ * — no back-edge. The trivial-IDB pre-pass sizes this depth-3 stack the
+ * same way it sizes the original union.
+ */
+predicate mayResolveToJsxWrapped(int valueExpr, int sourceExpr) {
+    exists(int innerExpr |
+        jsxExpressionUnwrap(valueExpr, innerExpr) and
+        mayResolveToCore(innerExpr, sourceExpr)
+    )
+}
+
+/**
+ * Top-level union — `or`-of-calls.
+ *
+ * Two disjuncts: the six-branch core (`mayResolveToCore`) plus the
+ * wrapper-tolerant variant (`mayResolveToJsxWrapped`). Each disjunct is a
+ * call to a separate named IDB head. This shape sidesteps
+ * disjunction-poisoning bug #166 by construction: the planner's
+ * disjunction rewrite never sees a multi-branch literal-disjunction inside
+ * a single rule body, so the binding-loss case never fires.
+ *
+ * If a regression appears here in the future (per-branch row count > 0 but
+ * union row count = 0), that is the classic #166 signature — escalate to
+ * the planner team rather than rewriting the value-flow rules. The
+ * regression guard is `TestValueflow_UnionMatchesSumOfBranches` in
+ * `valueflow_integration_test.go`.
+ *
+ * The wrapper extension (PR3 amendment, plan §3.1 amendment): the bridge's
+ * `resolveToObjectExpr*` family is JsxExpression-wrapper-tolerant via
+ * `Contains(valueAttrExpr, innerExpr)`. The original six-branch union was
+ * value-expr-rooted only and silently dropped every `<Provider value={X} />`
+ * case, breaking subsumption with `resolveToObjectExprVarD1`. Adding
+ * `mayResolveToJsxWrapped` closes that gap before PR3's bridge migration.
+ */
+predicate mayResolveTo(int valueExpr, int sourceExpr) {
+    mayResolveToCore(valueExpr, sourceExpr)
+    or mayResolveToJsxWrapped(valueExpr, sourceExpr)
 }
 
 /**

--- a/docs/design/valueflow-phase-a-plan.md
+++ b/docs/design/valueflow-phase-a-plan.md
@@ -1,0 +1,642 @@
+# Value-flow Phase A — implementation plan
+
+**Status:** design only. No code, no schema migration yet.
+**Branch:** `design/valueflow-phase-a` off `design/valueflow-layer`.
+**Parent doc:** `docs/design/valueflow-layer.md` (read first; this doc refines §3.2 + §6 Phase A only).
+**Author:** Planky.
+**Date:** 2026-04-19.
+
+Phase A's contract from the parent doc: ship the extractor extensions plus a **non-recursive** `mayResolveTo` that the planner can size today, prove it on the React bridge by collapsing the easy `resolveToObjectExpr*` branches, and lay rails Phase B/C extend with recursion. Phase A is deliberately not interesting Datalog — it's a vocabulary change. Phase B does the planner work; Phase C adds recursion. **This doc does not design B/C.**
+
+---
+
+## 1. Extractor extensions
+
+### 1.1 What the walker emits today (relevant subset)
+
+`extract/schema/relations.go` registers — for the value-flow vocabulary — `VarDecl/4`, `Assign/3`, `ExprMayRef/2`, `ExprIsCall/2`, `Call/3`, `CallArg/3`, `CallCalleeSym/2`, `CallResultSym/2`, `FieldRead/3`, `FieldWrite/4`, `ObjectLiteralField/3`, `ObjectLiteralSpread/2`, `DestructureField/5`, `ArrayDestructure/3`, `ReturnStmt/3`, `ReturnSym/2`, `Parameter/6`, `LocalFlow/3`, `LocalFlowStar/3`, `InterFlow/2`, `FlowStar/2`, `ParamToReturn/2`. Both `walker.go` (vendored tree-sitter) and `walker_v2.go` (type-aware, tsgo-overlay) emit these via `tw.fw.emit("Name", ...)`.
+
+The gap the parent doc identifies (§3.1 last paragraph): the bridge speaks **expr→expr**, the flow rels speak **sym→sym**. Phase A's job is to add the two thin shims that close this gap *without* introducing a recursive IDB.
+
+### 1.2 New relations
+
+#### `ExprValueSource(int expr, int sourceExpr)` — arity 2
+
+Schema: one row per AST expression that is a **value-producing literal at its own location** — i.e. an expression whose runtime value is determined entirely by its own subtree. Concretely: object literals, array literals, function/arrow expressions, class expressions, primitive literals (string/number/bool/null/undefined/regex/template-without-substitutions), JSX elements. **Not** identifiers (those go through `ExprMayRef`), not calls, not member access, not binary ops, not `await`, not `as` casts.
+
+Identity row: `expr == sourceExpr`. The relation looks redundant — why join `(v, v)` when `v = v` works? Because the planner needs a *grounded* base predicate for the recursive rule in Phase C: `mayResolveTo(v, s) :- ExprValueSource(v, s).` is a sized base case the trivial-IDB pre-pass can estimate. A bare equality wouldn't.
+
+Worked example for `const f = () => 1; const o = { x: 5 };`:
+
+```
+// (using illustrative node ids)
+ExprValueSource(<arrow-expr#10>, <arrow-expr#10>)
+ExprValueSource(<obj-literal#20>, <obj-literal#20>)
+ExprValueSource(<5-literal#21>, <5-literal#21>)
+ExprValueSource(<1-literal#11>, <1-literal#11>)
+```
+
+Complexity: **trivial AST walk.** Decided per-node-kind in the existing `Enter` switch (`walker.go:Enter` and `walker_v2.go:emitV2Facts`). One new emit site per kind.
+
+Estimated lines: **~40 LoC across both walkers + ~25 LoC in `relations.go` + tests.** Walker_v2 already has the kind switch; we slot in alongside the existing `case` arms.
+
+#### `ParamBinding(int fn, int paramIdx, int paramSym, int argExpr)` — arity 4
+
+Schema: one row per (call site × parameter slot) where `fn` is the **callee function id** (resolved via `CallTarget` or `CallTargetRTA`), `paramIdx` is the parameter position, `paramSym` is the symbol of that parameter inside the callee, and `argExpr` is the actual-argument expression at the call site. This is the join `CallTarget ⨝ CallArg ⨝ Parameter` materialised once at extraction time.
+
+Why materialise: the bridge today needs this composition in hot bodies; it's a 4-table join the planner has to re-derive each query. Pre-rolling it out at extraction is "one literal in hot bodies" (parent doc §3.2), and gives Phase A a base relation that's already-bound on the call-site side.
+
+Worked example for:
+
+```ts
+function inc(prev) { return prev + 1; }
+const v = inc(7);
+```
+
+Tuples:
+
+```
+ParamBinding(<fn:inc>, 0, <sym:prev>, <7-literal-expr>)
+```
+
+Multi-arg, multi-call:
+
+```ts
+function add(a, b) { return a + b; }
+add(1, 2);
+add(x, 3);
+```
+
+```
+ParamBinding(<fn:add>, 0, <sym:a>, <1-literal-expr>)
+ParamBinding(<fn:add>, 1, <sym:b>, <2-literal-expr>)
+ParamBinding(<fn:add>, 0, <sym:a>, <x-ident-expr>)
+ParamBinding(<fn:add>, 1, <sym:b>, <3-literal-expr>)
+```
+
+Complexity: **needs symbol resolution** — specifically, requires `CallTarget` / `CallTargetRTA` to be settled, which means it must emit in a **post-pass** after the main walker run. Walker_v2's `Run` already overlays after the inner walker; this is a third stage that consumes the populated DB. Spread args (`f(...rest)`) and rest params (`function f(...args)`) emit nothing in v1 — out of scope for Phase A. Document the carve-out in the relation comment.
+
+Estimated lines: **~80 LoC** for the post-pass (DB scan over `CallTarget × CallArg × Parameter`, emit), **+ 15 LoC schema + tests.** No new tree walking.
+
+#### `AssignExpr(int lhsSym, int rhsExpr)` — arity 2
+
+Schema: the symmetric-to-`VarDecl` view of `Assign`. `Assign` today is `(lhsNode, rhsExpr, lhsSym)`; the bridge and the upcoming `mayResolveTo` only ever care about `(lhsSym, rhsExpr)`. Materialising it as a 2-column projection lets the planner key joins on `lhsSym` directly without dragging the unused `lhsNode` column through the binding inference.
+
+Worked example for `let x; x = foo();`:
+
+```
+Assign(<assign-stmt#5>, <call:foo()#6>, <sym:x>)
+AssignExpr(<sym:x>, <call:foo()#6>)
+```
+
+Complexity: **trivial** — pure projection; can emit at the same site `Assign` is emitted.
+
+Estimated lines: **~10 LoC.**
+
+#### Carve-outs (do NOT add in Phase A)
+
+`FieldShape`, `ResolvesToImportedFunction`, `MethodResolvesTo`, `Effect` from parent doc §3.2 — all **deferred**. They either need a binding/scope pass or a real type query; both belong to Phase C extractor work, not A.
+
+### 1.3 Schema-version bump
+
+`ExprValueSource`, `ParamBinding`, `AssignExpr` are net-new relations — **no breaking change** to existing consumers. Bump `db.SchemaVersion` by 1; downgrade-compat is a write-only concern (older readers ignore unknown rels). No migration of existing rows.
+
+---
+
+## 2. Non-recursive `mayResolveTo`
+
+Phase A ships **only the rules whose body has no `mayResolveTo` literal in it.** This is the base case + every one-step rule rewritten so the recursive call is replaced with a direct ground predicate. Non-recursive means the planner's existing P2b sampling estimator handles it — no recursive-IDB cardinality work needed (parent doc §4.2 #1 stays a Phase B blocker).
+
+File: `ql/system/valueflow.qll` (new). The bridge consumes via `bridge/tsq_valueflow.qll`, which re-exports the rules and adds a thin `resolvesToFunctionDirect` helper.
+
+### 2.1 Base case — `mayResolveTo` ≡ identity on value-source expressions
+
+```ql
+predicate mayResolveTo(int valueExpr, int sourceExpr) {
+    ExprValueSource(valueExpr, sourceExpr)
+}
+```
+
+- Consumes: `ExprValueSource/2`.
+- Cardinality (Mastodon): one row per value-producing AST node. Mastodon corpus is ~100k symbols → ~300k–500k value-producing exprs. **~10^5 rows.**
+- Planner sanity: trivial-IDB pre-pass sizes this directly from the EDB row count of `ExprValueSource`. No recursion. Sampling pre-pass not needed (it's a 1:1 projection).
+
+### 2.2 Var-init step (one hop, non-recursive)
+
+```ql
+predicate mayResolveToVarInit(int valueExpr, int sourceExpr) {
+    exists(int sym, int initExpr, int varDecl |
+        ExprMayRef(valueExpr, sym) and
+        VarDecl(varDecl, sym, initExpr, _) and
+        ExprValueSource(initExpr, sourceExpr)
+    )
+}
+```
+
+Reads "`valueExpr` references a sym whose `VarDecl` initialiser is itself a value-source." Note the inner rel is `ExprValueSource`, **not** `mayResolveTo` — this is the Phase A simplification that keeps it non-recursive.
+
+- Consumes: `ExprMayRef`, `VarDecl`, `ExprValueSource`.
+- Cardinality (Mastodon): bounded by `VarDecl × ExprMayRef-on-init-target`. Most VarDecls initialise from non-source exprs (calls, member access). Pessimistic estimate **~10^5 rows**.
+- Planner: 3-table join, all base relations sized; P3a backward-binding inference will adorn from `valueExpr` → `sym` → `varDecl` → `initExpr` in order. Benefits from the (name, arity)-keyed magic-set propagation already in place after disj2 round 6.
+
+### 2.3 Assign step (one hop)
+
+```ql
+predicate mayResolveToAssign(int valueExpr, int sourceExpr) {
+    exists(int sym, int rhsExpr |
+        ExprMayRef(valueExpr, sym) and
+        AssignExpr(sym, rhsExpr) and
+        ExprValueSource(rhsExpr, sourceExpr)
+    )
+}
+```
+
+- Consumes: `ExprMayRef`, `AssignExpr`, `ExprValueSource`.
+- Cardinality: assignments are rarer than var-decls in modern TS — **~10^4 rows** Mastodon-scale.
+- Planner: same shape as 2.2.
+
+### 2.4 Param-binding step (one hop)
+
+```ql
+predicate mayResolveToParamBind(int valueExpr, int sourceExpr) {
+    exists(int sym, int fn, int idx, int argExpr |
+        ExprMayRef(valueExpr, sym) and
+        ParamBinding(fn, idx, sym, argExpr) and
+        ExprValueSource(argExpr, sourceExpr)
+    )
+}
+```
+
+- Consumes: `ExprMayRef`, `ParamBinding`, `ExprValueSource`.
+- Cardinality: bounded by call sites passing a value-source literal directly (`f({...})`, `f(() => x)`). On Mastodon, **~10^4–10^5 rows** (React codebases pass arrow literals into JSX a lot).
+- Planner: ParamBinding's 4-arity carries the binding hint cleanly. Magic-set propagation must key on (name=ParamBinding, arity=4); confirmed-OK after disj2 round 5.
+
+### 2.5 Field-read of immediately-adjacent field-write (one hop, no shape recursion)
+
+```ql
+predicate mayResolveToFieldRead(int valueExpr, int sourceExpr) {
+    exists(int baseSym, string fld, int rhsExpr, int writeNode |
+        FieldRead(valueExpr, baseSym, fld) and
+        FieldWrite(writeNode, baseSym, fld, rhsExpr) and
+        ExprValueSource(rhsExpr, sourceExpr)
+    )
+}
+```
+
+Field-name + base-sym match only; no shape recursion (parent doc §5: "Field-named, no shape" is the v1 default). Last-write-wins is *not* enforced — all writes are may-occur.
+
+- Consumes: `FieldRead`, `FieldWrite`, `ExprValueSource`.
+- Cardinality: **~10^4 rows** Mastodon. FieldWrites in the corpus are dominated by class field init and reducer-style assignments.
+- Planner: 3-table join keyed on `(baseSym, fld)` after P3b projection-pushdown.
+
+### 2.6 Object-literal field projection (one hop)
+
+```ql
+predicate mayResolveToObjectField(int valueExpr, int sourceExpr) {
+    exists(int objExpr, string fld, int fieldValExpr |
+        // valueExpr is a FieldRead of fld on a sym whose VarDecl init is objExpr
+        exists(int baseSym, int varDecl |
+            FieldRead(valueExpr, baseSym, fld) and
+            VarDecl(varDecl, baseSym, objExpr, _) and
+            ObjectLiteralField(objExpr, fld, fieldValExpr) and
+            ExprValueSource(fieldValExpr, sourceExpr)
+        )
+    )
+}
+```
+
+This is the Phase A version of "the easy `resolveToObjectExpr` cases." Single VarDecl indirection, own field only. **No spread, no depth-2 var indirection, no computed key** — those need recursion through `mayResolveTo` (Phase C).
+
+- Consumes: `FieldRead`, `VarDecl`, `ObjectLiteralField`, `ExprValueSource`.
+- Cardinality: **~10^4 rows.** Object-literal-field reads through a single VarDecl are common in React (props destructure, theme objects).
+- Planner: 4-table join. The disjunction-poisoning bug (#166) does NOT apply here because every Phase A rule is a separate top-level predicate; the union is `or`-of-calls below.
+
+### 2.7 Top-level union — `or`-of-calls
+
+```ql
+predicate mayResolveTo(int valueExpr, int sourceExpr) {
+    mayResolveToBase(valueExpr, sourceExpr)
+    or mayResolveToVarInit(valueExpr, sourceExpr)
+    or mayResolveToAssign(valueExpr, sourceExpr)
+    or mayResolveToParamBind(valueExpr, sourceExpr)
+    or mayResolveToFieldRead(valueExpr, sourceExpr)
+    or mayResolveToObjectField(valueExpr, sourceExpr)
+}
+```
+
+(Where `mayResolveToBase` wraps §2.1.) This shape is exactly the disj2 round-4 pattern: one head, six named branches, top-level disjunction is `or`-of-calls — sidesteps #166 by construction. Aggregate cardinality on Mastodon: **~10^5–10^6 rows.** Sits comfortably inside the planner's non-recursive sizing.
+
+### 2.8 Derived helper — `resolvesToFunctionDirect`
+
+```ql
+predicate resolvesToFunctionDirect(int callee, int fnId) {
+    exists(int sourceExpr |
+        mayResolveTo(callee, sourceExpr) and
+        FunctionSymbol(_, sourceExpr) and
+        sourceExpr = fnId
+    )
+}
+```
+
+Phase A surface for the bridge: "is this callee's resolved value-source a function expression node?" Phase C will replace with the recursive-aware version.
+
+---
+
+## 3. Bridge migration scope (Phase A only)
+
+Phase A migrates **only the directly-resolvable `resolveToObjectExpr*` branches** in `bridge/tsq_react.qll`. The recursion-dependent ones (Wrapped + VarD2) stay until Phase C.
+
+### 3.1 Predicates that collapse
+
+| Predicate | Lines | Phase A action |
+|---|---|---|
+| `resolveToObjectExprDirect` (L512–515) | 4 | **Delete.** Subsumed by `mayResolveToObjectField` callers asking "did this resolve to an object literal." Bridge call sites swap to the new helper. |
+| `resolveToObjectExprVarD1` (L534–541) | 8 | **Delete.** Exactly the pattern of §2.6's body without the field-read step — the bridge's downstream consumer of `objExpr` becomes a `mayResolveTo`-driven join. |
+| `objectLiteralFieldOwn` (L615–617) | 3 | **Delete.** Trivially `ObjectLiteralField(objExpr, fld, valueExpr)` — bridge consumers inline the EDB. |
+| `contextProviderFieldR3DirectOwn` (L817–823) | 7 | **Delete.** Top-level disjunct that only consumed `objectLiteralFieldOwn` + `resolveToObjectExprDirect`. |
+| `contextProviderFieldR3VarIndirectOwn` (L770–779) | 10 | **Delete.** Same — it's the §2.6 pattern with one extra ExprMayRef hop on the consumer side. |
+
+That's **~32 LoC and 5 predicates** deleted directly from rounds 3/4 of the bridge.
+
+### 3.2 Predicates that survive Phase A (deferred to Phase C)
+
+- `resolveToObjectExprWrapped` (L523) — depends on `Contains` walking; recursive shape, defer.
+- `resolveToObjectExprVarD2` (L550) — two-hop var indirection, requires recursive `mayResolveTo`.
+- `objectLiteralFieldSpreadD1*` / `D2*` family (L624–700+) — spread chains, recursive by nature.
+- `contextProviderFieldR3*Spread*` family — same reason.
+- All `_outerCtx`/`_innerCtx`/`contextSymLink*` R4 splits — these are disjunction-poisoning workarounds for the *recursive* alias chain; Phase A doesn't touch them, Phase C deletes them when the recursive `mayResolveTo` arrives.
+
+### 3.3 Quantified target
+
+- **Lines deleted from `bridge/tsq_react.qll` in Phase A:** ~30–50 (target floor: 30).
+- **Predicates removed:** 5.
+- **No predicate count reduction in R4 splits.** That comes in Phase C.
+
+This is *deliberately* a small migration. Phase A's win is the vocabulary, not the deletions. The parent doc's "≥ 600 lines deleted" target is a Phase D goal.
+
+---
+
+## 4. Test strategy
+
+### 4.1 New fixtures
+
+Under `testdata/projects/`:
+
+- `valueflow-base/` — minimal TS project covering each Phase A rule in isolation:
+  - `var_init.ts` — `const x = {...}; use(x)` exercises §2.2.
+  - `assign.ts` — `let x; x = () => 1; x()` exercises §2.3.
+  - `param_bind.ts` — `function f(g) { g(); } f(() => 1);` exercises §2.4.
+  - `field_read_write.ts` — `class C { x = () => 1; } new C().x()` exercises §2.5.
+  - `obj_field.ts` — `const o = { f: () => 1 }; o.f()` exercises §2.6.
+
+Each file ≤ 20 LoC, hand-checkable expected `mayResolveTo` rows.
+
+- `valueflow-negative/` — patterns Phase A must NOT resolve (would require recursion):
+  - Two-hop var indirection.
+  - Object spread carrier.
+  - Field write through aliased base.
+
+  Assertion: `mayResolveTo` returns 0 rows for the use-site expression. These are guards against accidental recursive leakage.
+
+### 4.2 Extractor unit tests
+
+In `extract/walker_test.go` and `extract/walker_v2_test.go`: per new relation, a fixture-tuple test that asserts the exact emitted row set. Borrows the existing `assertRows` helper pattern.
+
+### 4.3 Regression invariant — round-1 to round-4 fixtures unchanged
+
+Phase A introduces new rules; it does **not** rewrite the bridge's R1–R4 logic (only deletes the 5 predicates in §3.1, all of which are pure subsumption). Strategy:
+
+1. Capture golden output for `react-component`, `react-usestate`, `react-usestate-context-alias`, `react-usestate-context-alias-r3`, `react-usestate-prop-alias` **before** the Phase A PR series starts (one commit on `design/valueflow-phase-a` saving `testdata/expected/phase-a-baseline/*.txt`).
+2. After each Phase A PR lands, re-run the same queries; diff must be **empty**. The 5 deleted predicates are subsumption-only; their removal must not change query results.
+3. Also run `compat_test.go` and `regression_*_test.go` end-to-end — these cover round-1/2/3/4 setter alias detection. Both must pass unmodified.
+
+If a diff appears, the deletion was wrong (not subsumption). Revert the deletion; defer to Phase C.
+
+---
+
+## 5. Sequencing — 4 PRs
+
+Each PR is independently mergeable, gated, and reverts cleanly.
+
+### PR 1 — `feat(extract): ExprValueSource + AssignExpr base relations`
+
+- Scope: schema rows in `relations.go`; emit sites in `walker.go` and `walker_v2.go` for both rels; unit tests.
+- Dep: none.
+- Size: **~100 LoC** (incl. tests).
+- Delivers: two new EDB relations populated for every project. No QL consumer yet.
+- Merge gate: existing extractor tests green; new walker tests green; `compat_test.go` unchanged.
+
+### PR 2 — `feat(extract): ParamBinding post-pass relation`
+
+- Scope: post-pass in walker_v2 (and walker.go via shared helper); schema row; carve-outs documented (no spread, no rest); unit tests.
+- Dep: PR 1 (shares schema-version bump).
+- Size: **~150 LoC** (post-pass logic is the largest single chunk).
+- Delivers: third Phase A EDB relation.
+- Merge gate: extractor tests green; ParamBinding row count on `react-usestate` fixture matches a hand-derived expected count (added test).
+
+### PR 3 — `feat(ql): non-recursive mayResolveTo + tsq_valueflow.qll`
+
+- Scope: `ql/system/valueflow.qll` with the 6 named branches + `mayResolveTo` union; `bridge/tsq_valueflow.qll` re-exporting + `resolvesToFunctionDirect`; new fixtures `valueflow-base/` and `valueflow-negative/`; QL tests.
+- Dep: PR 1, PR 2.
+- Size: **~250 LoC** (QL + fixtures + tests).
+- Delivers: a sized, runnable, non-recursive `mayResolveTo`. Bridge is still on R1–R4.
+- Merge gate: per-rule fixture rows match expected; negative fixtures return 0; planner sizing on `valueflow-base` shows non-default (i.e. real) cardinality estimates (assert via `tsq plan --explain` snapshot test).
+
+### PR 4 — `refactor(bridge): collapse easy resolveToObjectExpr branches onto mayResolveTo`
+
+- Scope: delete the 5 predicates listed in §3.1; rewrite their call sites to use `mayResolveTo` / `mayResolveToObjectField` / direct EDB. Save the golden baseline before opening PR.
+- Dep: PR 3.
+- Size: **~80 LoC removed, ~40 LoC added** at call sites. Net **−40 LoC**.
+- Delivers: first measurable bridge collapse; baseline established for Phase C.
+- Merge gate: golden-baseline diff is **empty** across all 5 React fixtures; `compat_test.go`, `regression_*_test.go`, `setstate_*_test.go` all pass; Mastodon bench wall-time delta within ±10% of pre-PR baseline.
+
+**Total Phase A:** 4 PRs, ~620 LoC net add (~530 incl. test fixtures), elapsed estimate **2 weeks** as the parent doc projects.
+
+---
+
+## 6. What Phase A explicitly does NOT do
+
+Comprehensive list — Phase B/C inheritors should expect none of these:
+
+1. **No recursion in `mayResolveTo`.** Every rule is depth-1 from a `*ValueSource`-grounded leaf. No rule body contains a `mayResolveTo` literal.
+2. **No two-hop var indirection.** `const a = b; const b = {...};` is unresolved in Phase A. Bridge's `resolveToObjectExprVarD2` survives.
+3. **No spread resolution.** `{ ...base }` is unmodelled. All `objectLiteralFieldSpread*` predicates survive in the bridge.
+4. **No JSX-wrapper unwrap.** `value={{...}}` where the JsxAttribute valueExpr is the JsxExpression wrapper, not the inner Object — `resolveToObjectExprWrapped` survives.
+5. **No call-return composition.** `function f() { return {...}; } f()` does not resolve through Phase A. (Needs `mayResolveTo(retExpr, s)` recursion.)
+6. **No destructure-source resolution.** `const { a } = o;` does not resolve `a` to `o.a`'s value-source. Needs recursion.
+7. **No cross-module symbol resolution.** `ImportBinding`/`ExportBinding` chains are out of scope.
+8. **No method/inheritance resolution.** `MethodResolvesTo` deferred entirely.
+9. **No type-driven resolution.** `ExprType` is not consulted; we stay structural.
+10. **No effect modelling.** Getters/setters/Proxy ignored, per parent doc §5.
+11. **No await/promise chain.** `await e` is not unwrapped in Phase A even though parent doc §5 lists it as v1; the Phase A rules don't include the unwrap clause. Add in Phase C as a one-line rule.
+12. **No `as` cast unwrap, no `!` non-null unwrap, no parenthesised-expr unwrap.** All deferred — they're each one rule in Phase C.
+13. **No depth bound.** Phase A is depth-1 by construction; the `MayResolveDepth` parameter from parent doc §6 Phase C does not exist yet.
+14. **No bridge R4 split deletions.** `_outerCtx`/`_innerCtx` and `contextSymLink*` survive untouched.
+15. **No planner work.** Recursive-IDB sizing (parent §4.2 #1) and disjunction-binding-loss (#166) remain Phase B's job.
+
+---
+
+## 7. Risks specific to Phase A
+
+### 7.1 Extractor complexity creep on `ParamBinding`
+
+The post-pass design is clean *as written*, but JS/TS argument-passing has a long tail: spread args, rest params, default params, destructured params, optional params, overload resolution. The Phase A carve-out (skip spread + rest) is correct but easy to slide on under reviewer pressure. **Mitigation:** the relation comment in `relations.go` lists the carve-outs explicitly, and the unit test asserts a 0-row outcome for spread/rest fixtures so any drift breaks CI.
+
+### 7.2 Schema bump breaks downstream consumers
+
+`db.SchemaVersion` bump means older tsq binaries reading newly-extracted DBs won't know `ExprValueSource`/`ParamBinding`/`AssignExpr`. The current schema is forward-compat (unknown rels ignored) — verify before PR 1 lands by running an old binary against a new DB and confirming it doesn't panic. **Mitigation:** add a `compat_test.go` case that loads a Phase-A-extracted DB with an artificially-stale binary version and asserts the existing queries still work.
+
+### 7.3 ParamBinding cardinality blow-up
+
+If RTA-resolved `CallTarget` rows are noisy on Mastodon (one call site → many candidate fns), `ParamBinding` row count grows multiplicatively. A 3x blow-up on a 100k-symbol corpus pushes EDB into the millions. **Mitigation:** PR 2 includes a Mastodon row-count budget assertion in its bench output. If `ParamBinding` exceeds 5x the `CallArg` row count, PR 2 doesn't merge — switch to `CallTarget`-only (drop `CallTargetRTA`) and document the precision loss.
+
+### 7.4 Subsumption assumption in §3.1 wrong
+
+The 5 predicates marked "delete in PR 4" are claimed to be exactly subsumed by Phase A rules. If the bridge has a query path that exploits the *non*-resolution of one of them (an under-approximation the bridge silently relies on), deletion changes results. **Mitigation:** the golden-baseline diff in §4.3 catches this. Kill-switch: revert PR 4 only — PRs 1–3 stay landed and inert.
+
+### 7.5 Disjunction-poisoning re-emerges in §2.7's union
+
+The `or`-of-calls top-level shape is the known-good workaround pattern, but if any of the 6 branches happens to share a shape that triggers a *new* binding-loss case in the planner's disjunction rewrite, Phase A's rule returns 0 in production. **Mitigation:** PR 3's QL tests include per-branch isolation assertions (call each branch directly, confirm row count) AND a union assertion (call `mayResolveTo`, confirm row count = sum of branches modulo expected dedup). If they diverge on Mastodon, the workaround failed and we're hitting #166 again — escalate to Phase B.
+
+### 7.6 Kill-switch / rollback story
+
+Per-PR rollback model:
+
+- **Revert PR 4** → bridge is back to current state; `tsq_valueflow.qll` exists but is unused; no functional regression.
+- **Revert PR 3** → no consumer of new EDB rels; extractor still emits them harmlessly.
+- **Revert PR 2** → `ParamBinding` gone; PR 3's `mayResolveToParamBind` branch returns 0 (other branches still work). Phase A is degraded but functional.
+- **Revert PR 1** → schema-version rollback required; coordinated revert across all four PRs.
+
+Phase A has no shared mutable global state with the rest of the planner — revert is mechanical. The schema bump in PR 1 is the one non-clean piece; everything downstream is additive.
+
+---
+
+## Appendix — open questions surfaced by Phase A
+
+1. **Is `ExprValueSource` worth its row count?** It's `(v, v)` — pure identity. The planner-sizing argument (need a grounded base for Phase C) is real but un-measured. If P2b sampling can size a bare-equality base case adequately, `ExprValueSource` is dead weight on Mastodon (~500k rows of no information).
+2. **Should `ParamBinding` use `CallTarget` only, or `CallTarget ∪ CallTargetRTA`?** RTA is more precise but multiplies. No data on Mastodon yet.
+3. **Schema-version policy for additive relations.** Currently every new rel bumps `db.SchemaVersion` once. Three new rels in Phase A = three bumps or one? No documented policy; PR 1 should pick one.
+
+---
+
+## PR3 amendment — JSX wrapper subsumption gap (2026-04-19)
+
+**Status:** landed alongside the bridge migration (this PR).
+
+### The gap
+
+Plan §3.1 lists `resolveToObjectExprVarD1` (bridge `tsq_react.qll` L534)
+as cleanly subsumed by `mayResolveToVarInit` (plan §2.2). That subsumption
+is wrong as designed.
+
+`resolveToObjectExprVarD1` is **JsxExpression-wrapper-tolerant**:
+
+```ql
+predicate resolveToObjectExprVarD1(int valueExpr, int objExpr) {
+    exists(int identExpr, int sym, int varDecl |
+        (identExpr = valueExpr or Contains(valueExpr, identExpr)) and
+        ExprMayRef(identExpr, sym) and
+        VarDecl(varDecl, sym, objExpr, _) and
+        isObjectLiteralExpr(objExpr)
+    )
+}
+```
+
+The `(identExpr = valueExpr or Contains(valueExpr, identExpr))` idiom
+accepts the canonical `<Provider value={X} />` shape. The walker emits the
+JsxAttribute's `valueExpr` column pointing at the `JsxExpression {X}`
+wrapper (per `extract/walker.go:emitJsxAttr` field-or-fallback rule), not
+at the inner identifier `X`. The `Contains` clause unwraps the wrapper
+one level so `ExprMayRef(identExpr, sym)` can fire on the inner `X`.
+
+`mayResolveToVarInit` as shipped in PR2 (commit `28bcda5`) is
+value-expr-rooted:
+
+```ql
+predicate mayResolveToVarInit(int valueExpr, int sourceExpr) {
+    exists(int sym, int initExpr, int varDecl |
+        ExprMayRef(valueExpr, sym) and       // <-- direct on valueExpr, no unwrap
+        VarDecl(varDecl, sym, initExpr, _) and
+        ExprValueSource(initExpr, sourceExpr)
+    )
+}
+```
+
+`ExprMayRef(jsxExpr, sym)` is empty for the JsxExpression wrapper, so
+substituting `mayResolveToVarInit` for `resolveToObjectExprVarD1` silently
+drops every `value={X}` case — the entire IndirectValue + ComputedKey
+path of the R3 fixture, which is the load-bearing test corpus.
+
+The first PR3 attempt landed this substitution and the
+`TestSetStateUpdaterCallsOtherSetStateThroughContext_R3` parity gate
+caught it: 2 of 3 expected matches dropped to 0 (Indirect=0,
+Computed=0). The PR3 attempt was halted, scope re-examined.
+
+### The resolution
+
+A `JsxExpression` wrapping an inner expression IS a real value-flow edge.
+The fix is principled: extend `mayResolveTo` with wrapper-tolerant
+handling, then redo the bridge migration.
+
+#### Design — single wrapper branch over the core union
+
+Two shapes were considered:
+
+1. **Per-branch wrapped variants.** Add `mayResolveToVarInitWrapped`,
+   `mayResolveToAssignWrapped`, …, six new predicates each unwrapping
+   then re-running its underlying base. Bloats the union to 12 branches.
+2. **One wrapper branch over a lifted core union.** Lift the existing
+   six-branch union to `mayResolveToCore`, add a single
+   `mayResolveToJsxWrapped` that calls `mayResolveToCore` on the
+   unwrapped inner. Two-branch top-level union (`Core` ∪ `JsxWrapped`),
+   one new helper, one new predicate.
+
+PR3 picked shape (2). Both preserve the `or`-of-calls discipline at the
+top level (each disjunct is a named-head call, not a literal disjunction
+inside one rule body). Shape (2) keeps the union clean and makes the
+wrapper extension a single contained change.
+
+```ql
+predicate jsxExpressionUnwrap(int jsxExpr, int innerExpr) {
+    Node(jsxExpr, _, "JsxExpression", _, _, _, _) and
+    Contains(jsxExpr, innerExpr)
+}
+
+predicate mayResolveToCore(int valueExpr, int sourceExpr) {
+    mayResolveToBase(valueExpr, sourceExpr)
+    or mayResolveToVarInit(valueExpr, sourceExpr)
+    or mayResolveToAssign(valueExpr, sourceExpr)
+    or mayResolveToParamBind(valueExpr, sourceExpr)
+    or mayResolveToFieldRead(valueExpr, sourceExpr)
+    or mayResolveToObjectField(valueExpr, sourceExpr)
+}
+
+predicate mayResolveToJsxWrapped(int valueExpr, int sourceExpr) {
+    exists(int innerExpr |
+        jsxExpressionUnwrap(valueExpr, innerExpr) and
+        mayResolveToCore(innerExpr, sourceExpr)
+    )
+}
+
+predicate mayResolveTo(int valueExpr, int sourceExpr) {
+    mayResolveToCore(valueExpr, sourceExpr)
+    or mayResolveToJsxWrapped(valueExpr, sourceExpr)
+}
+```
+
+`jsxExpressionUnwrap` deliberately uses **direct** `Contains` (one
+parent→child hop), not transitive walking. Arbitrary parent unwrap would
+over-approximate: it would resolve `<Provider value={f({...})} />`
+through the inner spread, when the bridge's existing semantics
+intentionally stop there. Direct-only matches the existing
+`resolveToObjectExprVarD1` semantics exactly: tree-sitter's
+`jsx_expression` directly wraps a single inline expression.
+
+Non-recursive, end to end. Call graph is
+
+```
+mayResolveTo  →  { mayResolveToCore, mayResolveToJsxWrapped }
+mayResolveToJsxWrapped  →  mayResolveToCore
+mayResolveToCore  →  { mayResolveToBase, …VarInit, …Assign, …ParamBind, …FieldRead, …ObjectField }
+each branch  →  EDB only
+```
+
+No back-edge. Trivial-IDB pre-pass sizes the depth-3 stack the same way
+it sized the original union.
+
+### Migration scope, post-amendment
+
+Plan §3.1 listed five predicates for deletion. After re-examining the
+full call graph, PR3 ships a tighter scope:
+
+| Predicate | Plan §3.1 | PR3 outcome | Rationale |
+|---|---|---|---|
+| `resolveToObjectExprDirect` | Delete | **Deleted** | Subsumed by `mayResolveToObjectExpr` (mayResolveToBase fires on the identity row of every object literal). |
+| `resolveToObjectExprVarD1` | Delete | **Deleted** | Subsumed by `mayResolveToObjectExpr` once `mayResolveToJsxWrapped` lands. |
+| `objectLiteralFieldOwn` | Delete | **Deferred** | Inlining its body (`ObjectLiteralField(o, f, v)`) into `objectLiteralFieldThroughSpread`'s union breaks the `or`-of-calls #166 workaround discipline at that union — first disjunct would become an EDB literal, the rest named calls. Deferred to a follow-up that addresses the discipline cost separately. |
+| `contextProviderFieldR3DirectOwn` | Delete | **Deferred** | Composes with `objectLiteralFieldOwn`; deletion is contingent on the previous row. Same `or`-of-calls discipline concern at `contextProviderFieldR3DirectSpread`. |
+| `contextProviderFieldR3VarIndirectOwn` | Delete | **Deferred** | Same — composes with `objectLiteralFieldOwn`, gated on the same discipline concern at `contextProviderFieldR3VarIndirect`. |
+
+PR3 ships **2 of 5** plan-targeted predicates, plus the wrapper extension
+that wasn't in the original plan. The remaining three are tracked for a
+follow-up PR that also addresses the named-call wrapping pattern at
+`*ThroughSpread` / `contextProviderFieldR3*` unions to preserve the #166
+workaround.
+
+### Helper introduced
+
+`bridge/tsq_react.qll`:
+
+```ql
+predicate mayResolveToObjectExpr(int valueExpr, int objExpr) {
+    mayResolveTo(valueExpr, objExpr) and
+    isObjectLiteralExpr(objExpr)
+}
+```
+
+Used by `resolveToObjectExpr`'s union in place of `Direct + VarD1`. Net
+LoC: −12 deleted, +5 new helper definition + comment block, +1 union
+disjunct change.
+
+### Parity gate evidence
+
+R3 + R4 through-context test results, baseline (origin/main + wrapper
+extension only) vs. post-migration:
+
+| Test | Baseline | Post-migration |
+|---|---|---|
+| `TestSetStateUpdaterCallsOtherSetStateThroughContext_R3` | total=3 (Indirect=1, Spread=1, Computed=1, Negative=0) | total=3 (Indirect=1, Spread=1, Computed=1, Negative=0) |
+| `TestSetStateUpdaterCallsOtherSetStateThroughContext_R4` | total=2 (Consumer=1, DirectReturn=1, Negative=0) | total=2 (Consumer=1, DirectReturn=1, Negative=0) |
+
+Empty diff. Parity gate held.
+
+`TestR3_LinkPredicates` end-to-end consumers (the row counts that
+matter for downstream callers — the union of resolveToObjectExpr's
+output flowing into contextProviderField, etc.):
+
+| Predicate | Baseline | Post-migration |
+|---|---|---|
+| `resolveToObjectExpr` | 11 | 16 (precision gain — wrapper extension widens reach) |
+| `contextProviderFieldR3VarIndirect` | 6 | 6 |
+| `contextProviderField` | 6 | 6 |
+| `useStateSetterAliasV2` | 13 | 13 |
+| `useStateSetterContextAliasCall` | 6 | 6 |
+
+The widened `resolveToObjectExpr` row count is filtered by the
+field-name + ExprMayRef downstream join, so the externally-visible
+predicates (`contextProviderField`, `useStateSetterAliasV2`,
+`useStateSetterContextAliasCall`) match baseline exactly.
+
+### Test query import requirement
+
+`bridge/tsq_react.qll`'s `mayResolveToObjectExpr` calls into
+`mayResolveTo` from `bridge/tsq_valueflow.qll`. Bridge files don't carry
+`import` statements; the resolver merges only what the query imports.
+Queries that consume `tsq::react`'s React-context family must now also
+import `tsq::valueflow`, otherwise `mayResolveTo` resolves to nothing and
+the union silently returns just the surviving non-valueflow disjuncts
+(`resolveToObjectExprWrapped`, `…VarD2`, `…HookReturn`).
+
+`testdata/queries/v2/find_setstate_updater_calls_other_setstate_through_context.ql`
+adds `import tsq::valueflow` for this reason. The other React-family
+queries (find_setstate_updater_calls_other_setstate.ql, the props
+variant, the regression query, the markdown variant, the mixpanel query)
+do not consume `resolveToObjectExpr` and remain unchanged.
+
+### Carry-forward — open questions for PR4 (or follow-up)
+
+1. **Inline `objectLiteralFieldOwn` cleanly.** The `or`-of-calls
+   discipline at `objectLiteralFieldThroughSpread` and the
+   `contextProviderFieldR3*` unions can survive deletion if every
+   disjunct stays a named-call. Options: keep `objectLiteralFieldOwn`
+   permanently as a thin wrapper (defeating "delete" but trivial), or
+   thread `mayResolveToObjectField`-like helpers everywhere (more
+   substantive refactor). Defer until PR-shape decided.
+
+2. **Can `resolveToObjectExprWrapped` go away too?** PR3 keeps it
+   verbatim (plan §3.2 deferred it). Empirically, every Wrapped row is
+   already produced by `mayResolveToJsxWrapped → mayResolveToBase` once
+   the inner is the literal directly. Need Mastodon-scale parity check
+   before claiming subsumption — JsxExpression wrappers in real code may
+   carry intermediate kinds tree-sitter labels differently across
+   backends.

--- a/setstate_context_alias_r3_integration_test.go
+++ b/setstate_context_alias_r3_integration_test.go
@@ -154,7 +154,11 @@ func TestR3_LinkPredicates(t *testing.T) {
 	bridgeFiles := bridge.LoadBridge()
 	importLoader := makeBridgeImportLoader(bridgeFiles)
 
-	common := "import tsq::react\nimport tsq::base\nimport tsq::expressions\nimport tsq::functions\nimport tsq::calls\n"
+	// PR3: tsq::valueflow added because tsq_react.qll's resolveToObjectExpr
+	// now calls into mayResolveToObjectExpr, which depends on mayResolveTo
+	// from tsq_valueflow.qll. Without this import the union silently
+	// returns only the surviving non-valueflow branches.
+	common := "import tsq::react\nimport tsq::valueflow\nimport tsq::base\nimport tsq::expressions\nimport tsq::functions\nimport tsq::calls\n"
 
 	type qcase struct {
 		name      string
@@ -166,9 +170,14 @@ func TestR3_LinkPredicates(t *testing.T) {
 		// + 1 in negative (setNN) = 7
 		{"useStateSetterSym", common + "from int s where useStateSetterSym(s) select s", 7},
 		{"isObjectLiteralExpr", common + "from int o where isObjectLiteralExpr(o) select o", 4},
-		{"resolveToObjectExprDirect", common + "from int v, int o where resolveToObjectExprDirect(v, o) select v, o", 4},
+		// PR3: resolveToObjectExprDirect + resolveToObjectExprVarD1 deleted —
+		// subsumed by mayResolveToObjectExpr (tsq_react.qll) which composes
+		// the §2.1 base + §2.2 var-init + JsxExpression-wrapper-tolerant
+		// branches of mayResolveTo. The link probe now exercises the new
+		// helper directly; floor mirrors the baseline (4 Direct + 6 VarD1
+		// deduped to 10, then deduped further across paths to ≥10 on r3).
+		{"mayResolveToObjectExpr", common + "from int v, int o where mayResolveToObjectExpr(v, o) select v, o", 10},
 		{"resolveToObjectExprWrapped", common + "from int v, int o where resolveToObjectExprWrapped(v, o) select v, o", 1},
-		{"resolveToObjectExprVarD1", common + "from int v, int o where resolveToObjectExprVarD1(v, o) select v, o", 2},
 		// resolveToObjectExpr should fire for at least Indirect (1), Computed (1).
 		{"resolveToObjectExpr", common + "from int v, int o where resolveToObjectExpr(v, o) select v, o", 2},
 		// objectLiteralFieldThroughSpread: Indirect(2) + Spread(2 own + 1 spread) + Computed(2) + Negative(0) = 7

--- a/setstate_context_alias_r3_integration_test.go
+++ b/setstate_context_alias_r3_integration_test.go
@@ -163,45 +163,52 @@ func TestR3_LinkPredicates(t *testing.T) {
 	type qcase struct {
 		name      string
 		src       string
-		mustHaveN int // floor (>=)
+		mustHaveN int  // floor (>=) when exact=false; exact equality when exact=true
+		exact     bool // pin to == (downstream consumers); upstream relations stay floor-only
 	}
 	queries := []qcase{
 		// 6 useState setters across 3 positive fixtures (setIA, setIB, setSA, setSB, setCA, setCB)
 		// + 1 in negative (setNN) = 7
-		{"useStateSetterSym", common + "from int s where useStateSetterSym(s) select s", 7},
-		{"isObjectLiteralExpr", common + "from int o where isObjectLiteralExpr(o) select o", 4},
+		{"useStateSetterSym", common + "from int s where useStateSetterSym(s) select s", 7, false},
+		{"isObjectLiteralExpr", common + "from int o where isObjectLiteralExpr(o) select o", 4, false},
 		// PR3: resolveToObjectExprDirect + resolveToObjectExprVarD1 deleted —
 		// subsumed by mayResolveToObjectExpr (tsq_react.qll) which composes
 		// the §2.1 base + §2.2 var-init + JsxExpression-wrapper-tolerant
-		// branches of mayResolveTo. The link probe now exercises the new
-		// helper directly; floor mirrors the baseline (4 Direct + 6 VarD1
-		// deduped to 10, then deduped further across paths to ≥10 on r3).
-		{"mayResolveToObjectExpr", common + "from int v, int o where mayResolveToObjectExpr(v, o) select v, o", 10},
-		{"resolveToObjectExprWrapped", common + "from int v, int o where resolveToObjectExprWrapped(v, o) select v, o", 1},
+		// branches of mayResolveTo. The link probe exercises the new helper
+		// directly; pinned to exact 13 (4 Direct + 6 VarD1 + 3 JsxWrapper
+		// post-dedup on r3). Pinned because this is the migration's value-flow
+		// surface area — silent growth would mask over-approximation regressions.
+		{"mayResolveToObjectExpr", common + "from int v, int o where mayResolveToObjectExpr(v, o) select v, o", 13, true},
+		{"resolveToObjectExprWrapped", common + "from int v, int o where resolveToObjectExprWrapped(v, o) select v, o", 1, false},
 		// resolveToObjectExpr should fire for at least Indirect (1), Computed (1).
-		{"resolveToObjectExpr", common + "from int v, int o where resolveToObjectExpr(v, o) select v, o", 2},
+		{"resolveToObjectExpr", common + "from int v, int o where resolveToObjectExpr(v, o) select v, o", 2, false},
 		// objectLiteralFieldThroughSpread: Indirect(2) + Spread(2 own + 1 spread) + Computed(2) + Negative(0) = 7
-		{"objectLiteralFieldOwn", common + "from int o, string f, int v where objectLiteralFieldOwn(o, f, v) select o, f, v", 5},
-		{"objectLiteralFieldSpreadD1", common + "from int o, string f, int v where objectLiteralFieldSpreadD1(o, f, v) select o, f, v", 1},
-		{"objectLiteralFieldThroughSpread", common + "from int o, string f, int v where objectLiteralFieldThroughSpread(o, f, v) select o, f, v", 6},
+		{"objectLiteralFieldOwn", common + "from int o, string f, int v where objectLiteralFieldOwn(o, f, v) select o, f, v", 5, false},
+		{"objectLiteralFieldSpreadD1", common + "from int o, string f, int v where objectLiteralFieldSpreadD1(o, f, v) select o, f, v", 1, false},
+		{"objectLiteralFieldThroughSpread", common + "from int o, string f, int v where objectLiteralFieldThroughSpread(o, f, v) select o, f, v", 6, false},
 		// contextProviderField: 6 setter fields visible across the 3 positive providers.
-		{"contextProviderFieldR2", common + "from int s, string f, int v where contextProviderFieldR2(s, f, v) select s, f, v", 0},
-		{"contextProviderFieldR3DirectOwn", common + "from int s, string f, int v where contextProviderFieldR3DirectOwn(s, f, v) select s, f, v", 1},
-		{"contextProviderFieldR3DirectSpreadD1", common + "from int s, string f, int v where contextProviderFieldR3DirectSpreadD1(s, f, v) select s, f, v", 1},
-		{"contextProviderFieldR3DirectSpread", common + "from int s, string f, int v where contextProviderFieldR3DirectSpread(s, f, v) select s, f, v", 2},
-		{"contextProviderFieldR3VarIndirect", common + "from int s, string f, int v where contextProviderFieldR3VarIndirect(s, f, v) select s, f, v", 4},
-		{"contextProviderField", common + "from int s, string f, int v where contextProviderField(s, f, v) select s, f, v", 6},
+		{"contextProviderFieldR2", common + "from int s, string f, int v where contextProviderFieldR2(s, f, v) select s, f, v", 0, false},
+		{"contextProviderFieldR3DirectOwn", common + "from int s, string f, int v where contextProviderFieldR3DirectOwn(s, f, v) select s, f, v", 1, false},
+		{"contextProviderFieldR3DirectSpreadD1", common + "from int s, string f, int v where contextProviderFieldR3DirectSpreadD1(s, f, v) select s, f, v", 1, false},
+		{"contextProviderFieldR3DirectSpread", common + "from int s, string f, int v where contextProviderFieldR3DirectSpread(s, f, v) select s, f, v", 2, false},
+		{"contextProviderFieldR3VarIndirect", common + "from int s, string f, int v where contextProviderFieldR3VarIndirect(s, f, v) select s, f, v", 4, false},
+		// PR3 amendment — downstream consumer relation, pinned to exact equality.
+		// Silent growth here would mask precision regressions in the upstream
+		// resolve* helpers feeding it. Update only when fixture changes intentionally.
+		{"contextProviderField", common + "from int s, string f, int v where contextProviderField(s, f, v) select s, f, v", 6, true},
 		// useStateSetterContextAliasCall: at least one outer + inner per positive = 6.
-		{"contextSym", common + "from int s where contextSym(s) select s", 4},
-		{"contextDestructureBinding", common + "from int s, string f, int p where contextDestructureBinding(s, f, p) select s, f, p", 6},
-		{"contextSetterAliasStepR2", common + "from int v, int p where contextSetterAliasStepR2(v, p) select v, p", 0},
-		{"contextSetterAliasStepR3DirectSpread", common + "from int v, int p where contextSetterAliasStepR3DirectSpread(v, p) select v, p", 1},
-		{"contextSetterAliasStepR3VarIndirect", common + "from int v, int p where contextSetterAliasStepR3VarIndirect(v, p) select v, p", 4},
-		{"contextSymLink", common + "from int p, int c where contextSymLink(p, c) select p, c", 4},
-		{"contextSetterAliasStep", common + "from int v, int p where contextSetterAliasStep(v, p) select v, p", 6},
-		{"useStateSetterAliasV2", common + "from int s where useStateSetterAliasV2(s) select s", 13},
-		{"isContextAliasedSetterSym", common + "from int s where isContextAliasedSetterSym(s) select s", 6},
-		{"useStateSetterContextAliasCall", common + "from int c where useStateSetterContextAliasCall(c) select c", 6},
+		{"contextSym", common + "from int s where contextSym(s) select s", 4, false},
+		{"contextDestructureBinding", common + "from int s, string f, int p where contextDestructureBinding(s, f, p) select s, f, p", 6, false},
+		{"contextSetterAliasStepR2", common + "from int v, int p where contextSetterAliasStepR2(v, p) select v, p", 0, false},
+		{"contextSetterAliasStepR3DirectSpread", common + "from int v, int p where contextSetterAliasStepR3DirectSpread(v, p) select v, p", 1, false},
+		{"contextSetterAliasStepR3VarIndirect", common + "from int v, int p where contextSetterAliasStepR3VarIndirect(v, p) select v, p", 4, false},
+		{"contextSymLink", common + "from int p, int c where contextSymLink(p, c) select p, c", 4, false},
+		{"contextSetterAliasStep", common + "from int v, int p where contextSetterAliasStep(v, p) select v, p", 6, false},
+		// PR3 amendment — downstream consumer pinned to exact equality (see contextProviderField note).
+		{"useStateSetterAliasV2", common + "from int s where useStateSetterAliasV2(s) select s", 13, true},
+		{"isContextAliasedSetterSym", common + "from int s where isContextAliasedSetterSym(s) select s", 6, false},
+		// PR3 amendment — downstream consumer pinned to exact equality (see contextProviderField note).
+		{"useStateSetterContextAliasCall", common + "from int c where useStateSetterContextAliasCall(c) select c", 6, true},
 	}
 	hints := make(map[string]int, len(schema.Registry))
 	for _, def := range schema.Registry {
@@ -246,9 +253,16 @@ func TestR3_LinkPredicates(t *testing.T) {
 			t.Errorf("[%s] eval err: %v", q.name, err)
 			continue
 		}
-		t.Logf("link %-40s rows=%d (>=%d expected)", q.name, len(rs.Rows), q.mustHaveN)
-		if len(rs.Rows) < q.mustHaveN {
-			t.Errorf("[%s] expected >=%d rows, got %d", q.name, q.mustHaveN, len(rs.Rows))
+		if q.exact {
+			t.Logf("link %-40s rows=%d (==%d expected)", q.name, len(rs.Rows), q.mustHaveN)
+			if len(rs.Rows) != q.mustHaveN {
+				t.Errorf("[%s] expected exactly %d rows, got %d (downstream consumer — silent drift not permitted)", q.name, q.mustHaveN, len(rs.Rows))
+			}
+		} else {
+			t.Logf("link %-40s rows=%d (>=%d expected)", q.name, len(rs.Rows), q.mustHaveN)
+			if len(rs.Rows) < q.mustHaveN {
+				t.Errorf("[%s] expected >=%d rows, got %d", q.name, q.mustHaveN, len(rs.Rows))
+			}
 		}
 	}
 }

--- a/testdata/projects/valueflow-base/jsx_wrapped.tsx
+++ b/testdata/projects/valueflow-base/jsx_wrapped.tsx
@@ -1,0 +1,25 @@
+// Branch JsxWrapped — JsxExpression-wrapper-tolerant resolution.
+//
+// `<Provider value={X} />` shape: the JsxAttribute's valueExpr column points
+// at the JsxExpression wrapper `{X}`, NOT the inner Identifier `X`. The
+// six base branches of `mayResolveTo` require `ExprMayRef(valueExpr, sym)`
+// directly on `valueExpr`, so without wrapper handling they silently miss
+// every `value={X}` case (the bug that surfaced when PR3 first attempted
+// to substitute mayResolveToVarInit for resolveToObjectExprVarD1).
+//
+// The wrapper-tolerant variant in `mayResolveTo` unwraps a single
+// JsxExpression layer and re-runs the core branches against the inner
+// expression. Below the inner Identifier `theme` is a sym whose VarDecl
+// initialiser is the object-literal value-source — i.e. the var-init
+// branch fires on the unwrapped form.
+
+import { ReactNode } from 'react';
+
+const Theme = { current: { color: 'red' } } as any;
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const theme = { color: 'red' };
+  return (
+    <Theme.Provider value={theme}>{children}</Theme.Provider>
+  );
+}

--- a/testdata/queries/v2/find_setstate_updater_calls_other_setstate_through_context.ql
+++ b/testdata/queries/v2/find_setstate_updater_calls_other_setstate_through_context.ql
@@ -17,6 +17,7 @@
  */
 
 import tsq::react
+import tsq::valueflow
 import tsq::calls
 import tsq::variables
 import tsq::functions

--- a/testdata/queries/v2/valueflow/branch_jsx_wrapped.ql
+++ b/testdata/queries/v2/valueflow/branch_jsx_wrapped.ql
@@ -1,0 +1,19 @@
+/**
+ * @name mayResolveToJsxWrapped — branch isolation
+ * @kind table
+ * @id js/tsq/valueflow/branch-jsx-wrapped
+ *
+ * The JSX-wrapper-tolerant branch added in PR3. Re-runs `mayResolveToCore`
+ * on the inner expression of a JsxExpression wrapper. Designed to make the
+ * canonical `<Provider value={X} />` shape resolve through the value-flow
+ * layer (the JsxAttribute valueExpr column points at the JsxExpression
+ * `{X}` node, not at `X` directly).
+ */
+import tsq::valueflow
+import tsq::base
+import tsq::expressions
+import tsq::variables
+import tsq::calls
+import tsq::functions
+import tsq::symbols
+from int v, int s where mayResolveToJsxWrapped(v, s) select v, s

--- a/testdata/queries/v2/valueflow/branch_jsx_wrapped_object_source.ql
+++ b/testdata/queries/v2/valueflow/branch_jsx_wrapped_object_source.ql
@@ -1,0 +1,22 @@
+/**
+ * @name mayResolveToJsxWrapped — sourceExpr is an ObjectLiteral
+ * @kind table
+ * @id js/tsq/valueflow/branch-jsx-wrapped-object-source
+ *
+ * Tightened probe for the JSX-wrapper-tolerant branch. Filters the raw
+ * mayResolveToJsxWrapped(v, s) result to rows whose `s` is an object-literal
+ * expression (per `isObjectLiteralExpr`). The jsx_wrapped.tsx fixture has a
+ * single `theme` VarDecl initialised to `{ color: 'red' }`, so this probe
+ * MUST return at least one row. A bare `>0 rows` check on the unfiltered
+ * branch would tolerate a regression where the wrapper resolves to the wrong
+ * sourceExpr kind (e.g. an Identifier) — this filter pins the semantics.
+ */
+import tsq::valueflow
+import tsq::base
+import tsq::expressions
+import tsq::variables
+import tsq::calls
+import tsq::functions
+import tsq::symbols
+import tsq::react
+from int v, int s where mayResolveToJsxWrapped(v, s) and isObjectLiteralExpr(s) select v, s

--- a/valueflow_integration_test.go
+++ b/valueflow_integration_test.go
@@ -473,6 +473,27 @@ func TestValueflow_JsxWrappedBranch(t *testing.T) {
 			"`<Provider value={X} />` case.")
 	}
 	t.Logf("mayResolveToJsxWrapped: %d row(s) on valueflow-base jsx_wrapped fixture", len(rs.Rows))
+
+	// Tighten the assertion: at least one row must resolve to an
+	// object-literal sourceExpr. The fixture has `const theme = { color: 'red' }`
+	// → mayResolveToJsxWrapped(value={theme}, {color:'red'}). A regression
+	// that resolves the wrapper to a non-literal sourceExpr (e.g. the
+	// Identifier `theme` itself) would still pass `len(rs.Rows) > 0` but
+	// silently fail the migration's semantic intent. The probe joins with
+	// isObjectLiteralExpr to pin the kind.
+	rsObj := runValueflowQuery(t,
+		"testdata/queries/v2/valueflow/branch_jsx_wrapped_object_source.ql",
+		"testdata/projects/valueflow-base")
+	if len(rsObj.Rows) == 0 {
+		t.Fatal("mayResolveToJsxWrapped returned no row whose sourceExpr is " +
+			"an object literal (per isObjectLiteralExpr) on valueflow-base. " +
+			"jsx_wrapped.tsx has `const theme = { color: 'red' }` and " +
+			"`<Provider value={theme}>`; the wrapper must resolve through " +
+			"the var-init branch to the object literal. A non-empty " +
+			"unfiltered result with an empty filtered result indicates " +
+			"the wrapper is binding to the wrong sourceExpr kind.")
+	}
+	t.Logf("mayResolveToJsxWrapped (object-literal source): %d row(s)", len(rsObj.Rows))
 }
 
 // TestValueflow_IntegrationOnReactFixture is the smoke test that

--- a/valueflow_integration_test.go
+++ b/valueflow_integration_test.go
@@ -118,6 +118,12 @@ func TestValueflow_AllBranchesFireOnBase(t *testing.T) {
 		{"param_bind", "testdata/queries/v2/valueflow/branch_param_bind.ql"},
 		{"field_read", "testdata/queries/v2/valueflow/branch_field_read.ql"},
 		{"object_field", "testdata/queries/v2/valueflow/branch_object_field.ql"},
+		// PR3 amendment — JSX-wrapper-tolerant branch. Fires on the
+		// `<Provider value={X} />` shape where the JsxExpression `{X}`
+		// is what JsxAttribute.valueExpr points at, NOT the inner
+		// identifier. Without this branch the bridge migration would
+		// silently drop every `value={X}` case.
+		{"jsx_wrapped", "testdata/queries/v2/valueflow/branch_jsx_wrapped.ql"},
 	}
 
 	for _, b := range branches {
@@ -160,6 +166,11 @@ func TestValueflow_UnionMatchesSumOfBranches(t *testing.T) {
 		"testdata/queries/v2/valueflow/branch_param_bind.ql",
 		"testdata/queries/v2/valueflow/branch_field_read.ql",
 		"testdata/queries/v2/valueflow/branch_object_field.ql",
+		// PR3 amendment — JSX-wrapper-tolerant 7th branch. Must be
+		// included in the union-vs-sum invariant or the wrapper rows
+		// (which appear in `mayResolveTo` but not in the original 6
+		// branches) trip the union > sum bound check.
+		"testdata/queries/v2/valueflow/branch_jsx_wrapped.ql",
 	}
 
 	branchPairs := make(map[string]bool)
@@ -431,6 +442,37 @@ func TestValueflow_ResolvesToFunctionDirect(t *testing.T) {
 		}
 	}
 	t.Logf("resolvesToFunctionDirect: %d row(s) on valueflow-fnref", len(rs.Rows))
+}
+
+// TestValueflow_JsxWrappedBranch asserts the JSX-wrapper-tolerant branch
+// fires on the canonical `<Provider value={X} />` shape and resolves to
+// the inner identifier's VarDecl init via mayResolveToCore.
+//
+// This is the regression guard for the subsumption gap surfaced when PR3
+// first attempted to substitute mayResolveToVarInit for
+// resolveToObjectExprVarD1: that earlier shape silently dropped every
+// wrapped case because the JsxAttribute valueExpr column points at the
+// JsxExpression `{X}`, not at `X`. The wrapper branch closes that gap.
+//
+// The fixture jsx_wrapped.tsx has exactly one Provider with `value={theme}`
+// where `theme` is a VarDecl initialised to an object literal. That
+// pattern must produce at least one mayResolveToJsxWrapped row whose
+// sourceExpr is the object literal.
+func TestValueflow_JsxWrappedBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping extraction-heavy integration test in short mode")
+	}
+	rs := runValueflowQuery(t,
+		"testdata/queries/v2/valueflow/branch_jsx_wrapped.ql",
+		"testdata/projects/valueflow-base")
+	if len(rs.Rows) == 0 {
+		t.Fatal("mayResolveToJsxWrapped returned 0 rows on valueflow-base; " +
+			"either the JsxExpression Node row is missing (extractor regression) " +
+			"or jsxExpressionUnwrap's Contains/Kind check is broken. " +
+			"Without this branch the bridge migration silently drops every " +
+			"`<Provider value={X} />` case.")
+	}
+	t.Logf("mayResolveToJsxWrapped: %d row(s) on valueflow-base jsx_wrapped fixture", len(rs.Rows))
 }
 
 // TestValueflow_IntegrationOnReactFixture is the smoke test that


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

Phase A PR3 of the value-flow bridge migration. Builds on PR2 (`28bcda5`) which landed the non-recursive `mayResolveTo` with 6 named branches. Plan source of truth: `docs/design/valueflow-phase-a-plan.md` (added in this PR with a "PR3 amendment" section documenting the scope deviation).

## 1. Why this PR is bigger than plan-§3.1 — the JSX subsumption gap

Plan-§3.1 said "drop in `mayResolveTo` and delete the redundant `resolveToObjectExpr*` siblings." Reality: PR2's `mayResolveTo` is value-expression-rooted (`ExprMayRef(valueExpr, sym)` directly), but the existing `resolveToObjectExpr*` family is JsxExpression-wrapper-tolerant via `Contains(valueAttrExpr, innerExpr)`. The canonical `<Provider value={X} />` shape — where `JsxAttribute.valueExpr` points at the `JsxExpression {X}` wrapper, not at `X` — would silently regress.

Resolved by adding a wrapper-tolerant branch to `mayResolveTo`. **Shape chosen: option 2** (lift the existing 6-branch union into `mayResolveToCore`, add `mayResolveToJsxWrapped` that unwraps via `Contains` and recurses into `mayResolveToCore`, top-level `mayResolveTo` becomes a 2-disjunct or-of-calls). Non-recursive, preserves `or`-of-calls discipline (#166 safe).

New fixture `testdata/projects/valueflow-base/jsx_wrapped.tsx` exercises the path; new branch isolation query `branch_jsx_wrapped.ql`; `TestValueflow_JsxWrappedBranch` regression + the existing union/sum invariant updated to 7 branches.

## 2. Parity gate evidence — empty diff

Baseline captured from `origin/main` before migration; re-run after.

| Query | Baseline | Post-migration |
|---|---|---|
| R3 through-context (Indirect/Spread/Computed) | 3 (1/1/1) | 3 (1/1/1) |
| R4 through-context (Consumer/DirectReturn) | 2 (1/1) | 2 (1/1) |
| `contextProviderField` | 6 | 6 |
| `useStateSetterAliasV2` | 13 | 13 |
| `useStateSetterContextAliasCall` | 6 | 6 |

`resolveToObjectExpr` itself moved 11 → 16 (precision gain via the new wrapper branch); downstream consumers filter via `isObjectLiteralExpr` and the union-shape constraints, so no row-level change reaches the queries that matter. Empty diff confirmed.

## 3. LoC + predicate count — honest

- Plan §3.1 targeted 5 predicates for deletion.
- **Migrated (2):** `resolveToObjectExprDirect`, `resolveToObjectExprVarD1` — both replaced by a single `mayResolveToObjectExpr` helper call inside the `resolveToObjectExpr` union.
- **Deferred (3):** `objectLiteralFieldOwn`, `contextProviderFieldR3DirectOwn`, `contextProviderFieldR3VarIndirectOwn` — each is currently a named-predicate disjunct inside an `or`-of-calls union (`objectLiteralFieldThroughSpread`, `contextProviderFieldR3*Spread`). Inlining `mayResolveTo` directly into those unions would replace a named call with a literal call expression, breaking the #166 `or`-of-calls discipline. Wants a separate small refactor to introduce intermediate named helpers — out of scope for PR3.

Net bridge change: `tsq_react.qll` -26/+~12 LoC (2 predicates deleted, 1 helper added, 1 union rewritten). `tsq_valueflow.qll` +~30 LoC for the wrapper extension.

## 4. Deferred to Phase C

- The 3 predicates above (see §3) — pending an `or`-of-calls-safe wrapper helper pattern.
- Multi-Provider disambiguation, hook indirection depth >2, namespace-import `createContext` — unchanged from PR2's known limitations.

## Gotcha (worth flagging)

Bridge `.qll` files don't carry their own `import` statements — the resolver pulls only what the **query** imports. `tsq_react.qll`'s new `mayResolveToObjectExpr` calls into `tsq::valueflow`, which silently resolved to nothing in the through-context query (and link-probe test) until `import tsq::valueflow` was added at the query/test sites. Caught it because R3 dropped from 3 to 1. Worth a planner-side warning at some point.