### PR TITLE
feat(bridge): ExpressHandlerArgUse handler-arg flow via mayResolveTo (Phase D PR2)

### DIFF
--- a/bridge/tsq_express.qll
+++ b/bridge/tsq_express.qll
@@ -1,6 +1,13 @@
 /**
  * Bridge library for Express.js framework models (v2 Phase F).
  * Provides QL classes for Express handler detection and HTTP input sources.
+ *
+ * Phase D PR2 (additive): `ExpressHandlerArgUse` predicate links a use
+ * expression back to the Express route handler whose parameter it
+ * resolves to via value-flow. Thin wrapper over the system
+ * `MayResolveTo` relation (Phase C PR4) + schema `Parameter` /
+ * `ExprMayRef` / `ExpressHandler`. Non-recursive on the QL side —
+ * recursion lives in the system Datalog rules.
  */
 
 /**
@@ -26,4 +33,100 @@ class ExpressReqSource extends TaintSource {
 
     /** Gets a textual representation. */
     override string toString() { result = "ExpressReqSource" }
+}
+
+/**
+ * Holds when `useExpr` is a use-site expression referencing parameter
+ * `paramIdx` of an Express route handler function `fn`, where `fn`
+ * was registered via value-flow-resolvable callback passed to an
+ * `app.{get,post,put,delete,patch,use}(...)` method call.
+ *
+ * # How the linkage is established
+ *
+ * Given an `app.<method>(...)` call, the predicate takes one
+ * `CallArg(call, _, handlerArgExpr)` and uses
+ * `MayResolveTo(handlerArgExpr, fn)` (the Phase C recursive closure)
+ * to follow the callback expression back to the function node that
+ * it resolves to at runtime. `fn` is that function node id.
+ * `Parameter(fn, paramIdx, _, _, paramSym, _)` picks out the symbol
+ * of the `paramIdx`-th parameter, and `ExprMayRef(useExpr, paramSym)`
+ * asserts `useExpr` is an Identifier that references it.
+ *
+ * # Why this is the value-add over `ExpressHandler`
+ *
+ * The existing `ExpressHandler(fn)` rule (see
+ * `extract/rules/frameworks.go` `expressHandlerRule`) fires only when
+ * the callback is a named-variable identifier:
+ * `ExprMayRef(cbExpr, cbSym) + FunctionSymbol(cbSym, fn)`. It MISSES
+ * the inline-arrow case entirely: in `app.get('/x', (req, res) => …)`
+ * the callback argument is an `ArrowFunction` node, not an
+ * `Identifier`, so `ExprMayRef(cbExpr, _)` is empty and the handler
+ * is never registered. This predicate substitutes `MayResolveTo` for
+ * the `ExprMayRef + FunctionSymbol` leg, which:
+ *   - Identity-base-hits the inline-arrow case (an `ArrowFunction`
+ *     is an `ExprValueSource`, so `MayResolveTo(arrow, arrow)` fires
+ *     via the base rule in `extract/rules/mayresolveto.go`).
+ *   - Handles the named-variable case transitively via `lfsVarInit`.
+ *   - Will scale to future wrapper patterns (`app.get('/x', wrap(h))`,
+ *     `app.get('/x', handlers.create)`, etc.) as the closure body
+ *     grows in subsequent PRs — additive-only wrt this bridge.
+ *
+ * # Semantics and scope
+ *
+ *   - `paramIdx` is 0-indexed (0 = req, 1 = res in Express convention).
+ *   - Method filter: `get|post|put|delete|patch|use`. No receiver
+ *     check — matches any MethodCall with those method names, because
+ *     Express apps are often aliased (`app`, `router`, `r`, etc.) and
+ *     `ExpressHandler`'s own rule also matches on method name only.
+ *   - No CallArg idx pin: for `app.get(path, cb)` the cb is at idx=1;
+ *     for `app.use(cb)` it is at idx=0. Any slot whose argNode
+ *     value-flow-resolves to a function node with a matching
+ *     `paramIdx`-th parameter counts. This is the same idx-wildcard
+ *     posture as `expressHandlerRule`.
+ *   - Non-recursive QL body: the recursion lives inside `MayResolveTo`.
+ *     The planner's Phase B recursive-IDB sizing handles it.
+ *
+ * # Deviation from Phase D plan (acknowledged)
+ *
+ * The plan (§2 PR3) sketched the linkage as
+ * `mayResolveTo(useExpr, handlerArgExpr)` — a use→arg direction. The
+ * current `MayResolveTo(v, s)` has `s ∈ ExprValueSource`, i.e. the
+ * resolved side must be a value-source literal (function, object,
+ * primitive). A parameter Identifier is NOT a value source, so the
+ * literal plan sketch produces zero rows on every fixture. This
+ * implementation inverts the flow direction: we go arg→fn via
+ * `MayResolveTo(handlerArgExpr, fn)` (which DOES hold — `fn` is an
+ * `ArrowFunction`/`FunctionExpression` node, a value source), then
+ * attach `ExprMayRef + Parameter` for the param-use side. Same
+ * linkage, flow-direction-corrected for the as-shipped closure
+ * semantics. Noted in the PR description for adversarial review.
+ *
+ * # Additive
+ *
+ * No existing predicate is modified. Callers that don't reference
+ * `ExpressHandlerArgUse` see zero behaviour change. `ExpressHandler`
+ * still fires only on the named-variable case; future work may
+ * migrate it onto the same closure, but PR2 scope ends here.
+ *
+ * Example:
+ *   from int useExpr, int fn
+ *   where ExpressHandlerArgUse(useExpr, fn, 0)
+ *   select useExpr, fn
+ */
+predicate ExpressHandlerArgUse(int useExpr, int fn, int paramIdx) {
+    exists(int call, int handlerArgExpr, int paramSym, string method |
+        MethodCall(call, _, method) and
+        (
+            method = "get"
+            or method = "post"
+            or method = "put"
+            or method = "delete"
+            or method = "patch"
+            or method = "use"
+        ) and
+        CallArg(call, _, handlerArgExpr) and
+        MayResolveTo(handlerArgExpr, fn) and
+        Parameter(fn, paramIdx, _, _, paramSym, _) and
+        ExprMayRef(useExpr, paramSym)
+    )
 }

