### PR TITLE
refactor(bridge): delete Phase A resolveToObjectExpr wrapper (Phase D PR6)

### DIFF
--- a/bridge/tsq_react.qll
+++ b/bridge/tsq_react.qll
@@ -622,27 +622,17 @@ predicate resolveToObjectExprWrapped(int valueExpr, int objExpr) {
 }
 
 /**
- * `resolveToObjectExpr(valueExpr, objExpr)` — public "valueExpr
- * resolves to an object literal" predicate consumed by
- * `contextProviderFieldR3VarIndirect*`.
- *
- * PR6 collapses four former branches onto the recursive closure:
- *   - direct + VarD1 (Phase A PR3 subsumption) — `mayResolveToObjectExprDirect`.
- *   - VarD2 — transitive `lfsVarInit` inside `mayResolveToRec`.
- *   - HookReturnDirect + HookReturnVar — `lfsReturnToCallSite` +
- *     `lfsVarInit` inside `mayResolveToRec`; cross-module via
- *     `ifsRetToCall` on `CallTargetCrossModule`.
- *   - JsxExpression wrapper unwrap — `mayResolveToObjectExprJsxWrapped`,
- *     strictly more permissive than the old
- *     `resolveToObjectExprWrapped` (direct `Contains` to literal)
- *     because the closure follows variable indirection past the wrapper
- *     (`value={X}` where `X` VarDecl-binds a literal — the r3
- *     IndirectValue shape).
+ * Phase D PR6 (20 Apr 2026): the Phase A `resolveToObjectExpr` wrapper
+ * was deleted here. It had become a trivial one-line alias for
+ * `mayResolveToObjectExpr` after Phase C PR6's migration onto the
+ * recursive closure. In-file callers
+ * (`contextProviderFieldR3VarIndirect{Own,SpreadD1,SpreadD2}`) now call
+ * `mayResolveToObjectExpr` directly. The carve-out
+ * `resolveToObjectExprWrapped` below remains: it is a structurally
+ * distinct Contains-only unwrap, pinned by the r3 link-predicate
+ * regression test, and slated to retire alongside a future
+ * `lfsJsxExpressionUnwrap` step promotion.
  */
