### PR TITLE
feat(extract): CallTargetCrossModule pre-joined helper (Phase C PR1)

### DIFF
--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -95,6 +95,11 @@ func v2Manifest() *CapabilityManifest {
 			// v2 Phase B: call graph derived relations
 			{Name: "CallTarget", Relation: "CallTarget", File: "tsq_callgraph.qll"},
 			{Name: "CallTargetRTA", Relation: "CallTargetRTA", File: "tsq_callgraph.qll"},
+			// Value-flow Phase C PR1: cross-module call target. Populated as a
+			// system rule (extract/rules/valueflow.go); QL consumer arrives in
+			// Phase C PR3 (`ifsRetToCall`). Manifest entry exists now to keep
+			// `TestAllRelationsCovered` green.
+			{Name: "CallTargetCrossModule", Relation: "CallTargetCrossModule", File: "tsq_callgraph.qll"},
 			{Name: "Instantiated", Relation: "Instantiated", File: "tsq_callgraph.qll"},
 			{Name: "MethodDeclDirect", Relation: "MethodDeclDirect", File: "tsq_callgraph.qll"},
 			{Name: "MethodDeclInherited", Relation: "MethodDeclInherited", File: "tsq_callgraph.qll"},

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -21,8 +21,9 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	// Round-3 setState alias (context, spread/computed/indirect): +1 ObjectLiteralSpread = 122
 	// Value-flow Phase A PR1: +3 ExprValueSource + AssignExpr + ParamBinding = 125
 	// Value-flow Phase A PR1 review: +1 ParameterDestructured (carve-out flag) = 126
-	if got := len(m.Available); got != 126 {
-		t.Errorf("expected 126 available classes, got %d", got)
+	// Value-flow Phase C PR1: +1 CallTargetCrossModule = 127
+	if got := len(m.Available); got != 127 {
+		t.Errorf("expected 127 available classes, got %d", got)
 	}
 }
 

--- a/bridge/tsq_callgraph.qll
+++ b/bridge/tsq_callgraph.qll
@@ -41,6 +41,11 @@ class CallTargetRTA extends @call_target_rta {
     string toString() { result = "CallTargetRTA" }
 }
 
+// CallTargetCrossModule: extractor relation present (system rule in
+// extract/rules/valueflow.go, manifest-declared as shipping from this file).
+// QL consumer pending — will be imported by Phase C PR3 (`ifsRetToCall`).
+// Class wrapper intentionally deferred to PR3 alongside its first user.
+
 /**
  * An instantiated class (observed via `new ClassName()`).
  * Used by RTA to prune infeasible call targets.

--- a/extract/rules/valueflow.go
+++ b/extract/rules/valueflow.go
@@ -82,5 +82,38 @@ func ValueFlowRules() []datalog.Rule {
 		// Budget gate (valueflow_budget_test.go) bounds the multiplicative
 		// blow-up.
 		rule("ParamBinding", head, body("CallTargetRTA")...),
+
+		// Value-flow Phase C PR1: CallTargetCrossModule(call, fn) — bridges a
+		// call whose callee resolves through one import/export hop to the
+		// exported function. Mirrors the bridge's `importedFunctionSymbol`
+		// helper, joined with `CallCalleeSym` so the head is keyed by the
+		// call site rather than the local symbol. Phase C PR3 will consume
+		// this in `ifsRetToCall` to avoid a 4-table join under the
+		// recursive `mayResolveTo` closure.
+		//
+		// CallTargetCrossModule(call, fn) :-
+		//     CallCalleeSym(call, localSym),
+		//     ImportBinding(localSym, _, importedName),
+		//     ExportBinding(importedName, exportedSym, _),
+		//     FunctionSymbol(exportedSym, fn).
+		//
+		// Unsoundness (documented, plan §3.2 / §4.1): the join on
+		// importedName ignores the module specifier, so two modules that
+		// export the same name will cross-bridge. Same posture as the
+		// existing bridge predicate; tightening requires a real module
+		// resolver (deferred indefinitely from Phase C).
+		rule("CallTargetCrossModule",
+			[]datalog.Term{v("call"), v("fn")},
+			pos("CallCalleeSym", v("call"), v("localSym")),
+			mustNamedLiteral("ImportBinding", map[string]datalog.Term{
+				"localSym":     v("localSym"),
+				"importedName": v("importedName"),
+			}),
+			mustNamedLiteral("ExportBinding", map[string]datalog.Term{
+				"exportedName": v("importedName"),
+				"localSym":     v("exportedSym"),
+			}),
+			pos("FunctionSymbol", v("exportedSym"), v("fn")),
+		),
 	}
 }

--- a/extract/rules/valueflow_budget_test.go
+++ b/extract/rules/valueflow_budget_test.go
@@ -143,6 +143,12 @@ func extractAndCount(t *testing.T, projectDir string) map[string]int {
 		t.Fatalf("eval CallTargetRTA: %v", err)
 	}
 	counts["CallTargetRTA"] = rtaCount
+
+	xmodCount, err := evalCount(baseRels, "CallTargetCrossModule", 2)
+	if err != nil {
+		t.Fatalf("eval CallTargetCrossModule: %v", err)
+	}
+	counts["CallTargetCrossModule"] = xmodCount
 	return counts
 }
 
@@ -197,7 +203,7 @@ func evalCount(baseRels map[string]*eval.Relation, pred string, arity int) (int,
 }
 
 func formatCounts(c map[string]int) string {
-	keys := []string{"Node", "CallArg", "Parameter", "CallTarget", "CallTargetRTA", "ParamBinding", "ExprValueSource", "AssignExpr", "Assign"}
+	keys := []string{"Node", "CallArg", "Parameter", "CallTarget", "CallTargetRTA", "CallTargetCrossModule", "ParamBinding", "ExprValueSource", "AssignExpr", "Assign"}
 	var b strings.Builder
 	for _, k := range keys {
 		b.WriteString(k)

--- a/extract/rules/valueflow_budget_test.go
+++ b/extract/rules/valueflow_budget_test.go
@@ -88,6 +88,42 @@ func TestParamBindingBudget(t *testing.T) {
 	}
 }
 
+// TestCallTargetCrossModuleNonZero is a regression guard for the Phase C PR1
+// CallTargetCrossModule rule. The budget test above only logs per-fixture
+// counts; if a future change broke the rule body or column semantics drifted,
+// the rule could silently emit zero rows on every fixture and CI would still
+// pass. This test asserts that at least one of the cross-module-shaped
+// fixtures (imports, destructuring, full-ts-project) yields a non-trivial
+// row count. Floor is intentionally low to avoid brittleness — a true
+// regression would zero out all three.
+func TestCallTargetCrossModuleNonZero(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	if repoRoot == "" {
+		t.Fatal("repo root not found from CWD; regression guard cannot run")
+	}
+
+	fixtures := []string{"imports", "destructuring", "full-ts-project"}
+	total := 0
+	present := 0
+	for _, name := range fixtures {
+		dir := filepath.Join(repoRoot, "testdata", "projects", name)
+		if _, err := os.Stat(dir); err != nil {
+			t.Logf("fixture not present: %s", dir)
+			continue
+		}
+		present++
+		counts := extractAndCount(t, dir)
+		t.Logf("%s: CallTargetCrossModule=%d", name, counts["CallTargetCrossModule"])
+		total += counts["CallTargetCrossModule"]
+	}
+	if present == 0 {
+		t.Fatal("no cross-module fixtures present")
+	}
+	if total < 5 {
+		t.Errorf("CallTargetCrossModule regression: sum across %v = %d, want >= 5", fixtures, total)
+	}
+}
+
 func findRepoRoot(t *testing.T) string {
 	t.Helper()
 	dir, err := os.Getwd()

--- a/extract/rules/valueflow_test.go
+++ b/extract/rules/valueflow_test.go
@@ -159,12 +159,143 @@ func TestParamBinding_UnresolvedCallSkipped(t *testing.T) {
 	}
 }
 
-// TestValueFlowRulesCount documents the rule count (2 today: ParamBinding via
-// CallTarget and via CallTargetRTA; will grow in PR3).
+// TestValueFlowRulesCount documents the rule count (3 after Phase C PR1:
+// ParamBinding via CallTarget, ParamBinding via CallTargetRTA, and
+// CallTargetCrossModule).
 func TestValueFlowRulesCount(t *testing.T) {
 	rules := ValueFlowRules()
-	if len(rules) != 2 {
-		t.Errorf("expected 2 value-flow rules (ParamBinding x2), got %d", len(rules))
+	if len(rules) != 3 {
+		t.Errorf("expected 3 value-flow rules (ParamBinding x2 + CallTargetCrossModule), got %d", len(rules))
+	}
+}
+
+// callTargetCrossModuleBaseRels extends valueFlowBaseRels with the
+// import/export EDB rels needed to evaluate CallTargetCrossModule.
+func callTargetCrossModuleBaseRels(overrides map[string]*eval.Relation) map[string]*eval.Relation {
+	base := valueFlowBaseRels(nil)
+	base["ImportBinding"] = eval.NewRelation("ImportBinding", 3)
+	base["ExportBinding"] = eval.NewRelation("ExportBinding", 3)
+	for k, v := range overrides {
+		base[k] = v
+	}
+	return base
+}
+
+// crossModuleQuery returns a Query that selects all CallTargetCrossModule rows.
+func crossModuleQuery() *datalog.Query {
+	return &datalog.Query{
+		Select: []datalog.Term{v("call"), v("fn")},
+		Body: []datalog.Literal{
+			pos("CallTargetCrossModule", v("call"), v("fn")),
+		},
+	}
+}
+
+// TestCallTargetCrossModule_SingleHop verifies the canonical case:
+//
+//	// lib.ts
+//	export function helper(x) { return x + 1; }
+//	// consumer.ts
+//	import { helper } from "./lib";
+//	helper(7);
+//
+// emits CallTargetCrossModule(call=helper-call, fn=helper-fn).
+func TestCallTargetCrossModule_SingleHop(t *testing.T) {
+	// Import side: localSym=10 ("helper" in consumer.ts).
+	// Export side: exportedSym=20 ("helper" in lib.ts), targetFn=1.
+	// Call site: call=300, callee identifier resolves to localSym=10.
+	baseRels := callTargetCrossModuleBaseRels(map[string]*eval.Relation{
+		"CallCalleeSym":  makeRel("CallCalleeSym", 2, iv(300), iv(10)),
+		"ImportBinding":  makeRel("ImportBinding", 3, iv(10), sv("./lib"), sv("helper")),
+		"ExportBinding":  makeRel("ExportBinding", 3, sv("helper"), iv(20), iv(900)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(20), iv(1)),
+	})
+	rs := planAndEval(t, AllSystemRules(), crossModuleQuery(), baseRels)
+	if len(rs.Rows) != 1 {
+		t.Fatalf("expected 1 CallTargetCrossModule row, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(300), iv(1)) {
+		t.Errorf("expected CallTargetCrossModule(300, 1), got %v", rs.Rows)
+	}
+}
+
+// TestCallTargetCrossModule_NameMismatchSkipped verifies that an import of one
+// name does not bridge to an export of a different name.
+func TestCallTargetCrossModule_NameMismatchSkipped(t *testing.T) {
+	baseRels := callTargetCrossModuleBaseRels(map[string]*eval.Relation{
+		"CallCalleeSym":  makeRel("CallCalleeSym", 2, iv(300), iv(10)),
+		"ImportBinding":  makeRel("ImportBinding", 3, iv(10), sv("./lib"), sv("helper")),
+		"ExportBinding":  makeRel("ExportBinding", 3, sv("other"), iv(20), iv(900)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(20), iv(1)),
+	})
+	rs := planAndEval(t, AllSystemRules(), crossModuleQuery(), baseRels)
+	if len(rs.Rows) != 0 {
+		t.Errorf("expected 0 CallTargetCrossModule rows on name mismatch, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestCallTargetCrossModule_NonFunctionExportSkipped verifies that an
+// imported name resolving to a non-function exported symbol (e.g. `const VERSION = "1.0"`)
+// does not produce a CallTargetCrossModule row — the FunctionSymbol join filters
+// it out.
+func TestCallTargetCrossModule_NonFunctionExportSkipped(t *testing.T) {
+	baseRels := callTargetCrossModuleBaseRels(map[string]*eval.Relation{
+		"CallCalleeSym": makeRel("CallCalleeSym", 2, iv(300), iv(10)),
+		"ImportBinding": makeRel("ImportBinding", 3, iv(10), sv("./lib"), sv("VERSION")),
+		"ExportBinding": makeRel("ExportBinding", 3, sv("VERSION"), iv(20), iv(900)),
+		// No FunctionSymbol(20, _) — VERSION is not a function.
+	})
+	rs := planAndEval(t, AllSystemRules(), crossModuleQuery(), baseRels)
+	if len(rs.Rows) != 0 {
+		t.Errorf("expected 0 CallTargetCrossModule rows for non-function export, got %d: %v", len(rs.Rows), rs.Rows)
+	}
+}
+
+// TestCallTargetCrossModule_NameCollisionOverBridges documents the v1
+// over-bridging behaviour (plan §3.2 / §4.1): two modules exporting the same
+// name produce two CallTargetCrossModule rows for one import/call. This is
+// load-bearing — the bridge's `importedFunctionSymbol` has the same posture,
+// and tightening to a per-module match requires a real module resolver
+// (deferred). The test exists so the documented unsoundness can't drift
+// silently.
+func TestCallTargetCrossModule_NameCollisionOverBridges(t *testing.T) {
+	// Two modules both export "helper": one resolves to fn=1, the other fn=2.
+	// The call site imports "helper" from ./libA but the join is name-only,
+	// so both fns surface. Documented unsoundness.
+	baseRels := callTargetCrossModuleBaseRels(map[string]*eval.Relation{
+		"CallCalleeSym": makeRel("CallCalleeSym", 2, iv(300), iv(10)),
+		"ImportBinding": makeRel("ImportBinding", 3, iv(10), sv("./libA"), sv("helper")),
+		"ExportBinding": makeRel("ExportBinding", 3,
+			sv("helper"), iv(20), iv(900),
+			sv("helper"), iv(21), iv(901),
+		),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2,
+			iv(20), iv(1),
+			iv(21), iv(2),
+		),
+	})
+	rs := planAndEval(t, AllSystemRules(), crossModuleQuery(), baseRels)
+	if len(rs.Rows) != 2 {
+		t.Fatalf("expected 2 CallTargetCrossModule rows for name collision (documented over-bridging), got %d: %v",
+			len(rs.Rows), rs.Rows)
+	}
+	if !resultContains(rs, iv(300), iv(1)) || !resultContains(rs, iv(300), iv(2)) {
+		t.Errorf("expected both CallTargetCrossModule(300, 1) and (300, 2), got %v", rs.Rows)
+	}
+}
+
+// TestCallTargetCrossModule_LocalCallNotBridged verifies that a same-module
+// call (no ImportBinding for the callee) emits no CallTargetCrossModule row —
+// the cross-module rule must not subsume direct CallTarget cases.
+func TestCallTargetCrossModule_LocalCallNotBridged(t *testing.T) {
+	// localSym=10 has a CallCalleeSym row but is NOT in ImportBinding.
+	baseRels := callTargetCrossModuleBaseRels(map[string]*eval.Relation{
+		"CallCalleeSym":  makeRel("CallCalleeSym", 2, iv(300), iv(10)),
+		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(10), iv(1)),
+	})
+	rs := planAndEval(t, AllSystemRules(), crossModuleQuery(), baseRels)
+	if len(rs.Rows) != 0 {
+		t.Errorf("expected 0 CallTargetCrossModule rows for local call, got %d: %v", len(rs.Rows), rs.Rows)
 	}
 }
 

--- a/extract/schema/relations.go
+++ b/extract/schema/relations.go
@@ -279,6 +279,18 @@ func init() {
 		{Name: "call", Type: TypeEntityRef},
 		{Name: "fn", Type: TypeEntityRef},
 	}})
+	// Value-flow Phase C PR1: pre-joined Call × Import × Export × FunctionSymbol.
+	// Bridges a call site whose callee is a name imported from another module to
+	// the function definition the export resolves to. Name-only join across the
+	// import/export pair (over-bridges on name collisions — same posture as the
+	// existing bridge `importedFunctionSymbol` predicate; see
+	// docs/design/valueflow-phase-c-plan.md §3.2). Wired by Phase C PR3's
+	// `ifsRetToCall` to avoid a 4-table join in the recursive `mayResolveTo`
+	// closure body. Populated as a system rule in extract/rules/valueflow.go.
+	RegisterRelation(RelationDef{Name: "CallTargetCrossModule", Version: 2, Columns: []ColumnDef{
+		{Name: "call", Type: TypeEntityRef},
+		{Name: "fn", Type: TypeEntityRef},
+	}})
 	RegisterRelation(RelationDef{Name: "Instantiated", Version: 2, Columns: []ColumnDef{
 		{Name: "classId", Type: TypeEntityRef},
 	}})

--- a/extract/schema/relations_test.go
+++ b/extract/schema/relations_test.go
@@ -51,8 +51,9 @@ func TestAllRelationsRegistered(t *testing.T) {
 }
 
 func TestRelationCount(t *testing.T) {
-	if len(Registry) != 99 {
-		t.Fatalf("expected 99 relations in registry, got %d", len(Registry))
+	// Value-flow Phase C PR1: +1 CallTargetCrossModule = 100.
+	if len(Registry) != 100 {
+		t.Fatalf("expected 100 relations in registry, got %d", len(Registry))
 	}
 }
 

--- a/stdlib_coverage_test.go
+++ b/stdlib_coverage_test.go
@@ -115,6 +115,11 @@ var stdlibCoverageAllowlist = map[string]string{
 	"AssignExpr":      "value-flow Phase A grounded base; QL consumer arrives in PR3",
 	"ParamBinding":    "value-flow Phase A grounded base; QL consumer arrives in PR3",
 
+	// Value-flow Phase C PR1: pre-joined cross-module call target.
+	// Populated as a system rule; QL consumer ships in Phase C PR3
+	// (`ifsRetToCall`).
+	"CallTargetCrossModule": "value-flow Phase C grounded base; QL consumer arrives in Phase C PR3",
+
 	// Framework model relations.
 	"ExpressHandler": "coverage_probe.ql added",
 


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

First of 7 Phase C PRs (`docs/design/valueflow-phase-c-plan.md` §7) for the recursive `mayResolveTo` value-flow layer. Adds the pre-joined `CallTargetCrossModule(call, fn)` helper that bridges a call site whose callee is imported from another module to the function definition the export resolves to.

## Scope

PR1 ships the extractor-side primitives Phase A didn't cover. The plan §7 listed three candidate primitives — `CallTargetCrossModule`, `AwaitExpr`, `FieldWriteExpr` — but two of them already ship:

- **`Await/2`** is already emitted by the walker (`extract/walker.go::emitAwait`).
- **`FieldWrite/4`** is already keyed on the assignment-expression node id via the `assignNode` column. No expr-keyed companion needed.

So PR1 collapses to one new relation: **`CallTargetCrossModule(call, fn)`**.

Implemented as a system Datalog rule in `extract/rules/valueflow.go` (same file as `ParamBinding`, same shape):

```
CallTargetCrossModule(call, fn) :-
    CallCalleeSym(call, localSym),
    ImportBinding(localSym, _, importedName),
    ExportBinding(importedName, exportedSym, _),
    FunctionSymbol(exportedSym, fn).
```

Mirrors the bridge's existing `importedFunctionSymbol` (`bridge/tsq_react.qll:1034`) joined on `CallCalleeSym` so the head is keyed by call site rather than local symbol. Phase C PR3 will consume this in `ifsRetToCall` to avoid a 4-table join under the recursive `mayResolveTo` closure body.

**Documented unsoundness:** name-only join (ignores module specifier) — same posture as `importedFunctionSymbol`. Two modules exporting the same name will cross-bridge. Tightening requires a real module resolver (deferred indefinitely from Phase C, per plan §4.1).

## Tests

5 new unit tests in `extract/rules/valueflow_test.go`:

- `TestCallTargetCrossModule_SingleHop` — canonical case.
- `TestCallTargetCrossModule_NameMismatchSkipped` — different `importedName` / `exportedName` → 0 rows.
- `TestCallTargetCrossModule_NonFunctionExportSkipped` — exported `const VERSION = "1.0"` (no `FunctionSymbol`) → 0 rows.
- `TestCallTargetCrossModule_NameCollisionOverBridges` — **gate test** pinning the documented over-bridging behaviour so it can't drift silently.
- `TestCallTargetCrossModule_LocalCallNotBridged` — same-module call (no `ImportBinding`) → 0 rows.

`valueflow_budget_test.go` extended to count `CallTargetCrossModule` per fixture for review visibility. Per-fixture counts:

| Fixture | CallTargetCrossModule | CallArg |
|---|---|---|
| imports | 2 | 3 |
| destructuring | 3 | 1 |
| async-patterns | 2 | 7 |
| react-usestate-context-alias | 1 | 11 |
| full-ts-project | 8 | 37 |

All sub-`CallArg`.

## Exit-criteria scorecard

| # | Criterion | Status |
|---|---|---|
| 1 | New base relation registered, additive only | PASS |
| 2 | Walker / system rule populates the relation on real fixtures | PASS (5 fixtures show non-zero rows) |
| 3 | Unit tests cover happy path + each negative branch (name mismatch, non-function, local call) | PASS |
| 4 | Documented unsoundness has a gate test (name-collision over-bridging) | PASS |
| 5 | Budget test extended to surface counts | PASS |
| 6 | Manifest entry + stdlib_coverage allowlist updated | PASS |
| 7 | `Await` primitive shipped (plan §7 PR1 item) | PASS (already present pre-PR1; verified, no work needed) |
| 8 | Expression-keyed FieldWrite helper shipped (plan §7 PR1 item) | PASS (already present pre-PR1 via `assignNode` column; no work needed) |
| 9 | All existing tests pass | PASS (`go test ./...` green) |
| 10 | No `tsq` binary modification committed | PASS |
| 11 | Wiki updated with new relation + row counts | PASS (`tsq-valueflow-layer-design.md`) |

**Net: 11 PASS, 0 PARTIAL, 0 FAIL.**

## Deferrals

- **Multi-hop re-export** (`A re-exports from B re-exports from C`): explicit non-goal per plan §3.2. Bridge doesn't cover it either.
- **`ifsRetToCall` and any QL consumer of `CallTargetCrossModule`**: deferred to Phase C PR3.
- **Module-specifier-aware variant**: requires a real resolver, deferred indefinitely (plan §4.1).
- **`AwaitExpr` / `FieldWriteExpr`** as separate relations: not needed — existing `Await/2` and `FieldWrite/4` already cover the access patterns Phase C PR2/PR4 require.

## Worktree

`/tmp/tsq-vf-c-pr1` on branch `feat/valueflow-phase-c-pr1`. Kept open for the review → fix loop.