--- a/express_handler_arg_use_test.go
+++ b/express_handler_arg_use_test.go
@@ -1,0 +1,207 @@
+package integration_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/ql/eval"
+)
+
+// Phase D PR2 — `ExpressHandlerArgUse` predicate (additive,
+// tsq_express.qll).
+//
+// The predicate links a use-site expression back to the Express route
+// handler whose parameter it value-flow-resolves to. Additive-only:
+// no existing predicate is modified, no branch is deleted.
+//
+// Regression-guard discipline (wiki briefing rules (a)-(g)):
+//
+//   (a) Non-zero real-fixture assertion — the fixture emits 4
+//       expected param uses (req/res in two handlers); test t.Fatals
+//       if the query returns zero rows.
+//   (b) Per-kind floor — there is one kind (ExpressHandlerArgUse).
+//       Floor set at 3, i.e. ~50%+ of the 4 observed pins. Not 1:
+//       per wiki rule (b) a floor of 1 is decorative.
+//   (c) Overlap check — this predicate wraps `MayResolveTo` +
+//       `ExpressHandler` + `Parameter` + `ExprMayRef` and projects
+//       on (useExpr, fn, paramIdx). Overlap with PR1's
+//       `tsq::dataflow.mayResolveTo` is limited to the use→source
+//       closure step being the same system relation; this predicate
+//       adds the handler-arg filter on top, which is distinct signal.
+//   (d) No carve-outs.
+//   (e) N/A — predicate is non-recursive on the QL side; recursion
+//       is inside `MayResolveTo`, which has its own base/recursive
+//       split tests in Phase C PR7.
+//   (f) Manifest `File:` — no new manifest entry (ExpressHandlerArgUse
+//       is a predicate, not a class, and does not introduce a new
+//       relation). `TestClosure_ManifestFileFieldsGreppable` unaffected.
+//   (g) Planner-stack verification — `runClosureQuery` routes through
+//       `plan.EstimateAndPlan` + `eval.MakeEstimatorHook` (the same
+//       path used by PR1's parity tests), so the predicate's
+//       cardinality is sized against live hints.
+
+// expressUseRow is the projection of one ExpressHandlerArgUse row,
+// keyed by file-suffix + line for stable equality across walker-
+// ordering changes.
+type expressUseRow struct {
+	usePath  string
+	useLine  int64
+	paramIdx int64
+}
+
+// runExpressHandlerArgUseQuery evaluates
+// testdata/queries/v2/find_express_handler_arg_use.ql on `fixtureDir`
+// via the full planner stack and returns the projected rows. The `fn`
+// column is dropped — fn node-ids are not stable across walker passes;
+// `paramIdx` + `useLine` are sufficient to pin semantic identity for
+// the fixture's two distinct handlers.
+func runExpressHandlerArgUseQuery(t *testing.T, fixtureDir string) []expressUseRow {
+	t.Helper()
+	rs := runClosureQuery(t,
+		"testdata/queries/v2/find_express_handler_arg_use.ql",
+		fixtureDir)
+	return projectExpressUseRows(t, rs)
+}
+
+func projectExpressUseRows(t *testing.T, rs *eval.ResultSet) []expressUseRow {
+	t.Helper()
+	out := make([]expressUseRow, 0, len(rs.Rows))
+	for i, row := range rs.Rows {
+		if len(row) != 4 {
+			t.Fatalf("row %d: expected arity 4 (usePath,useLine,fn,paramIdx), got %d", i, len(row))
+		}
+		pv, ok1 := row[0].(eval.StrVal)
+		lv, ok2 := row[1].(eval.IntVal)
+		_, ok3 := row[2].(eval.IntVal) // fn — present but intentionally unused in projection
+		piv, ok4 := row[3].(eval.IntVal)
+		if !ok1 || !ok2 || !ok3 || !ok4 {
+			t.Fatalf("row %d: unexpected cell shape (%T, %T, %T, %T)",
+				i, row[0], row[1], row[2], row[3])
+		}
+		out = append(out, expressUseRow{
+			usePath:  lastPathSegment(pv.V),
+			useLine:  lv.V,
+			paramIdx: piv.V,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		if a.usePath != b.usePath {
+			return a.usePath < b.usePath
+		}
+		if a.useLine != b.useLine {
+			return a.useLine < b.useLine
+		}
+		return a.paramIdx < b.paramIdx
+	})
+	return out
+}
+
+func containsExpressUseRow(rows []expressUseRow, pin expressUseRow) bool {
+	for _, r := range rows {
+		if r == pin {
+			return true
+		}
+	}
+	return false
+}
+
+// TestExpressHandlerArgUse_Pins — primary regression-guard test.
+// Asserts both named-variable and inline-arrow handlers produce the
+// expected (req=paramIdx 0, res=paramIdx 1) param-use rows at the
+// documented line numbers in the fixture.
+func TestExpressHandlerArgUse_Pins(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping extraction-heavy integration test in short mode")
+	}
+
+	fixture := "testdata/projects/express-handler-arg-use"
+	rows := runExpressHandlerArgUseQuery(t, fixture)
+
+	// Rule (a): non-zero real-fixture assertion.
+	if len(rows) == 0 {
+		t.Fatalf("fixture %s: ExpressHandlerArgUse produced 0 rows; "+
+			"predicate is broken or fixture regressed (rule (a))", fixture)
+	}
+
+	// Rule (b): ≥3 total rows (≥50%+ of the 4 observed pins). Not 1 —
+	// per wiki rule (b) a floor of 1 is a decorative guard.
+	const minTotal = 3
+	if len(rows) < minTotal {
+		t.Errorf("fixture %s: expected ≥%d ExpressHandlerArgUse rows, got %d; rows:\n%+v",
+			fixture, minTotal, len(rows), rows)
+	}
+
+	// Pinned rows — file:line:paramIdx tuples the predicate must return.
+	//
+	//   line 41: `const id = req.query;` (named handler)      → req  (paramIdx 0)
+	//   line 42: `res.send('ok ' + id);` (named handler)      → res  (paramIdx 1)
+	//   line 48: `const id = req.query;` (inline handler)     → req  (paramIdx 0)
+	//   line 49: `res.send('inline ' + id);` (inline handler) → res  (paramIdx 1)
+	pins := []expressUseRow{
+		{usePath: "app.ts", useLine: 41, paramIdx: 0},
+		{usePath: "app.ts", useLine: 42, paramIdx: 1},
+		{usePath: "app.ts", useLine: 48, paramIdx: 0},
+		{usePath: "app.ts", useLine: 49, paramIdx: 1},
+	}
+	for _, pin := range pins {
+		if !containsExpressUseRow(rows, pin) {
+			t.Errorf("fixture %s: missing pin %+v from ExpressHandlerArgUse rows:\n%+v",
+				fixture, pin, rows)
+		}
+	}
+}
+
+// TestExpressHandlerArgUse_NamedVsInlineDistinctFns — sanity check
+// that the predicate distinguishes the two handlers via the `fn`
+// column. The named handler and the inline handler are different
+// function expressions; the two req-uses (lines 35, 42) must resolve
+// to different `fn` ids. Guards against a bug where the predicate
+// collapses all handlers onto one fn (e.g. if `exists` over fn was
+// dropped).
+func TestExpressHandlerArgUse_NamedVsInlineDistinctFns(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping extraction-heavy integration test in short mode")
+	}
+
+	fixture := "testdata/projects/express-handler-arg-use"
+	rs := runClosureQuery(t,
+		"testdata/queries/v2/find_express_handler_arg_use.ql",
+		fixture)
+
+	// Collect (useLine, fn) pairs for paramIdx=0 (req) rows.
+	fnsByLine := map[int64]map[int64]struct{}{}
+	for i, row := range rs.Rows {
+		if len(row) != 4 {
+			t.Fatalf("row %d: expected arity 4, got %d", i, len(row))
+		}
+		lv, ok1 := row[1].(eval.IntVal)
+		fv, ok2 := row[2].(eval.IntVal)
+		piv, ok3 := row[3].(eval.IntVal)
+		if !ok1 || !ok2 || !ok3 {
+			t.Fatalf("row %d: unexpected cell shape", i)
+		}
+		if piv.V != 0 {
+			continue
+		}
+		if _, ok := fnsByLine[lv.V]; !ok {
+			fnsByLine[lv.V] = map[int64]struct{}{}
+		}
+		fnsByLine[lv.V][fv.V] = struct{}{}
+	}
+
+	namedFns := fnsByLine[41]
+	inlineFns := fnsByLine[48]
+	if len(namedFns) == 0 || len(inlineFns) == 0 {
+		t.Fatalf("fixture %s: missing req-use rows — named line 41 fns=%v, inline line 48 fns=%v",
+			fixture, namedFns, inlineFns)
+	}
+	// The two lines must resolve to disjoint fn sets. If any fn
+	// overlaps, the predicate collapsed two distinct handlers.
+	for fn := range namedFns {
+		if _, collides := inlineFns[fn]; collides {
+			t.Errorf("fixture %s: named handler (line 41) and inline handler (line 48) "+
+				"share fn=%d — predicate is not distinguishing handlers", fixture, fn)
+		}
+	}
+}

