### PR TITLE
fix(valueflow): add lfsJsxPropBind for JSX prop → destructured param flow (#202 Gap A)

### DIFF
--- a/bridge/manifest.go
+++ b/bridge/manifest.go
@@ -50,6 +50,13 @@ func v2Manifest() *CapabilityManifest {
 			{Name: "ParameterRest", Relation: "ParameterRest", File: "tsq_functions.qll"},
 			{Name: "ParameterOptional", Relation: "ParameterOptional", File: "tsq_functions.qll"},
 			{Name: "ParameterDestructured", Relation: "ParameterDestructured", File: "tsq_functions.qll"},
+			// Value-flow Phase C PR8 (#202 Gap A): destructured-param slot →
+			// pattern-node bridge. Populated by the walker alongside
+			// `ParameterDestructured`; consumer is `lfsJsxPropBind` in
+			// extract/rules/localflowstep.go. Points at tsq_functions.qll as
+			// the planned QL consumer site (bridge class authored alongside
+			// the Phase D react-final bridge rollout).
+			{Name: "ParamDestructurePattern", Relation: "ParamDestructurePattern", File: "tsq_functions.qll"},
 			{Name: "ParamIsFunctionType", Relation: "ParamIsFunctionType", File: "tsq_functions.qll"},
 			{Name: "Call", Relation: "Call", File: "tsq_calls.qll"},
 			{Name: "CallArg", Relation: "CallArg", File: "tsq_calls.qll"},
@@ -69,6 +76,11 @@ func v2Manifest() *CapabilityManifest {
 			{Name: "ObjectLiteralSpread", Relation: "ObjectLiteralSpread", File: "tsq_expressions.qll"},
 			{Name: "JsxElement", Relation: "JsxElement", File: "tsq_jsx.qll"},
 			{Name: "JsxAttribute", Relation: "JsxAttribute", File: "tsq_jsx.qll"},
+			// Value-flow Phase C PR8 (#202 Gap A): JSX `{…}` wrapper →
+			// inner expression bridge used by `lfsJsxPropBind`. Points at
+			// tsq_jsx.qll as the planned QL consumer site (bridge class
+			// authored alongside the Phase D react-final bridge rollout).
+			{Name: "JsxExpressionInner", Relation: "JsxExpressionInner", File: "tsq_jsx.qll"},
 			{Name: "ImportBinding", Relation: "ImportBinding", File: "tsq_imports.qll"},
 			{Name: "ExportBinding", Relation: "ExportBinding", File: "tsq_imports.qll"},
 			{Name: "ExtractError", Relation: "ExtractError", File: "tsq_errors.qll"},

--- a/bridge/manifest_test.go
+++ b/bridge/manifest_test.go
@@ -26,8 +26,10 @@ func TestV1ManifestAvailableCount(t *testing.T) {
 	// Value-flow Phase C PR3: +2 InterFlowStep + FlowStep = 130
 	// Value-flow Phase C PR4: +1 MayResolveTo = 131
 	// Value-flow Phase C PR7: +1 MayResolveToCapHit = 132
-	if got := len(m.Available); got != 132 {
-		t.Errorf("expected 132 available classes, got %d", got)
+	// Value-flow Phase C PR8 (#202 Gap A): +1 ParamDestructurePattern,
+	// +1 JsxExpressionInner = 134
+	if got := len(m.Available); got != 134 {
+		t.Errorf("expected 134 available classes, got %d", got)
 	}
 }
 

--- a/bridge/tsq_react.qll
+++ b/bridge/tsq_react.qll
@@ -577,10 +577,14 @@ predicate jsxAttrValueObject(int valueAttrExpr, int objExpr) {
  * `contextSymLink*` splits follow to stay away from disjunction-poisoning
  * (#166).
  *
- * Retirement path: promote the unwrap to an `lfsJsxExpressionUnwrap`
- * step rule in `extract/rules/localflowstep.go`; once shipped, the
- * `JsxWrapped` branch collapses into `mayResolveToRec` and the wrapper
- * composition retires. Follow-up tracked in the PR6 wiki section.
+ * Deferred: `lfsJsxPropBind` now handles JSX-prop-specific unwrap via
+ * the `JsxExpressionInner` inline helper EDB (PR #203). A generalised
+ * `lfsJsxExpressionUnwrap` step kind remains open — needed only if a
+ * non-prop JSX unwrap surface emerges (e.g. JsxExpression children of a
+ * JsxElement body, or attribute positions outside the prop-binding
+ * shape `lfsJsxPropBind` covers). Until then the `JsxWrapped` branch
+ * stays — it guards the Provider-value Contains() path, which is not
+ * subsumed by `lfsJsxPropBind`'s destructure-keyed composition.
  */
 predicate mayResolveToObjectExprDirect(int valueExpr, int objExpr) {
     mayResolveToRec(valueExpr, objExpr) and

--- a/extract/rules/localflowstep.go
+++ b/extract/rules/localflowstep.go
@@ -50,13 +50,16 @@ import (
 // (same-module return-to-call edge) — the cross-module variant lives
 // in PR3's `ifsRetToCall` against `CallTargetCrossModule`.
 func LocalFlowStepRules() []datalog.Rule {
-	out := make([]datalog.Rule, 0, 22)
+	// Capacity: N per-kind rules + N union branches. Current N = 12
+	// (11 PR2 kinds + `lfsJsxPropBind` from PR8 / #202 Gap A).
+	out := make([]datalog.Rule, 0, 24)
 	out = append(out, lfsRules()...)
 	out = append(out, localFlowStepUnion()...)
 	return out
 }
 
-// lfsRules returns the eleven per-kind rules. Each emits its named IDB
+// lfsRules returns the twelve per-kind rules (11 PR2 kinds plus
+// `lfsJsxPropBind` from PR8 / #202 Gap A). Each emits its named IDB
 // head and is consumed by localFlowStepUnion.
 func lfsRules() []datalog.Rule {
 	return []datalog.Rule{
@@ -202,6 +205,71 @@ func lfsRules() []datalog.Rule {
 				"innerExpr": v("from"),
 			}),
 		),
+
+		// lfsJsxPropBind(from, to) :-
+		//     JsxAttribute(elem, propName, from),
+		//     JsxElement(elem, _, tagSym),
+		//     FunctionSymbol(tagSym, fn),
+		//     Parameter(fn, _, _, paramNode, _, _),
+		//     ParamDestructurePattern(paramNode, patternNode),
+		//     DestructureField(patternNode, propName, _, bindSym, _),
+		//     ExprMayRef(to, bindSym).
+		//
+		// Value-flow Phase C PR8 (#202 Gap A): bridges a JSX prop's
+		// value-expression at the element site to destructured-parameter uses
+		// inside the component body. Field-sensitive on the prop name —
+		// `DestructureField`'s `sourceField` column matches `JsxAttribute`'s
+		// `name`, so `<Inner value={cfg}/>` only flows `cfg` to the
+		// `value` binding inside `function Inner({value})`, not to siblings.
+		//
+		// Scope:
+		//   - Same-module call target via `FunctionSymbol`. The cross-module
+		//     variant composes via `ifsImportExport` on the tagSym ref in
+		//     `MayResolveToRec` already — PR8 deliberately does not double-
+		//     count it here.
+		//   - Object-destructure only (the common React-FC-props shape).
+		//     Array-destructure of JSX props is syntactically possible but
+		//     non-idiomatic; if it shows up in Mastodon row counts, split
+		//     out a sibling rule keyed on `ArrayDestructure`.
+		//   - Path-erased (PR2 posture): the field match on source name is
+		//     a structural precondition, not a `pathCompose` carrier. PR5's
+		//     access-path layer is where field-sensitivity gets tracked
+		//     through the closure proper.
+		//
+		// Overlap: none with `lfsParamBind`. `lfsParamBind` carves out
+		// destructured slots via `not ParameterDestructured(fn, idx)` on
+		// `ParamBinding` — the precise path this rule fills.
+		rule("lfsJsxPropBind",
+			[]datalog.Term{v("from"), v("to")},
+			mustNamedLiteral("JsxAttribute", map[string]datalog.Term{
+				"element":   v("elem"),
+				"name":      v("propName"),
+				"valueExpr": v("wrapper"),
+			}),
+			// `JsxAttribute.valueExpr` points at the JsxExpression `{…}`
+			// punctuation wrapper (see tsq_react.qll's Provider-value
+			// path). `JsxExpressionInner` bridges the wrapper to the
+			// inner semantic expression so `from` anchors at the actual
+			// value-carrier (e.g. the `cfg` identifier in
+			// `<Inner value={cfg} />`).
+			pos("JsxExpressionInner", v("wrapper"), v("from")),
+			mustNamedLiteral("JsxElement", map[string]datalog.Term{
+				"id":     v("elem"),
+				"tagSym": v("tagSym"),
+			}),
+			pos("FunctionSymbol", v("tagSym"), v("fn")),
+			mustNamedLiteral("Parameter", map[string]datalog.Term{
+				"fn":        v("fn"),
+				"paramNode": v("paramNode"),
+			}),
+			pos("ParamDestructurePattern", v("paramNode"), v("patternNode")),
+			mustNamedLiteral("DestructureField", map[string]datalog.Term{
+				"parent":      v("patternNode"),
+				"sourceField": v("propName"),
+				"bindSym":     v("bindSym"),
+			}),
+			pos("ExprMayRef", v("to"), v("bindSym")),
+		),
 	}
 }
 
@@ -224,6 +292,7 @@ func localFlowStepUnion() []datalog.Rule {
 		"lfsFieldRead",
 		"lfsFieldWrite",
 		"lfsAwait",
+		"lfsJsxPropBind",
 	}
 	out := make([]datalog.Rule, 0, len(kinds))
 	head := []datalog.Term{v("from"), v("to")}

--- a/extract/rules/localflowstep.go
+++ b/extract/rules/localflowstep.go
@@ -236,9 +236,12 @@ func lfsRules() []datalog.Rule {
 		//     access-path layer is where field-sensitivity gets tracked
 		//     through the closure proper.
 		//
-		// Overlap: none with `lfsParamBind`. `lfsParamBind` carves out
-		// destructured slots via `not ParameterDestructured(fn, idx)` on
-		// `ParamBinding` — the precise path this rule fills.
+		// No overlap with lfsParamBind: JSX elements don't participate in
+		// CallArg/CallTarget (they route through JsxElement +
+		// FunctionSymbol), so the entry point is structurally disjoint.
+		// lfsParamBind's destructured-slot carve-out
+		// (`not ParameterDestructured(fn, idx)` on `ParamBinding`) is
+		// belt-and-braces, not load-bearing here.
 		rule("lfsJsxPropBind",
 			[]datalog.Term{v("from"), v("to")},
 			mustNamedLiteral("JsxAttribute", map[string]datalog.Term{

--- a/extract/rules/localflowstep_test.go
+++ b/extract/rules/localflowstep_test.go
@@ -27,6 +27,11 @@ func localFlowStepBaseRels(overrides map[string]*eval.Relation) map[string]*eval
 	base["FieldRead"] = eval.NewRelation("FieldRead", 3)
 	base["FieldWrite"] = eval.NewRelation("FieldWrite", 4)
 	base["Await"] = eval.NewRelation("Await", 2)
+	// PR8 (#202 Gap A): lfsJsxPropBind EDB inputs.
+	base["JsxAttribute"] = eval.NewRelation("JsxAttribute", 3)
+	base["JsxElement"] = eval.NewRelation("JsxElement", 3)
+	base["ParamDestructurePattern"] = eval.NewRelation("ParamDestructurePattern", 2)
+	base["JsxExpressionInner"] = eval.NewRelation("JsxExpressionInner", 2)
 	for k, v := range overrides {
 		base[k] = v
 	}
@@ -200,6 +205,37 @@ func TestLfsAwait(t *testing.T) {
 	rs := evalStep(t, baseRels, "lfsAwait")
 	if len(rs.Rows) != 1 || !resultContains(rs, iv(400), iv(600)) {
 		t.Fatalf("expected lfsAwait(400, 600), got %v", rs.Rows)
+	}
+}
+
+// TestLfsJsxPropBind — `<Inner value={cfg} />` flows `cfg` to in-body
+// references of the `value` destructured binding of Inner. See #202
+// Gap A.
+func TestLfsJsxPropBind(t *testing.T) {
+	// JSX site: elem=700, JsxExpression wrapper=412, inner cfg identifier=413,
+	// tagSym=50, fn=1. Component: Parameter(fn=1, idx=0, paramNode=80,
+	// paramSym=10). Destructure: ParamDestructurePattern(paramNode=80,
+	// patternNode=85), DestructureField(patternNode=85, "value", "value",
+	// bindSym=20, 0). In-body use: ExprMayRef(useExpr=513, bindSym=20).
+	baseRels := localFlowStepBaseRels(map[string]*eval.Relation{
+		"JsxAttribute":            makeRel("JsxAttribute", 3, iv(700), sv("value"), iv(412)),
+		"JsxExpressionInner":      makeRel("JsxExpressionInner", 2, iv(412), iv(413)),
+		"JsxElement":              makeRel("JsxElement", 3, iv(700), iv(701), iv(50)),
+		"FunctionSymbol":          makeRel("FunctionSymbol", 2, iv(50), iv(1)),
+		"Parameter":               makeRel("Parameter", 6, iv(1), iv(0), sv("{ value }"), iv(80), iv(10), sv("")),
+		"ParamDestructurePattern": makeRel("ParamDestructurePattern", 2, iv(80), iv(85)),
+		"DestructureField": makeRel("DestructureField", 5,
+			iv(85), sv("value"), sv("value"), iv(20), iv(0),
+		),
+		"ExprMayRef": makeRel("ExprMayRef", 2, iv(513), iv(20)),
+	})
+	rs := evalStep(t, baseRels, "lfsJsxPropBind")
+	if len(rs.Rows) != 1 || !resultContains(rs, iv(413), iv(513)) {
+		t.Fatalf("expected lfsJsxPropBind(413, 513), got %v", rs.Rows)
+	}
+	rsUnion := evalStep(t, baseRels, "LocalFlowStep")
+	if !resultContains(rsUnion, iv(413), iv(513)) {
+		t.Errorf("LocalFlowStep should contain (413, 513), got %v", rsUnion.Rows)
 	}
 }
 

--- a/extract/rules/localflowstep_test.go
+++ b/extract/rules/localflowstep_test.go
@@ -208,34 +208,71 @@ func TestLfsAwait(t *testing.T) {
 	}
 }
 
-// TestLfsJsxPropBind — `<Inner value={cfg} />` flows `cfg` to in-body
-// references of the `value` destructured binding of Inner. See #202
-// Gap A.
+// TestLfsJsxPropBind — `<Inner value={cfg} onClick={handler} />` flows
+// `cfg` only to in-body references of the `value` destructured binding,
+// and `handler` only to references of the `onClick` binding. Exercises
+// field-sensitivity on the DestructureField.sourceField ↔ JsxAttribute.name
+// join: a single-attribute-single-field fixture would pass even if the
+// field-name join were ignored. See #202 Gap A.
 func TestLfsJsxPropBind(t *testing.T) {
-	// JSX site: elem=700, JsxExpression wrapper=412, inner cfg identifier=413,
-	// tagSym=50, fn=1. Component: Parameter(fn=1, idx=0, paramNode=80,
-	// paramSym=10). Destructure: ParamDestructurePattern(paramNode=80,
-	// patternNode=85), DestructureField(patternNode=85, "value", "value",
-	// bindSym=20, 0). In-body use: ExprMayRef(useExpr=513, bindSym=20).
+	// JSX site: elem=700, tagSym=50, fn=1.
+	// value attr: wrapper=412, inner cfg=413.
+	// onClick attr: wrapper=422, inner handler=423.
+	// Component: Parameter(fn=1, idx=0, paramNode=80, paramSym=10).
+	// Destructure: ParamDestructurePattern(80, 85).
+	// Fields: value→bindSym=20, onClick→bindSym=30.
+	// In-body uses: ExprMayRef(513, 20) [value use], ExprMayRef(523, 30) [onClick use].
 	baseRels := localFlowStepBaseRels(map[string]*eval.Relation{
-		"JsxAttribute":            makeRel("JsxAttribute", 3, iv(700), sv("value"), iv(412)),
-		"JsxExpressionInner":      makeRel("JsxExpressionInner", 2, iv(412), iv(413)),
+		"JsxAttribute": makeRel("JsxAttribute", 3,
+			iv(700), sv("value"), iv(412),
+			iv(700), sv("onClick"), iv(422),
+		),
+		"JsxExpressionInner": makeRel("JsxExpressionInner", 2,
+			iv(412), iv(413),
+			iv(422), iv(423),
+		),
 		"JsxElement":              makeRel("JsxElement", 3, iv(700), iv(701), iv(50)),
 		"FunctionSymbol":          makeRel("FunctionSymbol", 2, iv(50), iv(1)),
-		"Parameter":               makeRel("Parameter", 6, iv(1), iv(0), sv("{ value }"), iv(80), iv(10), sv("")),
+		"Parameter":               makeRel("Parameter", 6, iv(1), iv(0), sv("{ value, onClick }"), iv(80), iv(10), sv("")),
 		"ParamDestructurePattern": makeRel("ParamDestructurePattern", 2, iv(80), iv(85)),
 		"DestructureField": makeRel("DestructureField", 5,
 			iv(85), sv("value"), sv("value"), iv(20), iv(0),
+			iv(85), sv("onClick"), sv("onClick"), iv(30), iv(1),
 		),
-		"ExprMayRef": makeRel("ExprMayRef", 2, iv(513), iv(20)),
+		"ExprMayRef": makeRel("ExprMayRef", 2,
+			iv(513), iv(20),
+			iv(523), iv(30),
+		),
 	})
 	rs := evalStep(t, baseRels, "lfsJsxPropBind")
-	if len(rs.Rows) != 1 || !resultContains(rs, iv(413), iv(513)) {
-		t.Fatalf("expected lfsJsxPropBind(413, 513), got %v", rs.Rows)
+	// Pin exact expected row set — two field-sensitive edges and nothing else.
+	// Critically: NO (413 → 523) and NO (423 → 513) — those would indicate
+	// the field-name join was dropped.
+	want := [][2]eval.IntVal{
+		{iv(413), iv(513)}, // cfg → value-use
+		{iv(423), iv(523)}, // handler → onClick-use
+	}
+	if len(rs.Rows) != len(want) {
+		t.Fatalf("expected %d lfsJsxPropBind rows, got %d: %v", len(want), len(rs.Rows), rs.Rows)
+	}
+	for _, w := range want {
+		if !resultContains(rs, w[0], w[1]) {
+			t.Errorf("expected lfsJsxPropBind(%v, %v) in rows, got %v", w[0], w[1], rs.Rows)
+		}
+	}
+	// Negative: field-name join must reject cross-field wiring.
+	if resultContains(rs, iv(413), iv(523)) {
+		t.Errorf("field-sensitivity violated: cfg (413) leaked to onClick-use (523); rows=%v", rs.Rows)
+	}
+	if resultContains(rs, iv(423), iv(513)) {
+		t.Errorf("field-sensitivity violated: handler (423) leaked to value-use (513); rows=%v", rs.Rows)
 	}
 	rsUnion := evalStep(t, baseRels, "LocalFlowStep")
 	if !resultContains(rsUnion, iv(413), iv(513)) {
 		t.Errorf("LocalFlowStep should contain (413, 513), got %v", rsUnion.Rows)
+	}
+	if !resultContains(rsUnion, iv(423), iv(523)) {
+		t.Errorf("LocalFlowStep should contain (423, 523), got %v", rsUnion.Rows)
 	}
 }
 

--- a/extract/rules/valueflow_budget_test.go
+++ b/extract/rules/valueflow_budget_test.go
@@ -125,6 +125,12 @@ func TestLocalFlowStepKindsNonZero(t *testing.T) {
 		"valueflow-multihop",
 		"valueflow-negative",
 		"valueflow-fnref",
+		// PR8 (#202 Gap A): JSX prop → destructured-param closure
+		// fixture. The only corpus fixture that currently exercises
+		// the `lfsJsxPropBind` shape; if it goes missing, the
+		// per-kind floor below would read 0 and the regression guard
+		// would fire.
+		"valueflow-closure-direct-prop",
 	}
 
 	// Per-kind floors. Each value is ~50% of observed total — catches
@@ -146,6 +152,13 @@ func TestLocalFlowStepKindsNonZero(t *testing.T) {
 		"lfsFieldRead":          50,
 		"lfsFieldWrite":         4,
 		"lfsAwait":              3,
+		// PR8 (#202 Gap A): closed by `valueflow-closure-direct-prop`
+		// (the only corpus fixture that currently exercises the JSX
+		// prop → destructured-param shape). Floor = 1 row keeps the
+		// regression guard active without over-fitting to a single
+		// fixture's expected row count — if more fixtures land that
+		// exercise the shape, bump this honestly.
+		"lfsJsxPropBind": 1,
 	}
 
 	totals := map[string]int{}

--- a/extract/schema/relations.go
+++ b/extract/schema/relations.go
@@ -68,9 +68,35 @@ func init() {
 		{Name: "fn", Type: TypeEntityRef},
 		{Name: "idx", Type: TypeInt32},
 	}})
+	// ParamDestructurePattern(paramNode, patternNode) — links a destructured
+	// parameter slot to the ObjectPattern/ArrayPattern that does the binding.
+	// `paramNode` is the Parameter row's paramNode id (which may be a
+	// RequiredParameter/OptionalParameter/AssignmentPattern wrapper or, for an
+	// unwrapped arrow `({value}) =>`, the pattern itself); `patternNode` is the
+	// ObjectPattern/ArrayPattern id that owns the DestructureField rows.
+	// Emitted by the walker alongside the ParameterDestructured flag; Phase C
+	// PR8 (#202 Gap A) consumes it from `lfsJsxPropBind` to bridge a JSX
+	// prop's value-expression to the destructured-param use site inside the
+	// component body.
+	RegisterRelation(RelationDef{Name: "ParamDestructurePattern", Version: 1, Columns: []ColumnDef{
+		{Name: "paramNode", Type: TypeEntityRef},
+		{Name: "patternNode", Type: TypeEntityRef},
+	}})
 	RegisterRelation(RelationDef{Name: "ParamIsFunctionType", Version: 1, Columns: []ColumnDef{
 		{Name: "fn", Type: TypeEntityRef},
 		{Name: "idx", Type: TypeInt32},
+	}})
+	// JsxExpressionInner(wrapperNode, innerNode) — bridges a `{…}` JSX
+	// expression punctuation wrapper to its inner semantic expression.
+	// Phase C PR8 (#202 Gap A) uses this from `lfsJsxPropBind` so the
+	// value-flow layer can compose across the wrapper without forcing the
+	// whole bridge stack to relearn it — `JsxAttribute.valueExpr`
+	// continues to point at the JsxExpression wrapper so existing
+	// consumers (notably `tsq_react.qll`'s Provider-value path, which
+	// relies on `Contains` descent) stay untouched.
+	RegisterRelation(RelationDef{Name: "JsxExpressionInner", Version: 1, Columns: []ColumnDef{
+		{Name: "wrapperNode", Type: TypeEntityRef},
+		{Name: "innerNode", Type: TypeEntityRef},
 	}})
 	// Calls
 	RegisterRelation(RelationDef{Name: "Call", Version: 1, Columns: []ColumnDef{

--- a/extract/schema/relations_test.go
+++ b/extract/schema/relations_test.go
@@ -56,8 +56,10 @@ func TestRelationCount(t *testing.T) {
 	// Value-flow Phase C PR3: +2 InterFlowStep + FlowStep = 103.
 	// Value-flow Phase C PR4: +1 MayResolveTo = 104.
 	// Value-flow Phase C PR7: +1 MayResolveToCapHit = 105.
-	if len(Registry) != 105 {
-		t.Fatalf("expected 105 relations in registry, got %d", len(Registry))
+	// Value-flow Phase C PR8 (#202 Gap A): +1 ParamDestructurePattern,
+	// +1 JsxExpressionInner = 107.
+	if len(Registry) != 107 {
+		t.Fatalf("expected 107 relations in registry, got %d", len(Registry))
 	}
 }
 

--- a/extract/walker.go
+++ b/extract/walker.go
@@ -1159,7 +1159,7 @@ func (fw *FactWalker) emitJsxAttr(node ASTNode, elementID uint32) {
 				continue
 			}
 			valueID = fw.nid(child)
-			valueNode = child
+			valueNode = child // NB: also populates valueNode so JsxExpressionInner below can unwrap
 			break
 		}
 	}

--- a/extract/walker.go
+++ b/extract/walker.go
@@ -371,12 +371,59 @@ func (fw *FactWalker) emitParameters(fnNode ASTNode, fnID uint32) {
 		}
 		if isDestructured {
 			fw.emit("ParameterDestructured", fnID, idx)
+			// Value-flow Phase C PR8 (#202 Gap A): link the Parameter row's
+			// paramNode to the ObjectPattern/ArrayPattern that carries the
+			// DestructureField rows so `lfsJsxPropBind` can compose the
+			// JSX-prop → destructured-param-use edge. Identity case: when the
+			// param node IS the pattern (arrow `({v}) =>` with no
+			// RequiredParameter wrapper), emit (paramID, paramID).
+			patNode := destructurePatternNode(param, pKind)
+			var patID uint32
+			if patNode != nil {
+				patID = fw.nid(patNode)
+			} else {
+				patID = paramID
+			}
+			fw.emit("ParamDestructurePattern", paramID, patID)
 		}
 		if isFnType {
 			fw.emit("ParamIsFunctionType", fnID, idx)
 		}
 		idx++
 	}
+}
+
+// destructurePatternNode returns the ObjectPattern/ArrayPattern node
+// underlying a destructured parameter slot, peeling the
+// RequiredParameter / OptionalParameter / AssignmentPattern wrappers. Returns
+// nil when the param slot IS the pattern (bare arrow `({v}) =>`) — the caller
+// then emits the identity row.
+func destructurePatternNode(param ASTNode, pKind string) ASTNode {
+	switch pKind {
+	case "ObjectPattern", "ArrayPattern":
+		// Bare pattern at the parameter slot (arrow function without a
+		// RequiredParameter wrapper). Caller should emit identity.
+		return nil
+	case "RequiredParameter", "OptionalParameter":
+		patNode := childByField(param, "pattern")
+		if patNode == nil {
+			patNode = childByField(param, "name")
+		}
+		if patNode != nil {
+			pk := patNode.Kind()
+			if pk == "ObjectPattern" || pk == "ArrayPattern" {
+				return patNode
+			}
+		}
+	case "AssignmentPattern":
+		if left := childByField(param, "left"); left != nil {
+			lk := left.Kind()
+			if lk == "ObjectPattern" || lk == "ArrayPattern" {
+				return left
+			}
+		}
+	}
+	return nil
 }
 
 // isDestructuredParamKind reports whether the parameter slot's pattern is
@@ -1112,11 +1159,27 @@ func (fw *FactWalker) emitJsxAttr(node ASTNode, elementID uint32) {
 				continue
 			}
 			valueID = fw.nid(child)
+			valueNode = child
 			break
 		}
 	}
 
 	fw.emit("JsxAttribute", elementID, attrName, valueID)
+
+	// Emit JsxExpressionInner(wrapperNode, innerNode) so the value-flow
+	// layer can bridge across the `{…}` punctuation wrapper without the
+	// whole bridge stack having to relearn the wrapper shape. Consumed
+	// by `lfsJsxPropBind` (see extract/rules/localflowstep.go). See #202
+	// Gap A for why this runs off an explicit helper relation rather than
+	// hoisting the unwrap into `JsxAttribute.valueExpr` directly — the
+	// existing `tsq_react.qll` Provider-value path already relies on
+	// `valueExpr` pointing at the JsxExpression wrapper and uses
+	// `Contains` to descend.
+	if valueNode != nil && valueNode.Kind() == "JsxExpression" {
+		if inner := firstNonPunctChild(valueNode); inner != nil {
+			fw.emit("JsxExpressionInner", fw.nid(valueNode), fw.nid(inner))
+		}
+	}
 }
 
 // ---- Template Literals ----

--- a/stdlib_coverage_test.go
+++ b/stdlib_coverage_test.go
@@ -147,6 +147,12 @@ var stdlibCoverageAllowlist = map[string]string{
 	// extract/schema/relations.go for the scope-down note).
 	"MayResolveToCapHit": "value-flow Phase C PR7 cap-hit diagnostic; populated manually until evaluator wiring lands",
 
+	// Value-flow Phase C PR8 (#202 Gap A): walker-populated helper
+	// relations feeding `lfsJsxPropBind` in the datalog layer. QL
+	// bridge classes scheduled for Phase D react-final rollout.
+	"ParamDestructurePattern": "value-flow Phase C PR8 walker helper for lfsJsxPropBind; QL consumer deferred to Phase D",
+	"JsxExpressionInner":      "value-flow Phase C PR8 walker helper for lfsJsxPropBind; QL consumer deferred to Phase D",
+
 	// Framework model relations.
 	"ExpressHandler": "coverage_probe.ql added",
 

--- a/testdata/projects/valueflow-closure-direct-prop/DirectProp.tsx
+++ b/testdata/projects/valueflow-closure-direct-prop/DirectProp.tsx
@@ -1,22 +1,22 @@
 // Whole-closure integration fixture — Phase C PR7 §7/§8.
 //
-// SHAPE: direct prop pass (R1 analogue). Designed to exercise
-// "lfsVarInit + lfsParamBind composed" — value-source through a
-// JSX prop into a parameter binding.
+// SHAPE: direct prop pass (R1 analogue). Exercises lfsJsxPropBind
+// composing with lfsVarInit — cfg literal at line 28 flows through
+// the `value` prop into the destructured-param use at line 24.
 //
-// PR7 note: under the current PR6 closure the advertised
-// lfsVarInit+lfsParamBind composition does NOT fire — no row lands
-// on Inner's `value` parameter (line 23). See follow-up issue #202.
-// The pins in valueflow_closure_integration_test.go assert only
-// identity-observed reachability until that gap is closed.
+// PR8 (#202 Gap A): `lfsJsxPropBind` closes the JSX-prop →
+// destructured-param path. The walker also unwraps JsxExpression
+// `{…}` so the prop's valueExpr anchors at the inner cfg identifier
+// (line 29), letting the closure resolve back to cfg on line 28.
 //
 // Observed reachability set (mayResolveToRec; see
 // mayResolveTo.expected.csv for the machine-readable form):
 //
-//   DirectProp.tsx:21 → DirectProp.tsx:21   (import stmt base)
-//   DirectProp.tsx:28 → DirectProp.tsx:28   (cfg object literal base)
-//   DirectProp.tsx:29 → DirectProp.tsx:28   (JSX expr → cfg literal)
-//   DirectProp.tsx:29 → DirectProp.tsx:29   (JSX expr base)
+//   21 → 21   (import stmt base)
+//   24 → 28   (Inner `value` use → cfg — lfsJsxPropBind)
+//   28 → 28   (cfg object literal base)
+//   29 → 28   (JSX prop → cfg literal)
+//   29 → 29   (JSX element base)
 
 import { ReactNode } from 'react';
 

--- a/testdata/projects/valueflow-closure-direct-prop/mayResolveTo.expected.csv
+++ b/testdata/projects/valueflow-closure-direct-prop/mayResolveTo.expected.csv
@@ -1,5 +1,6 @@
 valueFile,valueLine,sourceFile,sourceLine
 DirectProp.tsx,21,DirectProp.tsx,21
+DirectProp.tsx,24,DirectProp.tsx,28
 DirectProp.tsx,28,DirectProp.tsx,28
 DirectProp.tsx,29,DirectProp.tsx,28
 DirectProp.tsx,29,DirectProp.tsx,29

--- a/testdata/projects/valueflow-jsx-prop-bind-arrow/ArrowInner.tsx
+++ b/testdata/projects/valueflow-jsx-prop-bind-arrow/ArrowInner.tsx
@@ -1,0 +1,22 @@
+// Arrow-assigned component fixture for #202 Gap A (PR #203).
+//
+// SHAPE: like DirectProp but the receiving component is an arrow
+// function assigned to a const, rather than a function declaration.
+// Idiomatic React style — `const Arrow = ({value}) => value`.
+//
+// If `FunctionSymbol` emission for arrow-assigned components is
+// populated by the walker, lfsJsxPropBind should fire just the same
+// and produce `(line 17 [value use] → line 20 [cfg literal])` via
+// mayResolveToRec.
+// If not, there is a silent walker-level miss worth filing as a
+// follow-up (don't fix here — that's a separate walker change).
+
+import { ReactNode } from 'react';
+
+const ArrowInner = ({ value }: { value: unknown }): ReactNode =>
+  value as ReactNode;
+
+export function ArrowHost(): ReactNode {
+  const cfg = { tag: 'src' };
+  return <ArrowInner value={cfg} />;
+}

--- a/valueflow_closure_integration_test.go
+++ b/valueflow_closure_integration_test.go
@@ -334,25 +334,29 @@ func allClosureExpectations() []closureExpectation {
 	// observed count changes.
 	return []closureExpectation{
 		{
-			// Direct prop pass (R1). Fixture advertises "lfsVarInit +
-			// lfsParamBind composed" but under the current PR6 closure
-			// the param-path row (Inner's `value` at line 20) does NOT
-			// appear. Pins below are identity-only — see follow-up
-			// issue #202 for closing the composition gap.
-			// Observed 4 rows: 17→17, 24→24, 25→24, 25→25.
+			// Direct prop pass (R1). Exercises the full
+			// "lfsVarInit + lfsJsxPropBind composed" path — cfg literal
+			// at line 28 reaches the destructured `value` use inside
+			// Inner at line 24. Closed by PR8 / #202 Gap A.
+			// Observed 5 rows: 21→21, 24→28, 28→28, 29→28, 29→29.
 			name:       "direct_prop",
 			projectDir: "testdata/projects/valueflow-closure-direct-prop",
 			pins: []locRow{
 				// base: cfg object literal resolves to itself (line 28)
 				{valueSuffix: "DirectProp.tsx", valueLine: 28,
 					sourceSuffix: "DirectProp.tsx", sourceLine: 28},
-				// JSX expr (line 29) reaches cfg literal — non-identity
-				// forward edge (lfsObjectLiteralStore composition).
+				// JSX prop (line 29) reaches cfg literal — composition
+				// of lfsVarInit through the inner JSX-expr identifier.
 				{valueSuffix: "DirectProp.tsx", valueLine: 29,
 					sourceSuffix: "DirectProp.tsx", sourceLine: 28},
+				// lfsJsxPropBind load-bearing edge: the `value` use
+				// inside Inner (line 24) reaches the cfg literal
+				// (line 28) — this is the #202 Gap A composition.
+				{valueSuffix: "DirectProp.tsx", valueLine: 24,
+					sourceSuffix: "DirectProp.tsx", sourceLine: 28},
 			},
-			minTotal: 2,  // ~50% of observed 4
-			maxTotal: 12, // ~3× observed — catches Cartesian blow-up
+			minTotal: 3,  // ~50% of observed 5 (rounded up to cover the 3 pins)
+			maxTotal: 15, // ~3× observed — catches Cartesian blow-up
 		},
 		{
 			// Context provider with own-fields (R2). Fixture advertises
@@ -740,6 +744,14 @@ func TestClosure_ManifestFileFieldsGreppable(t *testing.T) {
 		// deferred (follow-up #201). Consumer file will be
 		// tsq_valueflow.qll once emission lands.
 		"MayResolveToCapHit": "follow-up #201",
+
+		// Phase C PR8 (#202 Gap A): walker-populated helper relations
+		// consumed by `lfsJsxPropBind` in the datalog layer. The QL
+		// bridge classes for both are scheduled for the Phase D
+		// react-final bridge rollout — listing them here as ratchet
+		// entries keeps the manifest grep honest until then.
+		"ParamDestructurePattern": "Phase D react-final bridge",
+		"JsxExpressionInner":      "Phase D react-final bridge",
 
 		// Pre-PR7 baseline: manifest entries whose File field points
 		// at a planned consumer surface that does not yet reference

--- a/valueflow_closure_integration_test.go
+++ b/valueflow_closure_integration_test.go
@@ -541,6 +541,67 @@ func TestClosure_WholeClosureIntegration(t *testing.T) {
 	}
 }
 
+// TestClosure_ArrowComponentJsxPropBind — arrow-assigned component
+// coverage for PR #203 / #202 Gap A.
+//
+// SCOPE: idiomatic React style — `const Arrow = ({value}) => value`
+// — that `DirectProp` doesn't cover (DirectProp uses a named
+// `function Inner({value})` declaration). This test pins the
+// `lfsJsxPropBind` composition edge for an arrow-assigned component.
+//
+// Empirical outcome (2026-04-20): walker's FunctionSymbol emission
+// covers arrow-assigned components, so `lfsJsxPropBind` fires on
+// both declaration styles and the 17 → 20 edge is a hard
+// regression guard. If a future extractor change silently drops
+// arrow-component FunctionSymbol emission, this test fails fast
+// with the specific "edge absent" signal.
+func TestClosure_ArrowComponentJsxPropBind(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping extraction-heavy integration test in short mode")
+	}
+	rs := runClosureQuery(t,
+		"testdata/queries/v2/valueflow/all_mayResolveToRec_located.ql",
+		"testdata/projects/valueflow-jsx-prop-bind-arrow")
+	rows := projectLocatedRows(t, rs)
+	t.Logf("arrow-component fixture rows=%d", len(rows))
+	if testing.Verbose() {
+		t.Logf("full row set:\n%s", dumpRows(rows))
+	}
+
+	// Base case must fire — if the walker extracts nothing the probe
+	// is meaningless.
+	if len(rows) == 0 {
+		t.Fatal("arrow-component fixture produced 0 rows; " +
+			"base-case identity should fire at minimum. Walker or " +
+			"query wiring regressed.")
+	}
+
+	// Target edge: destructured `value` use (inside ArrowInner body,
+	// line 17) reaches the `cfg` object literal (line 20) via the
+	// lfsJsxPropBind → mayResolveToRec composition. This is the
+	// arrow-assigned analogue of the direct_prop 24 → 28 pin.
+	target := locRow{
+		valueSuffix: "ArrowInner.tsx", valueLine: 17,
+		sourceSuffix: "ArrowInner.tsx", sourceLine: 20,
+	}
+	if !containsLocRow(rows, target) {
+		t.Errorf("arrow-component fixture: missing pinned edge "+
+			"ArrowInner.tsx:17 → ArrowInner.tsx:20. Likely cause: "+
+			"walker no longer emits FunctionSymbol(tagSym, fn) for "+
+			"arrow-assigned components, breaking lfsJsxPropBind "+
+			"composition on idiomatic React-FC style. Rows:\n%s",
+			dumpRows(rows))
+	}
+	// Ceiling guard — catches Cartesian blow-up on this fixture
+	// (observed 7, 3× = 21).
+	const ceiling = 21
+	if len(rows) > ceiling {
+		t.Errorf("arrow-component fixture: %d rows > ceiling %d — "+
+			"Cartesian blow-up suspected:\n%s",
+			len(rows), ceiling, dumpRows(rows))
+	}
+}
+
 // TestClosure_RecursiveFunctionDoesNotHang asserts the recursive-
 // function fixture does not hang or blow the planner cap. The closure
 // terminates / produces some rows on a recursive function declaration.


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Summary

Closes #202 Gap A — the "JSX prop → destructured-param" composition
gap diagnosed in `valueflow-closure-direct-prop` /
`react-usestate-prop-alias`. `<Inner value={cfg} />` now flows `cfg`
through to in-body references of the destructured `value` binding of
Inner. Gap B (context-family provider composition) is deliberately
re-scoped to Phase D react-final and filed as **#204**. The Phase C
plan §6.3 context-subsumption claim is formally retracted in the
wiki (Phase C PR7 / #202 follow-up section of
`Wiki/Tech/tsq-valueflow-layer-design.md`) — React runtime semantics
don't belong in the generic value-flow primitive layer.

## Shape

New per-kind rule `lfsJsxPropBind` added to the eleven existing PR2
`lfs*` kinds (union stays field-sensitive on prop name):

```
lfsJsxPropBind(from, to) :-
    JsxAttribute(elem, propName, wrapper),
    JsxExpressionInner(wrapper, from),
    JsxElement(elem, _, tagSym),
    FunctionSymbol(tagSym, fn),
    Parameter(fn, _, _, paramNode, _, _),
    ParamDestructurePattern(paramNode, patternNode),
    DestructureField(patternNode, propName, _, bindSym, _),
    ExprMayRef(to, bindSym).
```

Two new walker-populated helper relations back the rule:

- **`ParamDestructurePattern(paramNode, patternNode)`** — bridges a
  destructured-param slot to its `ObjectPattern`/`ArrayPattern`,
  peeling `RequiredParameter` / `OptionalParameter` /
  `AssignmentPattern` wrappers. Emitted alongside
  `ParameterDestructured`.
- **`JsxExpressionInner(wrapperNode, innerNode)`** — bridges the
  `{…}` JsxExpression punctuation wrapper to its inner semantic
  expression. Emitted alongside `JsxAttribute`.

`JsxExpressionInner` is deliberately NOT hoisted into
`JsxAttribute.valueExpr` directly: the existing `tsq_react.qll`
Provider-value path relies on `valueExpr` pointing at the wrapper
and uses `Contains()` to descend; changing the column broke that
path during early iterations. Staying off the hot column keeps the
blast radius to the one new rule.

## Regression guard

- **`TestLfsJsxPropBind`** (unit) pins the rule shape end-to-end on
  a synthetic fact set **and exercises field-sensitivity** — a
  two-attribute / two-field fixture (`value`, `onClick`) with
  explicit cross-field leakage assertions. Added in review-fix
  commit.
- **`TestLocalFlowStepKindsNonZero`** adds
  `valueflow-closure-direct-prop` to the fixture set and a floor of
  1 for `lfsJsxPropBind` — catches total-absence regression without
  over-fitting to a single fixture's row count.
- **`TestClosure_WholeClosureIntegration/direct_prop`** now pins
  `DirectProp.tsx:24 → DirectProp.tsx:28` in both the
  `closureExpectation` minTotal/maxTotal/nonIdentity set and the
  `mayResolveTo.expected.csv` golden.
- **`TestClosure_ArrowComponentJsxPropBind`** (added in review-fix
  commit) pins the arrow-assigned-component analogue — idiomatic
  `const Arrow = ({value}) => value` React-FC style — on fixture
  `testdata/projects/valueflow-jsx-prop-bind-arrow/ArrowInner.tsx`.
  Walker emission confirmed to cover arrow components.

## Review-fix commit (2026-04-20)

Addresses adversarial review feedback on the original push:

- **MAJOR 1**: Gap B follow-up filed as #204
  (`feat(valueflow): context-family provider composition —
  createContext/useContext bridge (#202 Gap B, Phase D)`).
- **MAJOR 2**: Wiki retraction landed — Phase C PR7 / #202 section
  in `Wiki/Tech/tsq-valueflow-layer-design.md` now carries an
  explicit Gap A CLOSED / Gap B RETRACTED note with the structural
  reason and a pointer to #204.
- **MINOR 3**: `tsq_react.qll` "Retirement path" comment updated to
  describe the actual PR #203 landing (prop-specific unwrap via
  `JsxExpressionInner` helper EDB) rather than the stale
  "promote to `lfsJsxExpressionUnwrap` step rule" narrative.
- **MINOR 4**: `TestLfsJsxPropBind` extended with field-sensitivity
  negative case (see above).
- **MINOR 5**: Arrow-assigned-component fixture added and
  empirically confirmed to fire — promoted to hard assertion.
- **NIT**: `lfsParamBind` overlap comment clarified (structural
  disjointness via JsxElement + FunctionSymbol routing, not
  destructure carve-out). Walker valueNode assignment documented
  inline.

## Explicit non-goals

- **Object-destructure only.** Array-destructure of JSX props is
  syntactically possible but non-idiomatic — split out a sibling
  rule keyed on `ArrayDestructure` if it shows up in Mastodon row
  counts.
- **No cross-module double-counting.** The cross-module variant
  already composes via `ifsImportExport` on the `tagSym` ref inside
  `MayResolveToRec`.
- **Context-family (#202 Gap B) is out of scope.** Follow-up #204
  filed for Phase D react-final: explicit `createContext` /
  `useContext` bridge on top of `mayResolveToRec`.

## Bridge / coverage follow-up

Both new relations ship without a QL consumer class yet; bridge
class authorship is scheduled for Phase D react-final rollout. They
appear as ratchet entries with pointed reasons in:

- `bridge/manifest.go` (File: `tsq_functions.qll`, `tsq_jsx.qll`).
- `valueflow_closure_integration_test.go`
  `knownPlaceholderEntries` ("Phase D react-final bridge").
- `stdlib_coverage_test.go` `stdlibCoverageAllowlist`
  ("QL consumer deferred to Phase D").

## Numbers

- Relation count: 105 → 107 (+ParamDestructurePattern, +JsxExpressionInner).
- Manifest available: 132 → 134.
- LocalFlowStep kinds: 11 → 12.

## Test plan

- [x] `go test ./...` — all packages green from a clean testcache
      (review-fix commit retested 2026-04-20).
- [x] `TestClosure_WholeClosureIntegration/direct_prop` passes with
      the 24→28 pinned edge.
- [x] `TestClosure_ArrowComponentJsxPropBind` passes with the
      17→20 pinned edge on the arrow-assigned fixture.
- [x] `TestContextChain_LinkPredicates`,
      `TestR3_LinkPredicates`, `TestClosure_ManifestFileFieldsGreppable`,
      `TestCompatStdlibCoverage` — ripple coverage green.
- [x] Unit test `TestLfsJsxPropBind` pins rule shape and
      field-sensitivity negative case.
- [x] Regression guard floor in `TestLocalFlowStepKindsNonZero`.