-predicate resolveToObjectExpr(int valueExpr, int objExpr) {
-    mayResolveToObjectExpr(valueExpr, objExpr)
-}
-
 /**
  * Holds if `objExpr` is the parent of at least one ObjectLiteralField or
  * ObjectLiteralSpread row — i.e. it is an object literal expression in the
@@ -839,7 +829,7 @@ predicate contextProviderFieldR2(int ctxSym, string fieldName, int valueSym) {
 
 /**
  * Round-3 variable-indirect path: the Provider's value attribute is an
- * Identifier resolving to an ObjectLiteral via `resolveToObjectExpr`.
+ * Identifier resolving to an ObjectLiteral via `mayResolveToObjectExpr`.
  * Spread + computed-string-key fields of the resolved object are visible.
  */
 predicate contextProviderFieldR3VarIndirectOwn(int ctxSym, string fieldName, int valueSym) {
@@ -847,7 +837,7 @@ predicate contextProviderFieldR3VarIndirectOwn(int ctxSym, string fieldName, int
         JsxElement(elem, tagNode, _) and
         FieldRead(tagNode, ctxSym, "Provider") and
         JsxAttribute(elem, "value", valueAttrExpr) and
-        resolveToObjectExpr(valueAttrExpr, objExpr) and
+        mayResolveToObjectExpr(valueAttrExpr, objExpr) and
         objectLiteralFieldOwn(objExpr, fieldName, valueExpr) and
         ExprMayRef(valueExpr, valueSym)
     )
@@ -858,7 +848,7 @@ predicate contextProviderFieldR3VarIndirectSpreadD1(int ctxSym, string fieldName
         JsxElement(elem, tagNode, _) and
         FieldRead(tagNode, ctxSym, "Provider") and
         JsxAttribute(elem, "value", valueAttrExpr) and
-        resolveToObjectExpr(valueAttrExpr, objExpr) and
+        mayResolveToObjectExpr(valueAttrExpr, objExpr) and
         objectLiteralFieldSpreadD1(objExpr, fieldName, valueExpr) and
         ExprMayRef(valueExpr, valueSym)
     )
@@ -869,7 +859,7 @@ predicate contextProviderFieldR3VarIndirectSpreadD2(int ctxSym, string fieldName
         JsxElement(elem, tagNode, _) and
         FieldRead(tagNode, ctxSym, "Provider") and
         JsxAttribute(elem, "value", valueAttrExpr) and
-        resolveToObjectExpr(valueAttrExpr, objExpr) and
+        mayResolveToObjectExpr(valueAttrExpr, objExpr) and
         objectLiteralFieldSpreadD2(objExpr, fieldName, valueExpr) and
         ExprMayRef(valueExpr, valueSym)
     )

--- a/setstate_context_alias_r3_integration_test.go
+++ b/setstate_context_alias_r3_integration_test.go
@@ -154,10 +154,11 @@ func TestR3_LinkPredicates(t *testing.T) {
 	bridgeFiles := bridge.LoadBridge()
 	importLoader := makeBridgeImportLoader(bridgeFiles)
 
-	// PR3: tsq::valueflow added because tsq_react.qll's resolveToObjectExpr
-	// now calls into mayResolveToObjectExpr, which depends on mayResolveTo
-	// from tsq_valueflow.qll. Without this import the union silently
-	// returns only the surviving non-valueflow branches.
+	// PR3 / Phase D PR6: tsq::valueflow imported because
+	// `mayResolveToObjectExpr` (and `contextProviderFieldR3VarIndirect*`
+	// which calls it) depends on `mayResolveToRec` from tsq_valueflow.qll.
+	// Without this import the union silently returns only the surviving
+	// non-valueflow branches.
 	common := "import tsq::react\nimport tsq::valueflow\nimport tsq::base\nimport tsq::expressions\nimport tsq::functions\nimport tsq::calls\n"
 
 	type qcase struct {
@@ -215,8 +216,12 @@ func TestR3_LinkPredicates(t *testing.T) {
 		// regressions, just against the new (post-PR6) surface area.
 		{"mayResolveToObjectExpr", common + "from int v, int o where mayResolveToObjectExpr(v, o) select v, o", 19, true},
 		{"resolveToObjectExprWrapped", common + "from int v, int o where resolveToObjectExprWrapped(v, o) select v, o", 1, false},
-		// resolveToObjectExpr should fire for at least Indirect (1), Computed (1).
-		{"resolveToObjectExpr", common + "from int v, int o where resolveToObjectExpr(v, o) select v, o", 2, false},
+		// Phase D PR6 (20 Apr 2026): `resolveToObjectExpr` predicate deleted
+		// from tsq_react.qll. It had become a trivial one-line alias for
+		// `mayResolveToObjectExpr` after Phase C PR6. The exact-pinned
+		// `mayResolveToObjectExpr` row above (19 rows) is the canonical
+		// regression guard for the union; the old row here was a
+		// floor-of-2 that the 19-row union trivially subsumed.
 		// objectLiteralFieldThroughSpread: Indirect(2) + Spread(2 own + 1 spread) + Computed(2) + Negative(0) = 7
 		{"objectLiteralFieldOwn", common + "from int o, string f, int v where objectLiteralFieldOwn(o, f, v) select o, f, v", 5, false},
 		{"objectLiteralFieldSpreadD1", common + "from int o, string f, int v where objectLiteralFieldSpreadD1(o, f, v) select o, f, v", 1, false},


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Summary

Preparatory cleanup ahead of plan-PR7 (R1–R4 deletion) — narrow
scope: delete the now-dead Phase A `resolveToObjectExpr` wrapper
that became a trivial one-line identity alias for
`mayResolveToObjectExpr` after Phase C PR6 migrated onto the
recursive closure. Redirect three in-file callers. Drop the stale
test assertion.

**Scope framing (adversarial-review finding 1).** The branch name
(`feat/valueflow-phase-d-pr6-react-final`) is a legacy label from
an earlier slotting. Per the current plan doc
(`docs/design/valueflow-phase-d-plan.md`), **plan-PR6 is
`compat_tainttracking.qll`** (future work, not this PR), and the
full R1–R4 shape-predicate deletion (~600 LoC) is **plan-PR7**,
gated on the Phase D measurement matrix.

This PR is neither plan-PR6 nor plan-PR7 in full. It is a
**PR7-preparatory sliver** — one 3-line identity-alias deletion
lifted out of plan-PR7 early because it's blocker-free, has zero
external consumers, and gives us a small signal that the deletion
paths work cleanly before the big R1–R4 cut. Branch name stays
(renaming requires force-push; not worth the churn — this PR-body
reframe is the record).

## Changelog

- **Removed**: `resolveToObjectExpr` (identity alias, zero external
  consumers, subsumed by `mayResolveToObjectExpr`).

## Changes

- **bridge/tsq_react.qll**
  - Delete `predicate resolveToObjectExpr` (3-line trivial alias onto
    `mayResolveToObjectExpr`).
  - Redirect the three in-file callers
    (`contextProviderFieldR3VarIndirect{Own,SpreadD1,SpreadD2}`) to
    `mayResolveToObjectExpr` directly.
  - Update stale doc comment on `contextProviderFieldR3VarIndirectOwn`.
  - Add a header note explaining what was deleted and why
    `resolveToObjectExprWrapped` is kept (carve-out — see below).
- **setstate_context_alias_r3_integration_test.go**
  - Drop the now-impossible `resolveToObjectExpr` link-predicate row.
    The exact-pinned `mayResolveToObjectExpr` row (19 rows) remains
    as the canonical regression guard.
  - Refresh the tsq::valueflow-import breadcrumb comment to refer to
    `mayResolveToRec` instead of the deleted alias.

Net LoC: +25 / −30 (−5).

## Scope-outs (rule c / rule d honest accounting)

- `resolveToObjectExprWrapped` — **kept** as a carve-out.
  - Honest framing (adversarial-review finding 2): kept because the
    r3 regression test measures it directly; parity check with
    `mayResolveToObjectExprJsxWrapped` is deferred alongside the
    `lfsJsxExpressionUnwrap` step-promotion per the in-tree
    docstring (`bridge/tsq_react.qll`, line 611). The structural
    argument (direct `Contains(v, o) ∧ isObjectLiteralExpr(o)`
    unwrap vs closure shape) is real but secondary — the in-tree
    docstring is already honest about it being test-harness-shaped,
    and retirement is gated on the `lfsJsxExpressionUnwrap`
    migration in `extract/rules/localflowstep.go`, not on this PR.
- The Phase A non-recursive `mayResolveTo` in `tsq_valueflow.qll`
  (PHASE-C-PR6 NOTE) — **kept**. Consumed by `tsq_dataflow.qll:63`
  and `resolvesToFunctionDirect` in `tsq_valueflow.qll:309`. Those
  belong to Phase D PR4/PR5 (compat_dataflow / taint rewrites), not
  this react-layer cleanup.

## Regression guards

- (a) Surviving predicates still have non-zero fixture assertions.
  The r3 link-predicate test continues to pin `mayResolveToObjectExpr`
  = 19 (exact), `resolveToObjectExprWrapped` = 1, and all
  `contextProviderFieldR3VarIndirect*` consumer rows unchanged.
- (b) No floors adjusted.
- (c) Subsumption proof: `resolveToObjectExpr`'s body was **literally**
  `mayResolveToObjectExpr(valueExpr, objExpr)` — identity mapping.
  Every row of the former = exactly a row of the latter. The three
  consumer-site redirects are semantics-preserving by construction.
  On the r3 fixture: former would produce 19 rows (identical to
  `mayResolveToObjectExpr`); the historical floor of 2 was trivially
  subsumed.
- (d) `resolveToObjectExprWrapped` carve-out justified above
  (direct test consumer, deferred retirement path documented
  in-code).
- (f) Manifest — `grep resolveToObjectExpr bridge/manifest.go` → no
  matches. No manifest entries affected.
- (g) N/A — no recursive IDBs touched.

## Mutation probe (PR #206 blocker)

Replaced `mayResolveToObjectExpr`'s body with `none()`. Ran the R3
link-predicate suite:

```
contextProviderFieldR3VarIndirect  rows=0 (>=4 expected)   FAIL
contextProviderField               rows=2 (==6 expected)   FAIL
useStateSetterAliasV2              rows=9 (==13 expected)  FAIL
useStateSetterContextAliasCall     rows=2 (==6 expected)   FAIL
isContextAliasedSetterSym          rows=2 (>=6 expected)   FAIL
contextSetterAliasStep             rows=2 (>=6 expected)   FAIL
```

Mutation fails as required — confirms the migrated consumers
genuinely consume the closure. Reverted before commit.

## Subsumption table

| Predicate | Before (rows) | After (rows) | Relationship |
|---|---|---|---|
| `resolveToObjectExpr` | identical to `mayResolveToObjectExpr` (alias) | **deleted** | Identity-equal to surviving `mayResolveToObjectExpr` |
| `mayResolveToObjectExpr` | 19 (pinned exact) | 19 (pinned exact) | Unchanged |
| `resolveToObjectExprWrapped` | 1 (kept carve-out) | 1 (kept carve-out) | Unchanged |
| `contextProviderFieldR3VarIndirect` | 4 | 4 | Unchanged — identity redirect |

## Tests

Baseline before deletion: full `go test -timeout 600s ./...` → all 18
packages green.
After deletion: full `go test -timeout 600s ./...` → all 18 packages
green. Wall time effectively unchanged (~35s).

No fixture row counts changed in the test suite (the only row that
was removed was the now-impossible `resolveToObjectExpr` query
itself).

## Test plan

- [ ] CI green on the PR
- [ ] Adversarial review checks: semantic equivalence of the three
      consumer redirects; rule-d justification for
      `resolveToObjectExprWrapped` carve-out holds up; no lingering
      references to deleted predicate in .qll files
- [ ] No merge until adversarial review passes (per Cain standing
      instruction)