--- a/express_handler_arg_use_test.go
+++ b/express_handler_arg_use_test.go
@@ -49,6 +49,17 @@ type expressUseRow struct {
 	paramIdx int64
 }
 
+// expressUseRowFull includes the fnLine column — used by negative
+// assertions that need to distinguish which handler fn a row resolves
+// to without relying on unstable fn node-ids.
+type expressUseRowFull struct {
+	usePath  string
+	useLine  int64
+	fn       int64
+	paramIdx int64
+	fnLine   int64
+}
+
 // runExpressHandlerArgUseQuery evaluates
 // testdata/queries/v2/find_express_handler_arg_use.ql on `fixtureDir`
 // via the full planner stack and returns the projected rows. The `fn`
@@ -67,16 +78,17 @@ func projectExpressUseRows(t *testing.T, rs *eval.ResultSet) []expressUseRow {
 	t.Helper()
 	out := make([]expressUseRow, 0, len(rs.Rows))
 	for i, row := range rs.Rows {
-		if len(row) != 4 {
-			t.Fatalf("row %d: expected arity 4 (usePath,useLine,fn,paramIdx), got %d", i, len(row))
+		if len(row) != 5 {
+			t.Fatalf("row %d: expected arity 5 (usePath,useLine,fn,paramIdx,fnLine), got %d", i, len(row))
 		}
 		pv, ok1 := row[0].(eval.StrVal)
 		lv, ok2 := row[1].(eval.IntVal)
 		_, ok3 := row[2].(eval.IntVal) // fn — present but intentionally unused in projection
 		piv, ok4 := row[3].(eval.IntVal)
-		if !ok1 || !ok2 || !ok3 || !ok4 {
-			t.Fatalf("row %d: unexpected cell shape (%T, %T, %T, %T)",
-				i, row[0], row[1], row[2], row[3])
+		_, ok5 := row[4].(eval.IntVal) // fnLine — present but unused in this projection
+		if !ok1 || !ok2 || !ok3 || !ok4 || !ok5 {
+			t.Fatalf("row %d: unexpected cell shape (%T, %T, %T, %T, %T)",
+				i, row[0], row[1], row[2], row[3], row[4])
 		}
 		out = append(out, expressUseRow{
 			usePath:  lastPathSegment(pv.V),
@@ -94,6 +106,35 @@ func projectExpressUseRows(t *testing.T, rs *eval.ResultSet) []expressUseRow {
 		}
 		return a.paramIdx < b.paramIdx
 	})
+	return out
+}
+
+// projectExpressUseRowsFull returns the full 5-column projection
+// including fn and fnLine — needed for negative assertions that must
+// distinguish which handler function each row resolves to.
+func projectExpressUseRowsFull(t *testing.T, rs *eval.ResultSet) []expressUseRowFull {
+	t.Helper()
+	out := make([]expressUseRowFull, 0, len(rs.Rows))
+	for i, row := range rs.Rows {
+		if len(row) != 5 {
+			t.Fatalf("row %d: expected arity 5, got %d", i, len(row))
+		}
+		pv, ok1 := row[0].(eval.StrVal)
+		lv, ok2 := row[1].(eval.IntVal)
+		fv, ok3 := row[2].(eval.IntVal)
+		piv, ok4 := row[3].(eval.IntVal)
+		flv, ok5 := row[4].(eval.IntVal)
+		if !ok1 || !ok2 || !ok3 || !ok4 || !ok5 {
+			t.Fatalf("row %d: unexpected cell shape", i)
+		}
+		out = append(out, expressUseRowFull{
+			usePath:  lastPathSegment(pv.V),
+			useLine:  lv.V,
+			fn:       fv.V,
+			paramIdx: piv.V,
+			fnLine:   flv.V,
+		})
+	}
 	return out
 }
 
@@ -134,20 +175,50 @@ func TestExpressHandlerArgUse_Pins(t *testing.T) {
 
 	// Pinned rows — file:line:paramIdx tuples the predicate must return.
 	//
-	//   line 41: `const id = req.query;` (named handler)      → req  (paramIdx 0)
-	//   line 42: `res.send('ok ' + id);` (named handler)      → res  (paramIdx 1)
-	//   line 48: `const id = req.query;` (inline handler)     → req  (paramIdx 0)
-	//   line 49: `res.send('inline ' + id);` (inline handler) → res  (paramIdx 1)
+	//   line 50: `const id = req.query;` (named handler)      → req  (paramIdx 0)
+	//   line 51: `res.send('ok ' + id);` (named handler)      → res  (paramIdx 1)
+	//   line 57: `const id = req.query;` (inline handler)     → req  (paramIdx 0)
+	//   line 58: `res.send('inline ' + id);` (inline handler) → res  (paramIdx 1)
 	pins := []expressUseRow{
-		{usePath: "app.ts", useLine: 41, paramIdx: 0},
-		{usePath: "app.ts", useLine: 42, paramIdx: 1},
-		{usePath: "app.ts", useLine: 48, paramIdx: 0},
-		{usePath: "app.ts", useLine: 49, paramIdx: 1},
+		{usePath: "app.ts", useLine: 50, paramIdx: 0},
+		{usePath: "app.ts", useLine: 51, paramIdx: 1},
+		{usePath: "app.ts", useLine: 57, paramIdx: 0},
+		{usePath: "app.ts", useLine: 58, paramIdx: 1},
 	}
 	for _, pin := range pins {
 		if !containsExpressUseRow(rows, pin) {
 			t.Errorf("fixture %s: missing pin %+v from ExpressHandlerArgUse rows:\n%+v",
 				fixture, pin, rows)
+		}
+	}
+
+	// Adversarial negative assertions — these rows MUST NOT appear.
+	// They prove the predicate actually filters via `CallArg` +
+	// `MayResolveTo(handlerArgExpr, fn)` + method-name allow-list.
+	//
+	// Mutation probe: commenting out `CallArg(call, _, handlerArgExpr)`
+	// OR `MayResolveTo(handlerArgExpr, fn)` at bridge/tsq_express.qll
+	// should surface `decoy`'s param uses (lines 66-67). Commenting
+	// out any of the method-name disjuncts together with adding `on`
+	// would surface `otherHandler`'s (lines 75-76). Either leg going
+	// silent means the predicate has decayed to a parameter-only
+	// overapproximation.
+	//
+	//   line 69: `const x = req.query;` inside `decoyHandler` fn expr
+	//   line 70: `res.send(x);`         inside `decoyHandler` fn expr
+	//   line 81: `const y = req.query;` inside `function otherHandler`
+	//   line 82: `res.send(y);`         inside `function otherHandler`
+	forbidden := []expressUseRow{
+		{usePath: "app.ts", useLine: 69, paramIdx: 0},
+		{usePath: "app.ts", useLine: 70, paramIdx: 1},
+		{usePath: "app.ts", useLine: 81, paramIdx: 0},
+		{usePath: "app.ts", useLine: 82, paramIdx: 1},
+	}
+	for _, bad := range forbidden {
+		if containsExpressUseRow(rows, bad) {
+			t.Errorf("fixture %s: forbidden row %+v present in ExpressHandlerArgUse rows — "+
+				"predicate has decayed to parameter-only overapproximation or method filter is broken; rows:\n%+v",
+				fixture, bad, rows)
 		}
 	}
 }
@@ -168,40 +239,109 @@ func TestExpressHandlerArgUse_NamedVsInlineDistinctFns(t *testing.T) {
 	rs := runClosureQuery(t,
 		"testdata/queries/v2/find_express_handler_arg_use.ql",
 		fixture)
+	full := projectExpressUseRowsFull(t, rs)
 
-	// Collect (useLine, fn) pairs for paramIdx=0 (req) rows.
-	fnsByLine := map[int64]map[int64]struct{}{}
-	for i, row := range rs.Rows {
-		if len(row) != 4 {
-			t.Fatalf("row %d: expected arity 4, got %d", i, len(row))
-		}
-		lv, ok1 := row[1].(eval.IntVal)
-		fv, ok2 := row[2].(eval.IntVal)
-		piv, ok3 := row[3].(eval.IntVal)
-		if !ok1 || !ok2 || !ok3 {
-			t.Fatalf("row %d: unexpected cell shape", i)
-		}
-		if piv.V != 0 {
+	// Collect (useLine → {fn, fnLine}) for paramIdx=0 (req) rows.
+	type fnPair struct {
+		fn     int64
+		fnLine int64
+	}
+	fnsByLine := map[int64]map[fnPair]struct{}{}
+	for _, r := range full {
+		if r.paramIdx != 0 {
 			continue
 		}
-		if _, ok := fnsByLine[lv.V]; !ok {
-			fnsByLine[lv.V] = map[int64]struct{}{}
+		if _, ok := fnsByLine[r.useLine]; !ok {
+			fnsByLine[r.useLine] = map[fnPair]struct{}{}
 		}
-		fnsByLine[lv.V][fv.V] = struct{}{}
+		fnsByLine[r.useLine][fnPair{fn: r.fn, fnLine: r.fnLine}] = struct{}{}
 	}
 
-	namedFns := fnsByLine[41]
-	inlineFns := fnsByLine[48]
+	namedFns := fnsByLine[50]
+	inlineFns := fnsByLine[57]
 	if len(namedFns) == 0 || len(inlineFns) == 0 {
-		t.Fatalf("fixture %s: missing req-use rows — named line 41 fns=%v, inline line 48 fns=%v",
+		t.Fatalf("fixture %s: missing req-use rows — named line 50 pairs=%v, inline line 57 pairs=%v",
 			fixture, namedFns, inlineFns)
 	}
 	// The two lines must resolve to disjoint fn sets. If any fn
 	// overlaps, the predicate collapsed two distinct handlers.
-	for fn := range namedFns {
-		if _, collides := inlineFns[fn]; collides {
-			t.Errorf("fixture %s: named handler (line 41) and inline handler (line 48) "+
-				"share fn=%d — predicate is not distinguishing handlers", fixture, fn)
+	for p := range namedFns {
+		for q := range inlineFns {
+			if p.fn == q.fn {
+				t.Errorf("fixture %s: named handler (line 50) and inline handler (line 57) "+
+					"share fn=%d — predicate is not distinguishing handlers", fixture, p.fn)
+			}
+		}
+	}
+
+	// MINOR 1 — fnLine pinning. The handler fn each row resolves to
+	// must land at a handler decl line in the fixture:
+	//
+	//   line 49: `const namedHandler = function(req, res) { … };`
+	//            — the function expression literal on the RHS.
+	//   line 56: `app.get('/inline', (req, res) => { … });`
+	//            — the arrow function expression literal.
+	//
+	// Fixture decoys: `decoyHandler` var at line 68 (fn expr on the
+	// RHS of `const decoyHandler = function(...)`) and `otherHandler`
+	// at line 80 (`function otherHandler`). The predicate must NOT
+	// resolve to either of those. Using a disjoint-from-decoys check
+	// rather than an exact-line pin: extractor may report the fn
+	// literal's start at either the `function`/`(` token or the
+	// enclosing initialiser — both acceptable, as long as it isn't
+	// a decoy.
+	forbiddenFnLines := map[int64]string{
+		68: "decoyHandler",
+		80: "otherHandler",
+	}
+	for useLine, pairs := range fnsByLine {
+		for p := range pairs {
+			if name, bad := forbiddenFnLines[p.fnLine]; bad {
+				t.Errorf("fixture %s: useLine=%d resolved to fnLine=%d (%s decoy) — "+
+					"predicate is leaking into a non-registered handler",
+					fixture, useLine, p.fnLine, name)
+			}
+		}
+	}
+	// Also assert the named and inline rows' fnLines are disjoint —
+	// catches a fn-id collision that somehow preserves fn diversity
+	// (vanishingly unlikely, but cheap).
+	namedFnLines := map[int64]struct{}{}
+	for p := range namedFns {
+		namedFnLines[p.fnLine] = struct{}{}
+	}
+	for p := range inlineFns {
+		if _, collides := namedFnLines[p.fnLine]; collides {
+			t.Errorf("fixture %s: named and inline handlers share fnLine=%d — "+
+				"expected distinct handler decl sites", fixture, p.fnLine)
+		}
+	}
+}
+
+// TestExpressHandlerArgUse_MethodFilter_AppOnNegative — MINOR 2.
+// `app.on('evt', otherHandler)` registers a handler via a method
+// (`on`) that is NOT in the ExpressHandlerArgUse allow-list
+// (get|post|put|delete|patch|use). Its parameter uses (lines 81, 82)
+// must produce zero rows. If this test starts failing, the method
+// filter in bridge/tsq_express.qll has been widened — review the
+// allow-list change is intentional.
+func TestExpressHandlerArgUse_MethodFilter_AppOnNegative(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping extraction-heavy integration test in short mode")
+	}
+
+	fixture := "testdata/projects/express-handler-arg-use"
+	rows := runExpressHandlerArgUseQuery(t, fixture)
+
+	forbidden := []expressUseRow{
+		{usePath: "app.ts", useLine: 81, paramIdx: 0},
+		{usePath: "app.ts", useLine: 82, paramIdx: 1},
+	}
+	for _, bad := range forbidden {
+		if containsExpressUseRow(rows, bad) {
+			t.Errorf("fixture %s: app.on handler param use %+v leaked into "+
+				"ExpressHandlerArgUse — method filter is broken; rows:\n%+v",
+				fixture, bad, rows)
 		}
 	}
 }

--- a/testdata/projects/express-handler-arg-use/app.ts
+++ b/testdata/projects/express-handler-arg-use/app.ts
@@ -24,10 +24,19 @@
 //
 //   line  paramIdx  handler
 //   ----  --------  -------------
-//   41    0         namedHandler        (req.query → req)
-//   42    1         namedHandler        (res.send → res)
-//   48    0         inlineHandler       (req.query → req)
-//   49    1         inlineHandler       (res.send → res)
+//   50    0         namedHandler        (req.query → req)
+//   51    1         namedHandler        (res.send → res)
+//   57    0         inlineHandler       (req.query → req)
+//   58    1         inlineHandler       (res.send → res)
+//
+// Forbidden rows (must NOT appear — adversarial guards):
+//
+//   line  reason
+//   ----  -------------------------------------------------------
+//   69    `decoyHandler` fn never reaches app.<method> — CallArg filter
+//   70    `decoyHandler` fn never reaches app.<method> — CallArg filter
+//   81    `otherHandler` reached via app.on (method filter excludes "on")
+//   82    `otherHandler` reached via app.on (method filter excludes "on")
 //
 // Pinned in express_handler_arg_use_test.go.
 
@@ -48,3 +57,28 @@ app.get('/inline', (req, res) => {
     const id = req.query;
     res.send('inline ' + id);
 });
+
+// Decoy: same (req, res) signature, bound to a var (so the decoy fn
+// literal IS an ExprValueSource and MayResolveTo-reachable from the
+// `decoyHandler` identifier), but the `decoyHandler` identifier is
+// never passed to any `app.<method>` call. If the predicate ever
+// drops its `CallArg(call, _, handlerArgExpr)` leg, the MayResolveTo
+// edge `decoyHandler → fn` would surface these param uses (lines
+// 69-70) as rows; they must not appear.
+const decoyHandler = function(req: any, res: any) {
+    const x = req.query;
+    res.send(x);
+};
+// Use the decoy in a non-handler context so the extractor keeps the
+// ref live (prevents dead-code pruning of the var binding).
+const _decoyRef: any = decoyHandler;
+
+// Negative method-filter fixture: `app.on(...)` is NOT in the allow-list
+// (get|post|put|delete|patch|use). A handler registered via `app.on` must
+// not produce ExpressHandlerArgUse rows for its param uses (lines 81-82),
+// proving the method filter actually bites.
+const otherHandler = function(req: any, res: any) {
+    const y = req.query;
+    res.send(y);
+};
+app.on('evt', otherHandler);

--- a/testdata/projects/express-handler-arg-use/app.ts
+++ b/testdata/projects/express-handler-arg-use/app.ts
@@ -1,0 +1,50 @@
+// Phase D PR2 — ExpressHandlerArgUse fixture.
+//
+// Exercises the additive `ExpressHandlerArgUse(useExpr, fn, paramIdx)`
+// predicate in bridge/tsq_express.qll. The predicate asks: for a given
+// use-site expression `useExpr`, does value-flow resolve it back to
+// parameter `paramIdx` of Express route handler `fn`?
+//
+// Two shapes covered:
+//
+//   1. Named-variable handler (namedHandler / app.get('/named', …)).
+//      The callback passed to `app.get` is the identifier `namedHandler`,
+//      which `mayResolveTo` walks through the VarDecl init back to the
+//      function expression. Inside the handler body, `req.query` and
+//      `res.send` both sit on parameter uses that the predicate must
+//      link back to (namedHandler fn, idx=0) and (namedHandler fn, idx=1)
+//      respectively.
+//
+//   2. Inline arrow handler (app.get('/inline', (req, res) => …)).
+//      Baseline shape — the callback argument is the function expression
+//      itself (no var indirection). Parameter uses inside should still
+//      surface via the predicate.
+//
+// Expected ExpressHandlerArgUse rows (by param use line):
+//
+//   line  paramIdx  handler
+//   ----  --------  -------------
+//   41    0         namedHandler        (req.query → req)
+//   42    1         namedHandler        (res.send → res)
+//   48    0         inlineHandler       (req.query → req)
+//   49    1         inlineHandler       (res.send → res)
+//
+// Pinned in express_handler_arg_use_test.go.
+
+const express = require('express');
+const app = express();
+
+// Named-variable handler — handler is registered by identifier, so the
+// `app.get` CallArg's argNode is the `namedHandler` Ident expression,
+// not the function expression. `mayResolveTo` bridges the VarDecl init.
+const namedHandler = function(req, res) {
+    const id = req.query;
+    res.send('ok ' + id);
+};
+app.get('/named', namedHandler);
+
+// Inline arrow handler — baseline case, no var indirection.
+app.get('/inline', (req, res) => {
+    const id = req.query;
+    res.send('inline ' + id);
+});

--- a/testdata/queries/v2/find_express_handler_arg_use.ql
+++ b/testdata/queries/v2/find_express_handler_arg_use.ql
@@ -12,10 +12,13 @@
 import tsq::express
 import tsq::base
 
-from ASTNode use, int fn, int paramIdx
-where ExpressHandlerArgUse(use, fn, paramIdx)
+from ASTNode use, ASTNode fnNode, int fn, int paramIdx
+where
+  ExpressHandlerArgUse(use, fn, paramIdx) and
+  fnNode = fn
 select
   use.getFile().getPath() as "usePath",
   use.getStartLine() as "useLine",
   fn as "fn",
-  paramIdx as "paramIdx"
+  paramIdx as "paramIdx",
+  fnNode.getStartLine() as "fnLine"

--- a/testdata/queries/v2/find_express_handler_arg_use.ql
+++ b/testdata/queries/v2/find_express_handler_arg_use.ql
@@ -1,0 +1,21 @@
+/**
+ * @name Express handler arg uses
+ * @description Phase D PR2. Projects every
+ *              `ExpressHandlerArgUse(useExpr, fn, paramIdx)` row with
+ *              the use-site expression's file path + start line. Keyed
+ *              for fixture-grounded regression-guard assertions in
+ *              `express_handler_arg_use_test.go`.
+ * @kind table
+ * @id js/tsq/express/handler-arg-use-located
+ */
+
+import tsq::express
+import tsq::base
+
+from ASTNode use, int fn, int paramIdx
+where ExpressHandlerArgUse(use, fn, paramIdx)
+select
+  use.getFile().getPath() as "usePath",
+  use.getStartLine() as "useLine",
+  fn as "fn",
+  paramIdx as "paramIdx"


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Summary

Phase D PR2 — additive `ExpressHandlerArgUse(useExpr, fn, paramIdx)` predicate in `bridge/tsq_express.qll`. Uses the Phase C recursive `MayResolveTo` closure (via `tsq_dataflow.qll` PR1 or the system relation directly) to link Express route-handler parameter uses back to the registered handler function — **including inline-arrow handlers that the existing `ExpressHandler` rule misses entirely**.

Independent of other Phase D PRs. No deletions. No existing predicate modified.

## Linkage

```
MethodCall(call, _, get|post|put|delete|patch|use)
CallArg(call, _, handlerArgExpr)
MayResolveTo(handlerArgExpr, fn)          ← value-flow resolution
Parameter(fn, paramIdx, _, _, paramSym, _)
ExprMayRef(useExpr, paramSym)
```

## Value-add over existing `ExpressHandler`

`ExpressHandler(fn)` derives via `ExprMayRef(cbExpr, cbSym) + FunctionSymbol(cbSym, fn)`. That requires `cbExpr` to be an `Identifier` — so it fires for `app.get('/x', namedHandler)` but SILENTLY DROPS `app.get('/x', (req, res) => …)` because an `ArrowFunction` node is not an `Identifier` and `ExprMayRef` never fires.

`ExpressHandlerArgUse` replaces the `ExprMayRef + FunctionSymbol` leg with `MayResolveTo`:
- Inline-arrow case: `MayResolveTo(arrow, arrow)` hits the base rule (`ArrowFunction` is an `ExprValueSource`).
- Named-variable case: handled transitively via `lfsVarInit` (`const h = fn; app.get(_, h)` resolves `h` → `fn` expr node).
- Future wrapper patterns (`app.get(p, wrap(h))`, `app.get(p, handlers.create)`, etc.) come online as the closure body grows — additive-only wrt this bridge.

The fixture verifies both paths: 4 param-use rows (2 per handler) — `ExpressHandler` would have returned param uses for only the named handler.

## Plan deviation — flagged for reviewer

Plan §2 PR3 sketches the linkage as `mayResolveTo(useExpr, handlerArgExpr)` — a use→arg direction.

**That sketch produces zero rows on every real fixture.** `MayResolveTo(v, s)` requires `s ∈ ExprValueSource`, and parameter Identifiers are not value sources (see `extract/kinds.go` `ValueSourceKinds` — covers object/array/function/class literals and primitives; identifiers are not in the set). The literal plan sketch is dead.

Implementation inverts to **arg→fn** via `MayResolveTo(handlerArgExpr, fn)` — which DOES hold, because `fn` is an `ArrowFunction` / `FunctionExpression` node and those ARE value sources. Then `ExprMayRef + Parameter` attach the param-use side. Same linkage, flow-direction-corrected for the as-shipped closure semantics. Documented inline in the predicate docstring under "Deviation from Phase D plan (acknowledged)" and in this PR description.

## Fixture

`testdata/projects/express-handler-arg-use/app.ts` — 50 lines. Two Express routes:
- **Named-variable handler** (`const namedHandler = function(req, res) { … }; app.get('/named', namedHandler)`) — exercises `lfsVarInit` multi-hop resolution.
- **Inline arrow handler** (`app.get('/inline', (req, res) => { … })`) — exercises `MayResolveTo` base case; **this is the case `ExpressHandler` silently drops**.

Four expected param-use rows:
| line | paramIdx | handler | use |
|---|---|---|---|
| 41 | 0 | namedHandler | `req.query` → `req` |
| 42 | 1 | namedHandler | `res.send` → `res` |
| 48 | 0 | inlineHandler | `req.query` → `req` |
| 49 | 1 | inlineHandler | `res.send` → `res` |

## Tests

Both routed through the full planner stack (`runClosureQuery` → `plan.EstimateAndPlan` + `eval.MakeEstimatorHook`), not raw datalog.

- `TestExpressHandlerArgUse_Pins` — non-zero floor + ≥3-row total floor (≥50%+ of 4 observed pins, per regression-guard rule (b)) + four pinned `(file, line, paramIdx)` tuples.
- `TestExpressHandlerArgUse_NamedVsInlineDistinctFns` — asserts the two handlers produce disjoint `fn` sets. Guards against a predicate-collapse bug where both handlers' uses alias onto one `fn`.

## Regression-guard accounting (wiki rules a–g)

| Rule | Applied? | How |
|---|---|---|
| (a) Non-zero real-fixture | yes | `t.Fatal` on 0 rows |
| (b) ≥50% floor, not 1 | yes | `minTotal = 3`; pins provide the lower bound |
| (c) Overlap with prior PRs | noted | overlaps PR1 (`tsq::dataflow.mayResolveTo`) only in the use→source closure step; this predicate adds the handler-registration filter on top — distinct signal |
| (d) Carve-outs | none | method-name filter is structural (Express semantics), not a precision carve-out |
| (e) Base/recursive split | N/A | predicate is non-recursive on the QL side; recursion lives inside `MayResolveTo` (Phase C PR4/PR7 covers base/delta) |
| (f) Manifest `File:` grep | N/A | no new manifest entry (predicate, not class, no new relation) — existing `TestClosure_ManifestFileFieldsGreppable` unaffected |
| (g) End-to-end planner | yes | `runClosureQuery` routes through `plan.EstimateAndPlan` + estimator hook, same path as PR1 parity tests |

## LoC

| File | Δ lines |
|---|---|
| `bridge/tsq_express.qll` | +103 (predicate body ~15 lines; rest docstring) |
| `express_handler_arg_use_test.go` | +207 (new) |
| `testdata/projects/express-handler-arg-use/app.ts` | +50 (new fixture) |
| `testdata/queries/v2/find_express_handler_arg_use.ql` | +21 (new query) |
| **Total** | **+381, -0** |

Plan budget was ~25 LoC predicate + ~50 LoC fixture/test. Predicate body hits the budget; docstring / test scaffolding is on the larger side, consistent with PR1 (#205) rigor (diff-triage discipline, regression-guard annotations).

## Test plan

- [x] `go test -timeout 600s ./...` green on tsq-vf-d-pr2 worktree (all 18 packages)
- [x] `go test -run TestExpressHandlerArgUse` green (2 tests)
- [x] `go test -run "Express|Taint|Valueflow|Closure|Dataflow" ./...` green — no regression on adjacent integration tests
- [ ] Adversarial review (parent will spawn subagent)
- [ ] CI green on push
- [ ] Merge gated on reviewer sign-off per janky PR workflow

## Future work (not this PR)

- Migrate `ExpressHandler(fn)` itself onto `MayResolveTo` so the named+inline coverage applies to the rest of the `tsq_express` surface and the downstream `TaintSource` rules. Explicit non-goal for PR2 per plan §2 "additive, isolated".
- Extend the method-name filter if additional Express patterns surface during Phase D corpus measurement.
- CSV-pinned matrix row on the jitsi corpus, per plan §4 — belongs to the Phase D PR7 finalisation, not PR2.