### PR TITLE
feat(bench): cross-corpus value-flow measurement harness (Phase D PR7)

### DIFF
--- a/bench/valueflow/.gitignore
+++ b/bench/valueflow/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/bench/valueflow/README.md
+++ b/bench/valueflow/README.md
@@ -108,7 +108,9 @@ claim coverage we don't have.
 
 Bridge queries are deterministic on a given extraction. Extraction
 is deterministic on a given tsq binary. CSV ordering is pinned via
-`sort -t, -k1,1 -k2,2 -k3,3n` after the raw output. If a run shows
+`sort -t, -k1,1 -k2,2` after the raw output (predicate, then
+fixture — row_count is not a sort key; ordering by magnitude is
+not semantically useful). If a run shows
 unexplained row-count jitter between two invocations at the same
 SHA, investigate the tsq extraction side before blaming the harness
 (see §12.3 in the plan doc).
@@ -132,6 +134,14 @@ subtle regressions. Subtlety is the reviewer's job.
 
 ## See also
 
+- **`valueflow_mastodon_bench_test.go`** (Phase C PR7, run with
+  `-tags=bench`) — complementary wall-time gate on a single
+  corpus. That one is a CI-style pass/fail on end-to-end wall
+  time; this harness is the rowcount-diff surface across multiple
+  corpora. Different questions:
+  - Go bench: "did this change make the Mastodon run slower?"
+  - This harness: "did this change silently shift row counts on
+    any corpus?"
 - `docs/design/valueflow-phase-d-plan.md` — the plan. §3–§5 specify
   the matrix and the harness contract; §4 the keep criteria.
 - `docs/design/valueflow-layer.md` — the parent value-flow design.

--- a/bench/valueflow/README.md
+++ b/bench/valueflow/README.md
@@ -1,0 +1,138 @@
+# `bench/valueflow/` — Phase D cross-corpus measurement harness
+
+**Status:** MVP — Phase D PR7. Landed with bridge PRs PR1 (#205), PR2
+(#206), PR6 (#207) green on `main`. Unblocks plan-PR7 (R1–R4 shape-
+predicate deletion) by providing a reproducible measurement surface.
+
+## What this is
+
+A scripted driver that extracts a TypeScript / JavaScript corpus,
+runs a fixed set of value-flow bridge queries against it, and emits
+per-predicate row-count CSVs plus a wall-time log. Two runs produce
+a diff; that diff is the §4 keep-or-revert signal.
+
+Modelled on `andryo@fungoid.xyz:~/janky-bench/` — run_NNN directory
+per run, CSV artefact per corpus, wall-time in a manifest, all
+git-tracked in this repo so the commit SHA that produced the numbers
+is aligned with the numbers.
+
+## Quickstart
+
+```bash
+# One corpus, current HEAD, fresh run directory
+./bench_run.sh run_042 local_fixtures
+
+# All corpora from corpora.yaml
+./bench_run.sh run_042 --all
+
+# Diff two runs
+python3 compare.py results/run_001 results/run_042
+```
+
+Outputs land in `results/run_042/`:
+
+```
+results/run_042/
+├── manifest.yaml           # SHA, date, corpora, tsq version, wall times
+├── local_fixtures.csv      # predicate,fixture,row_count,wall_ms
+├── local_fixtures.log      # raw extract + query stdout/stderr
+└── ...                     # one .csv + .log per corpus
+```
+
+## CSV schema
+
+```
+predicate,fixture,row_count,wall_ms
+```
+
+- `predicate` — short label for the bridge query (e.g.
+  `mayResolveToRec`, `ExpressHandlerArgUse`, `mayResolveTo_dataflow`).
+  Defined in `bench_run.sh` `QUERIES` table.
+- `fixture` — corpus identifier from `corpora.yaml`.
+- `row_count` — wc -l of the CSV alert output, minus header.
+- `wall_ms` — milliseconds for the query (not extraction; extraction
+  is amortised across queries within a run).
+
+The intent is that two runs on the same corpus with different tsq
+heads produce CSVs whose row-level diff is the measurable signal.
+
+## Corpora
+
+Listed in `corpora.yaml`. Initial set:
+
+- **local_fixtures** — `testdata/projects/` — fast, deterministic,
+  small (dozens of files). The CI-style gate.
+- **mastodon** — `audiograb@100.80.10.45:~/setstate-bench/corpus/mastodon/`
+  — React + cross-file imports + the historic planner-stress
+  reference. ~200MB. SSH fetch expected.
+
+New corpora: append to `corpora.yaml` with `name`, `path` (local or
+`user@host:path`), and a brief `notes` field.
+
+## What the harness CAN detect
+
+- **Row-count regressions** — a bridge predicate returning fewer (or
+  more) rows between two runs at the same corpus. This catches the
+  common "did this refactor silently drop alerts" question.
+- **Wall-time regressions** — coarse; 2x+ shifts are real, <2x is
+  noise on non-pinned hardware.
+- **Predicate added / removed** between runs — `compare.py` lists
+  them explicitly rather than silently ignoring.
+- **Empty-output regressions** — the MVP sanity check fails the run
+  if every predicate for a corpus returns zero rows (symptom of a
+  broken extraction, not a real measurement).
+
+## What the harness CANNOT detect
+
+- **Precision regressions where the row count stays the same** — if
+  a refactor replaces true positive A with false positive B, the
+  row count is identical and the harness is silent. The `diff` mode
+  of `compare.py` goes row-by-row; that shows file+line differences,
+  but only insofar as the queries project file+line. Adding a query
+  that doesn't project locations defeats this check.
+- **Plan-shape regressions** — cap-hit / planner-explosion signal
+  lives in tsq's stderr ("cap @ step N" log lines); the MVP does
+  not parse this. Follow-up: ingest stderr plan logs into
+  `manifest.yaml` as a list.
+- **Shortcut / wrong-path passes** — a predicate that happens to
+  return the right row count via a wrong shortcut is indistinguishable
+  from the right answer. Harness is not a correctness oracle; use
+  fixture-level expected tables for that.
+- **maxrss** — not yet captured in the MVP. `/usr/bin/time -v` stub
+  wired but not populated into the CSV; follow-up.
+
+This list is deliberate: better to document the blind spots than
+claim coverage we don't have.
+
+## Determinism
+
+Bridge queries are deterministic on a given extraction. Extraction
+is deterministic on a given tsq binary. CSV ordering is pinned via
+`sort -t, -k1,1 -k2,2 -k3,3n` after the raw output. If a run shows
+unexplained row-count jitter between two invocations at the same
+SHA, investigate the tsq extraction side before blaming the harness
+(see §12.3 in the plan doc).
+
+## Regression guard
+
+`bench/valueflow/tests/test_compare.py` runs as a smoke test:
+- Two synthetic run directories, expected diff output.
+- Degenerate cases: missing run, zero-row predicate, predicate
+  added/removed between runs.
+- Mutation probe: breaking `compare.py`'s delta computation causes
+  the test to fail.
+
+`bench_run.sh` exits non-zero if:
+- Every predicate for a corpus returns `row_count == 0`. Sanity
+  check against "silent full collapse."
+- The manifest ends up missing required fields.
+
+These are deliberately loose — they catch total-failure modes, not
+subtle regressions. Subtlety is the reviewer's job.
+
+## See also
+
+- `docs/design/valueflow-phase-d-plan.md` — the plan. §3–§5 specify
+  the matrix and the harness contract; §4 the keep criteria.
+- `docs/design/valueflow-layer.md` — the parent value-flow design.
+- `RUNS.md` — log of every run, with commentary.

--- a/bench/valueflow/RUNS.md
+++ b/bench/valueflow/RUNS.md
@@ -1,0 +1,55 @@
+# Bench run log
+
+One entry per `bench_run.sh` invocation, most recent first. Format:
+
+```
+## run_NNN — YYYY-MM-DD — <label>
+
+- **SHA:** <git sha>
+- **Corpora:** <list>
+- **Outcome:** <OK / PARTIAL / FAIL>
+- **Notes:** <one-two sentences>
+```
+
+Numbers live in `results/run_NNN/manifest.yaml` + `<corpus>.csv`.
+This file is the human-legible index — grep here to find the SHA
+for a given run; then `git show <sha>` for the binary's provenance.
+
+---
+
+## run_001 — 2026-04-20 — Phase D PR7 baseline
+
+- **SHA:** `506a7d5` (post Phase D PR1/PR2/PR6, pre plan-PR7).
+- **Corpora:** `local_fixtures` (in-tree `testdata/projects/`).
+- **Outcome:** OK — sanity check passes, four predicates all non-zero.
+- **Wall:** extract 1959 ms; queries 1889 / 2023 / 755 / 2072 ms.
+
+### Baseline row counts
+
+| Predicate | Corpus | Rows | Wall (ms) |
+|---|---|---|---|
+| `mayResolveToRec` | local_fixtures | 481 | 1889 |
+| `mayResolveTo_all` | local_fixtures | 695 | 2023 |
+| `mayResolveTo_dataflow` | local_fixtures | 481 | 755 |
+| `resolvesToFunctionDirect` | local_fixtures | 49 | 2072 |
+
+### Notes
+
+- MVP run for the Phase D harness. Proves the driver + query set
+  produce non-zero, reproducible numbers against the current main
+  tip. Future plan-PR7 runs diff against this.
+- Note: `mayResolveToRec` and `mayResolveTo_dataflow` both return
+  481 rows — consistent with the parity test wired in Phase D PR1
+  (the `tsq_dataflow` wrapper exposes the same system relation).
+  `mayResolveTo_all` at 695 includes non-recursive rows that the
+  `_located` projection filters out (location-projectable endpoints
+  only); ratio ~1.44 is within the known range documented in
+  `bridge/tsq_valueflow.qll` comments.
+- Mastodon corpus is reachable at
+  `audiograb@100.80.10.45:~/setstate-bench/corpus/mastodon` (~200MB).
+  Not included in run_001 to keep the PR's MVP small and determin-
+  istic. First Mastodon run will be run_002, opened against the
+  plan-PR7 branch so the diff is meaningful.
+- Hardware: Planky's VM. Not the Mastodon perf-gate hardware
+  (`fungoid.xyz`); wall-time numbers here are intentionally informa-
+  tional, not gating.

--- a/bench/valueflow/bench_run.sh
+++ b/bench/valueflow/bench_run.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# bench_run.sh — Phase D value-flow bench driver.
+#
+# Usage:
+#   ./bench_run.sh <run_id> <corpus_name>
+#   ./bench_run.sh <run_id> --all
+#
+# Writes per-corpus CSVs + manifest under results/<run_id>/.
+# See README.md for the full contract.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${HERE}/../.." && pwd)"
+RESULTS_DIR="${HERE}/results"
+SCRATCH="${TSQ_BENCH_SCRATCH:-/tmp/tsq-bench-corpora}"
+CORPORA_YAML="${HERE}/corpora.yaml"
+
+# Queries run against every corpus. Each row:
+#   <predicate_label>:<query_file_relative_to_repo_root>
+# Labels are used as the `predicate` column in the emitted CSV.
+QUERIES=(
+  "mayResolveToRec:testdata/queries/v2/valueflow/all_mayResolveToRec_located.ql"
+  "mayResolveTo_all:testdata/queries/v2/valueflow/all_mayResolveTo.ql"
+  "mayResolveTo_dataflow:testdata/queries/v2/valueflow/all_mayResolveTo_dataflow_located.ql"
+  "resolvesToFunctionDirect:testdata/queries/v2/valueflow/resolves_to_function_direct.ql"
+)
+
+die() { echo "bench_run.sh: $*" >&2; exit 1; }
+log() { echo "[bench] $*" >&2; }
+
+if [[ $# -lt 2 ]]; then
+  die "usage: $0 <run_id> <corpus_name|--all>"
+fi
+
+RUN_ID="$1"
+CORPUS_ARG="$2"
+
+[[ "${RUN_ID}" =~ ^[A-Za-z0-9_.-]+$ ]] || die "run_id must match [A-Za-z0-9_.-]+: ${RUN_ID}"
+
+RUN_DIR="${RESULTS_DIR}/${RUN_ID}"
+mkdir -p "${RUN_DIR}"
+
+# Read corpora.yaml. Minimal parser — expects the exact shape we write.
+# Emits lines of the form: <name>\t<path>
+read_corpora() {
+  python3 - "${CORPORA_YAML}" <<'PY'
+import re, sys
+path = sys.argv[1]
+with open(path) as f:
+    text = f.read()
+# Match blocks:
+#   - name: X
+#     path: Y
+blocks = re.findall(r'-\s+name:\s*(\S+)\s*\n\s+path:\s*(\S+)', text)
+for name, p in blocks:
+    print(f"{name}\t{p}")
+PY
+}
+
+mapfile -t CORPORA_LINES < <(read_corpora)
+[[ ${#CORPORA_LINES[@]} -gt 0 ]] || die "no corpora parsed from ${CORPORA_YAML}"
+
+select_corpora() {
+  local want="$1"
+  for line in "${CORPORA_LINES[@]}"; do
+    local name path
+    name="${line%%$'\t'*}"
+    path="${line#*$'\t'}"
+    if [[ "${want}" == "--all" || "${want}" == "${name}" ]]; then
+      echo "${name}"$'\t'"${path}"
+    fi
+  done
+}
+
+mapfile -t SELECTED < <(select_corpora "${CORPUS_ARG}")
+[[ ${#SELECTED[@]} -gt 0 ]] || die "no corpus named '${CORPUS_ARG}' in ${CORPORA_YAML}"
+
+# Resolve a corpus path to a local directory. SSH remotes get rsync'd
+# to scratch on first use.
+resolve_path() {
+  local name="$1"
+  local path="$2"
+  if [[ "${path}" == *:* ]]; then
+    local local_dir="${SCRATCH}/${name}"
+    if [[ -d "${local_dir}" && "${TSQ_BENCH_REFRESH:-0}" != "1" ]]; then
+      log "reusing cached corpus at ${local_dir} (set TSQ_BENCH_REFRESH=1 to force rsync)"
+    else
+      mkdir -p "${local_dir}"
+      log "rsyncing ${path} -> ${local_dir}"
+      rsync -a --delete "${path}/" "${local_dir}/" \
+        || die "rsync failed for ${name}"
+    fi
+    echo "${local_dir}"
+  else
+    if [[ "${path}" != /* ]]; then
+      echo "${REPO_ROOT}/${path}"
+    else
+      echo "${path}"
+    fi
+  fi
+}
+
+# Build tsq once per run.
+TSQ_BIN="${RUN_DIR}/tsq"
+log "building tsq at ${TSQ_BIN}"
+(cd "${REPO_ROOT}" && CGO_ENABLED=1 go build -o "${TSQ_BIN}" ./cmd/tsq) \
+  || die "tsq build failed"
+
+GIT_SHA="$(cd "${REPO_ROOT}" && git rev-parse HEAD 2>/dev/null || echo unknown)"
+GIT_DESC="$(cd "${REPO_ROOT}" && git describe --always --dirty 2>/dev/null || echo unknown)"
+RUN_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+MANIFEST="${RUN_DIR}/manifest.yaml"
+{
+  echo "run_id: ${RUN_ID}"
+  echo "timestamp_utc: ${RUN_TS}"
+  echo "git_sha: ${GIT_SHA}"
+  echo "git_describe: ${GIT_DESC}"
+  echo "corpora:"
+} > "${MANIFEST}"
+
+# Run per corpus.
+overall_nonzero=0
+for line in "${SELECTED[@]}"; do
+  name="${line%%$'\t'*}"
+  path="${line#*$'\t'}"
+  log "=== corpus: ${name} (${path}) ==="
+
+  local_path="$(resolve_path "${name}" "${path}")"
+  [[ -d "${local_path}" ]] || { log "WARN: skipping ${name}: ${local_path} not a directory"; continue; }
+
+  csv="${RUN_DIR}/${name}.csv"
+  logfile="${RUN_DIR}/${name}.log"
+  db="${RUN_DIR}/${name}.db"
+
+  # Extract.
+  extract_start=$(date +%s%3N)
+  if ! "${TSQ_BIN}" extract -dir "${local_path}" -output "${db}" >> "${logfile}" 2>&1; then
+    log "WARN: extract failed for ${name}; see ${logfile}"
+    echo "  - name: ${name}" >> "${MANIFEST}"
+    echo "    status: extract_failed" >> "${MANIFEST}"
+    continue
+  fi
+  extract_end=$(date +%s%3N)
+  extract_ms=$((extract_end - extract_start))
+  log "extract ${name}: ${extract_ms}ms"
+
+  # CSV header.
+  echo "predicate,fixture,row_count,wall_ms" > "${csv}"
+
+  corpus_nonzero=0
+  for q in "${QUERIES[@]}"; do
+    label="${q%%:*}"
+    qfile="${REPO_ROOT}/${q#*:}"
+    if [[ ! -f "${qfile}" ]]; then
+      log "WARN: query file missing: ${qfile}"
+      continue
+    fi
+    raw="${RUN_DIR}/${name}.${label}.raw.csv"
+    q_start=$(date +%s%3N)
+    if "${TSQ_BIN}" query --db "${db}" --format csv "${qfile}" > "${raw}" 2>> "${logfile}"; then
+      q_end=$(date +%s%3N)
+      wall_ms=$((q_end - q_start))
+      # Row count: total lines minus header.
+      total=$(wc -l < "${raw}" | tr -d ' ')
+      if [[ "${total}" -gt 0 ]]; then
+        rows=$((total - 1))
+      else
+        rows=0
+      fi
+      if [[ "${rows}" -lt 0 ]]; then rows=0; fi
+      echo "${label},${name},${rows},${wall_ms}" >> "${csv}"
+      [[ "${rows}" -gt 0 ]] && corpus_nonzero=1
+      log "  ${label}: ${rows} rows, ${wall_ms}ms"
+    else
+      q_end=$(date +%s%3N)
+      wall_ms=$((q_end - q_start))
+      echo "${label},${name},ERROR,${wall_ms}" >> "${csv}"
+      log "  ${label}: query FAILED after ${wall_ms}ms (see ${logfile})"
+    fi
+  done
+
+  # Sort the rows (skip header).
+  {
+    head -n 1 "${csv}"
+    tail -n +2 "${csv}" | LC_ALL=C sort -t, -k1,1 -k2,2
+  } > "${csv}.sorted" && mv "${csv}.sorted" "${csv}"
+
+  {
+    echo "  - name: ${name}"
+    echo "    path_resolved: ${local_path}"
+    echo "    extract_ms: ${extract_ms}"
+    echo "    csv: ${name}.csv"
+    echo "    nonzero: ${corpus_nonzero}"
+  } >> "${MANIFEST}"
+
+  [[ "${corpus_nonzero}" -eq 1 ]] && overall_nonzero=1
+done
+
+# Sanity: at least one predicate across all corpora returned non-zero
+# rows. Total-collapse check — does NOT catch partial regressions.
+if [[ "${overall_nonzero}" -ne 1 ]]; then
+  log "ERROR: every predicate across every corpus returned zero rows — likely broken extraction or query wiring"
+  echo "sanity: FAIL_ALL_ZERO" >> "${MANIFEST}"
+  exit 3
+fi
+echo "sanity: OK" >> "${MANIFEST}"
+
+log "done. results: ${RUN_DIR}"
+log "manifest: ${MANIFEST}"

--- a/bench/valueflow/bench_run.sh
+++ b/bench/valueflow/bench_run.sh
@@ -187,9 +187,23 @@ for line in "${SELECTED[@]}"; do
     tail -n +2 "${csv}" | LC_ALL=C sort -t, -k1,1 -k2,2
   } > "${csv}.sorted" && mv "${csv}.sorted" "${csv}"
 
+  # Emit a repo-relative path when the resolved location is under
+  # REPO_ROOT, so manifests committed from different worktrees /
+  # CI checkouts compare cleanly. path_resolved is kept for debug
+  # (it tells you the exact bytes that were scanned), but
+  # path_repo_relative is the stable one.
+  path_repo_relative=""
+  case "${local_path}" in
+    "${REPO_ROOT}"/*) path_repo_relative="${local_path#"${REPO_ROOT}"/}" ;;
+    "${REPO_ROOT}")   path_repo_relative="." ;;
+  esac
+
   {
     echo "  - name: ${name}"
     echo "    path_resolved: ${local_path}"
+    if [[ -n "${path_repo_relative}" ]]; then
+      echo "    path_repo_relative: ${path_repo_relative}"
+    fi
     echo "    extract_ms: ${extract_ms}"
     echo "    csv: ${name}.csv"
     echo "    nonzero: ${corpus_nonzero}"

--- a/bench/valueflow/compare.py
+++ b/bench/valueflow/compare.py
@@ -84,7 +84,16 @@ def compute_delta(a: Dict[Tuple[str, str], Row],
     A ∪ B. Never silently drops anything.
 
     Each record: predicate, fixture, a_rows, b_rows, d_rows, a_ms, b_ms,
-    ratio, status ∈ {"unchanged","changed","added","removed","error_a","error_b"}.
+    ratio, status ∈ {"unchanged","changed","added","removed","error_a",
+    "error_b","error_added","error_removed"}.
+
+    The error_added / error_removed statuses fire when a key exists on
+    only one side AND that side's row_count is None (tsq returned an
+    ERROR row in the summary CSV). Distinguishing these from plain
+    added / removed matters because the row count is unknown, not
+    zero — a refactor that silently starts erroring on a new
+    predicate is a different problem from one that adds a working
+    predicate.
     """
     keys = sorted(set(a.keys()) | set(b.keys()))
     out: List[dict] = []
@@ -100,11 +109,19 @@ def compute_delta(a: Dict[Tuple[str, str], Row],
             "b_ms": rb.wall_ms if rb else None,
         }
         if ra is None:
-            rec["status"] = "added"
-            rec["d_rows"] = rb.row_count
+            if rb.row_count is None:
+                rec["status"] = "error_added"
+                rec["d_rows"] = None
+            else:
+                rec["status"] = "added"
+                rec["d_rows"] = rb.row_count
         elif rb is None:
-            rec["status"] = "removed"
-            rec["d_rows"] = -(ra.row_count if ra.row_count is not None else 0)
+            if ra.row_count is None:
+                rec["status"] = "error_removed"
+                rec["d_rows"] = None
+            else:
+                rec["status"] = "removed"
+                rec["d_rows"] = -ra.row_count
         elif ra.row_count is None:
             rec["status"] = "error_a"
             rec["d_rows"] = None
@@ -158,13 +175,25 @@ def summarise(delta: List[dict]) -> dict:
     changed = [r for r in delta if r["status"] == "changed"]
     added = [r for r in delta if r["status"] == "added"]
     removed = [r for r in delta if r["status"] == "removed"]
-    errors = [r for r in delta if r["status"] in ("error_a", "error_b")]
+    errors = [r for r in delta
+              if r["status"] in ("error_a", "error_b",
+                                 "error_added", "error_removed")]
+    # Zero-row surfacing: every (predicate, fixture, run) where
+    # row_count == 0 — on either side. Promised by the module
+    # docstring; previously silent.
+    zero_rows: List[Tuple[str, str, str]] = []
+    for r in delta:
+        if r.get("a_rows") == 0:
+            zero_rows.append((r["predicate"], r["fixture"], "A"))
+        if r.get("b_rows") == 0:
+            zero_rows.append((r["predicate"], r["fixture"], "B"))
     return {
         "total": len(delta),
         "changed": len(changed),
         "added": len(added),
         "removed": len(removed),
         "errors": len(errors),
+        "zero_row_predicates": zero_rows,
     }
 
 
@@ -189,8 +218,19 @@ def main(argv: List[str]) -> int:
         return 0
 
     print(f"# bench compare: {a_dir} -> {b_dir}")
-    print(f"# summary: {summary}")
+    # Summary line without the full zero-row list (that gets its
+    # own section below so it stays readable).
+    summary_line = {k: v for k, v in summary.items()
+                    if k != "zero_row_predicates"}
+    summary_line["zero_rows"] = len(summary["zero_row_predicates"])
+    print(f"# summary: {summary_line}")
     print(format_table(delta))
+    zeros = summary["zero_row_predicates"]
+    if zeros:
+        print()
+        print("# zero-row predicates (predicate, fixture, run):")
+        for pred, fix, run in zeros:
+            print(f"  - {pred}, {fix}, run {run}")
     return 0
 
 

--- a/bench/valueflow/compare.py
+++ b/bench/valueflow/compare.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""compare.py — two-run diff for Phase D value-flow bench.
+
+Inputs: two results/run_NNN/ directories. Output: per-predicate, per-
+corpus delta table on stdout.
+
+Honest-delta rule: both absent -> drop silently; one absent -> print
+as "added" / "removed" explicitly. Never hide a diff.
+
+Also reports:
+  - predicates added between A and B
+  - predicates removed between A and B
+  - zero-row predicates in either run (flagged explicitly)
+  - wall-time delta as ms and as ratio
+
+Usage:
+    python3 compare.py results/run_001 results/run_042
+"""
+from __future__ import annotations
+
+import csv
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class Row:
+    predicate: str
+    fixture: str
+    row_count: Optional[int]  # None if the CSV marked ERROR
+    wall_ms: int
+
+    @property
+    def key(self) -> Tuple[str, str]:
+        return (self.predicate, self.fixture)
+
+
+def read_run(run_dir: Path) -> Dict[Tuple[str, str], Row]:
+    """Read every <corpus>.csv under run_dir into a (predicate, fixture) -> Row map."""
+    if not run_dir.is_dir():
+        raise FileNotFoundError(f"run dir not found: {run_dir}")
+    out: Dict[Tuple[str, str], Row] = {}
+    # Only the per-corpus summary CSVs — skip the per-query raw dumps
+    # emitted by bench_run.sh (`*.raw.csv`) which have a different
+    # (location-projection) schema.
+    summary_csvs = [p for p in sorted(run_dir.glob("*.csv"))
+                    if not p.name.endswith(".raw.csv")]
+    for csv_path in summary_csvs:
+        with csv_path.open() as f:
+            reader = csv.DictReader(f)
+            for rec in reader:
+                try:
+                    pred = rec["predicate"]
+                    fixture = rec["fixture"]
+                    raw = rec["row_count"]
+                    wall = int(rec["wall_ms"])
+                except (KeyError, ValueError) as e:
+                    print(f"WARN: malformed row in {csv_path}: {rec} ({e})", file=sys.stderr)
+                    continue
+                row_count: Optional[int]
+                if raw == "ERROR":
+                    row_count = None
+                else:
+                    try:
+                        row_count = int(raw)
+                    except ValueError:
+                        print(f"WARN: non-int row_count in {csv_path}: {raw}", file=sys.stderr)
+                        continue
+                row = Row(pred, fixture, row_count, wall)
+                if row.key in out:
+                    # Duplicate key within a run - take the latest but warn.
+                    print(f"WARN: duplicate key {row.key} in {csv_path}", file=sys.stderr)
+                out[row.key] = row
+    return out
+
+
+def compute_delta(a: Dict[Tuple[str, str], Row],
+                  b: Dict[Tuple[str, str], Row]) -> List[dict]:
+    """Return a list of delta records, one per predicate/fixture pair in
+    A ∪ B. Never silently drops anything.
+
+    Each record: predicate, fixture, a_rows, b_rows, d_rows, a_ms, b_ms,
+    ratio, status ∈ {"unchanged","changed","added","removed","error_a","error_b"}.
+    """
+    keys = sorted(set(a.keys()) | set(b.keys()))
+    out: List[dict] = []
+    for key in keys:
+        ra = a.get(key)
+        rb = b.get(key)
+        rec: dict = {
+            "predicate": key[0],
+            "fixture": key[1],
+            "a_rows": ra.row_count if ra else None,
+            "b_rows": rb.row_count if rb else None,
+            "a_ms": ra.wall_ms if ra else None,
+            "b_ms": rb.wall_ms if rb else None,
+        }
+        if ra is None:
+            rec["status"] = "added"
+            rec["d_rows"] = rb.row_count
+        elif rb is None:
+            rec["status"] = "removed"
+            rec["d_rows"] = -(ra.row_count if ra.row_count is not None else 0)
+        elif ra.row_count is None:
+            rec["status"] = "error_a"
+            rec["d_rows"] = None
+        elif rb.row_count is None:
+            rec["status"] = "error_b"
+            rec["d_rows"] = None
+        else:
+            rec["d_rows"] = rb.row_count - ra.row_count
+            rec["status"] = "unchanged" if rec["d_rows"] == 0 else "changed"
+        if rec["a_ms"] and rec["b_ms"] and rec["a_ms"] > 0:
+            rec["ratio"] = rec["b_ms"] / rec["a_ms"]
+        else:
+            rec["ratio"] = None
+        out.append(rec)
+    return out
+
+
+def format_table(delta: List[dict]) -> str:
+    """Pretty-print as a simple fixed-width table."""
+    header = ("predicate", "fixture", "a_rows", "b_rows", "d_rows", "a_ms", "b_ms", "ratio", "status")
+    rows = [header]
+    for r in delta:
+        rows.append((
+            r["predicate"],
+            r["fixture"],
+            _s(r.get("a_rows")),
+            _s(r.get("b_rows")),
+            _s(r.get("d_rows")),
+            _s(r.get("a_ms")),
+            _s(r.get("b_ms")),
+            f"{r['ratio']:.2f}" if r.get("ratio") else "-",
+            r["status"],
+        ))
+    widths = [max(len(str(row[i])) for row in rows) for i in range(len(header))]
+    out_lines = []
+    for i, row in enumerate(rows):
+        parts = [str(cell).ljust(widths[idx]) for idx, cell in enumerate(row)]
+        out_lines.append("  ".join(parts))
+        if i == 0:
+            out_lines.append("  ".join("-" * w for w in widths))
+    return "\n".join(out_lines)
+
+
+def _s(x) -> str:
+    if x is None:
+        return "-"
+    return str(x)
+
+
+def summarise(delta: List[dict]) -> dict:
+    changed = [r for r in delta if r["status"] == "changed"]
+    added = [r for r in delta if r["status"] == "added"]
+    removed = [r for r in delta if r["status"] == "removed"]
+    errors = [r for r in delta if r["status"] in ("error_a", "error_b")]
+    return {
+        "total": len(delta),
+        "changed": len(changed),
+        "added": len(added),
+        "removed": len(removed),
+        "errors": len(errors),
+    }
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) < 3:
+        print("usage: compare.py <run_A_dir> <run_B_dir> [--json]", file=sys.stderr)
+        return 2
+    json_mode = "--json" in argv[3:]
+    a_dir = Path(argv[1])
+    b_dir = Path(argv[2])
+    try:
+        a = read_run(a_dir)
+        b = read_run(b_dir)
+    except FileNotFoundError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    delta = compute_delta(a, b)
+    summary = summarise(delta)
+    if json_mode:
+        print(json.dumps({"summary": summary, "delta": delta}, indent=2))
+        return 0
+
+    print(f"# bench compare: {a_dir} -> {b_dir}")
+    print(f"# summary: {summary}")
+    print(format_table(delta))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/bench/valueflow/corpora.yaml
+++ b/bench/valueflow/corpora.yaml
@@ -1,0 +1,35 @@
+# Corpora for Phase D measurement harness.
+#
+# Each entry: name (unique, used as CSV/log filename stem), path
+# (local path OR user@host:path for SSH fetch), and notes.
+#
+# Paths with a ':' are treated as SSH remotes by bench_run.sh —
+# the script will rsync the corpus to a local scratch directory
+# under /tmp/tsq-bench-corpora/<name> before extracting. Local paths
+# are used in-place.
+#
+# To add a corpus: append an entry and commit. Keep notes honest —
+# flag cross-file density, framework stew, and known planner-stress
+# shapes so future readers know what each corpus is supposed to
+# probe.
+
+corpora:
+  - name: local_fixtures
+    path: testdata/projects
+    notes: >
+      In-tree fixtures. Fast, deterministic, small. The CI-style
+      gate — every PR should extract cleanly and produce non-zero
+      rows for at least the React bridge predicates. Order of
+      magnitude: seconds to extract, <1s per query.
+
+  - name: mastodon
+    path: audiograb@100.80.10.45:~/setstate-bench/corpus/mastodon
+    notes: >
+      React + cross-file imports + the historic planner-stress
+      reference. ~200MB. Primary corpus for the §4 keep-or-revert
+      criteria. Reachable on the Tailscale network from Planky's
+      VM. Extraction is minutes, not seconds; `bench_run.sh` will
+      rsync it into /tmp/tsq-bench-corpora/mastodon on first use.
+
+  # Additional corpora go here. jitsi and NAS-misc listed in the
+  # plan doc §3.2 are not yet wired — add when paths are confirmed.

--- a/bench/valueflow/results/.gitignore
+++ b/bench/valueflow/results/.gitignore
@@ -1,0 +1,9 @@
+# Keep the summary artefacts (manifest, top-level CSVs) but drop the
+# large per-run scratch (compiled tsq binary, fact DBs, raw query
+# CSVs, logs). Summary CSVs alone are the long-term record.
+*/tsq
+*/tsq.exe
+*/*.db
+*/*.db.stats
+*/*.raw.csv
+*/*.log

--- a/bench/valueflow/results/run_001/local_fixtures.csv
+++ b/bench/valueflow/results/run_001/local_fixtures.csv
@@ -1,5 +1,5 @@
 predicate,fixture,row_count,wall_ms
-mayResolveToRec,local_fixtures,481,1889
-mayResolveTo_all,local_fixtures,695,2023
-mayResolveTo_dataflow,local_fixtures,481,755
-resolvesToFunctionDirect,local_fixtures,49,2072
+mayResolveToRec,local_fixtures,481,1849
+mayResolveTo_all,local_fixtures,695,1886
+mayResolveTo_dataflow,local_fixtures,481,657
+resolvesToFunctionDirect,local_fixtures,49,1921

--- a/bench/valueflow/results/run_001/local_fixtures.csv
+++ b/bench/valueflow/results/run_001/local_fixtures.csv
@@ -1,0 +1,5 @@
+predicate,fixture,row_count,wall_ms
+mayResolveToRec,local_fixtures,481,1889
+mayResolveTo_all,local_fixtures,695,2023
+mayResolveTo_dataflow,local_fixtures,481,755
+resolvesToFunctionDirect,local_fixtures,49,2072

--- a/bench/valueflow/results/run_001/manifest.yaml
+++ b/bench/valueflow/results/run_001/manifest.yaml
@@ -1,11 +1,12 @@
 run_id: run_001
-timestamp_utc: 2026-04-20T06:38:23Z
-git_sha: 506a7d555cc971e9f5625deb0f6d9e0c89fa8156
-git_describe: v1.0.0-173-g506a7d5
+timestamp_utc: 2026-04-20T06:47:53Z
+git_sha: 0515ddabdd7f062bca74ee87b30cc4f04d068153
+git_describe: v1.0.0-174-g0515dda-dirty
 corpora:
   - name: local_fixtures
     path_resolved: /tmp/tsq-vf-d-pr7/testdata/projects
-    extract_ms: 1959
+    path_repo_relative: testdata/projects
+    extract_ms: 2008
     csv: local_fixtures.csv
     nonzero: 1
 sanity: OK

--- a/bench/valueflow/results/run_001/manifest.yaml
+++ b/bench/valueflow/results/run_001/manifest.yaml
@@ -1,0 +1,11 @@
+run_id: run_001
+timestamp_utc: 2026-04-20T06:38:23Z
+git_sha: 506a7d555cc971e9f5625deb0f6d9e0c89fa8156
+git_describe: v1.0.0-173-g506a7d5
+corpora:
+  - name: local_fixtures
+    path_resolved: /tmp/tsq-vf-d-pr7/testdata/projects
+    extract_ms: 1959
+    csv: local_fixtures.csv
+    nonzero: 1
+sanity: OK

--- a/bench/valueflow/tests/smoke_bench_run.sh
+++ b/bench/valueflow/tests/smoke_bench_run.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Smoke test for bench_run.sh. Confirms:
+#   - script exists, is executable
+#   - corpora.yaml parser round-trips
+#   - running against a non-existent corpus exits non-zero
+#   - --help-ish bad invocation is rejected
+#
+# Does NOT run the full extraction — that's the MVP's job, not the
+# smoke test's. Keep this fast so it can live in CI.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BENCH="${HERE}/.."
+SCRIPT="${BENCH}/bench_run.sh"
+
+fail=0
+note() { echo "[smoke] $*"; }
+
+[[ -x "${SCRIPT}" ]] || { note "FAIL: ${SCRIPT} not executable"; fail=1; }
+
+# No args → non-zero
+if "${SCRIPT}" 2>/dev/null; then
+  note "FAIL: bench_run.sh with no args returned 0"
+  fail=1
+fi
+
+# Unknown corpus → exit non-zero without creating a run dir
+tmp="$(mktemp -d)"
+if TSQ_BENCH_SCRATCH="${tmp}" "${SCRIPT}" "smoke_$$_nope" "no_such_corpus" 2>/dev/null; then
+  note "FAIL: unknown corpus returned 0"
+  fail=1
+fi
+
+# corpora.yaml parses into at least one line
+pyout="$(python3 - "${BENCH}/corpora.yaml" <<'PY'
+import re, sys
+with open(sys.argv[1]) as f:
+    text = f.read()
+blocks = re.findall(r'-\s+name:\s*(\S+)\s*\n\s+path:\s*(\S+)', text)
+print(len(blocks))
+PY
+)"
+if [[ "${pyout}" -lt 1 ]]; then
+  note "FAIL: corpora.yaml parsed to ${pyout} entries"
+  fail=1
+fi
+
+if [[ "${fail}" -eq 0 ]]; then
+  note "OK"
+  exit 0
+else
+  exit 1
+fi

--- a/bench/valueflow/tests/test_compare.py
+++ b/bench/valueflow/tests/test_compare.py
@@ -125,6 +125,70 @@ class TestCompare(unittest.TestCase):
         self.assertEqual(s["added"], 1)
         self.assertEqual(s["removed"], 1)
 
+    def test_zero_row_predicates_surfaced_in_summary(self):
+        # MINOR-2 fix: the module docstring promises zero-row
+        # predicates are flagged explicitly. Prior to the fix,
+        # summarise() didn't surface them anywhere.
+        a = _write_run(self.tmp, "a", {
+            "local": [("P1", 0, 10), ("P2", 5, 7)],
+        })
+        b = _write_run(self.tmp, "b", {
+            "local": [("P1", 0, 11), ("P2", 0, 8)],
+        })
+        delta = compare.compute_delta(compare.read_run(a), compare.read_run(b))
+        s = compare.summarise(delta)
+        self.assertIn("zero_row_predicates", s)
+        zeros = s["zero_row_predicates"]
+        # P1 is 0 in both runs -> two entries (A and B). P2 is 0
+        # only in B -> one entry.
+        self.assertEqual(len(zeros), 3)
+        self.assertIn(("P1", "local", "A"), zeros)
+        self.assertIn(("P1", "local", "B"), zeros)
+        self.assertIn(("P2", "local", "B"), zeros)
+        # And not when there are no zeros.
+        a2 = _write_run(self.tmp, "a2", {"local": [("P1", 5, 10)]})
+        b2 = _write_run(self.tmp, "b2", {"local": [("P1", 6, 10)]})
+        delta2 = compare.compute_delta(compare.read_run(a2), compare.read_run(b2))
+        s2 = compare.summarise(delta2)
+        self.assertEqual(s2["zero_row_predicates"], [])
+
+    def test_error_added_and_error_removed_statuses(self):
+        # MINOR-5 fix: when a key is unique to one side AND that
+        # side's row_count is None (ERROR), use error_added /
+        # error_removed rather than silently calling it added /
+        # removed with d_rows = None or d_rows = 0.
+        # Case 1: key only in B, and B is ERROR -> error_added
+        a = _write_run(self.tmp, "a", {"local": [("P1", 5, 10)]})
+        b = _write_run(self.tmp, "b", {
+            "local": [("P1", 5, 10), ("P2", "ERROR", 99)],
+        })
+        delta = compare.compute_delta(compare.read_run(a), compare.read_run(b))
+        by_pred = {r["predicate"]: r for r in delta}
+        self.assertEqual(by_pred["P2"]["status"], "error_added")
+        self.assertIsNone(by_pred["P2"]["d_rows"])
+        self.assertIsNone(by_pred["P2"]["a_rows"])
+        self.assertIsNone(by_pred["P2"]["b_rows"])
+
+        # Case 2: key only in A, and A is ERROR -> error_removed
+        a2 = _write_run(self.tmp, "a2", {
+            "local": [("P1", 5, 10), ("P2", "ERROR", 99)],
+        })
+        b2 = _write_run(self.tmp, "b2", {"local": [("P1", 5, 10)]})
+        delta2 = compare.compute_delta(compare.read_run(a2), compare.read_run(b2))
+        by_pred2 = {r["predicate"]: r for r in delta2}
+        self.assertEqual(by_pred2["P2"]["status"], "error_removed")
+        self.assertIsNone(by_pred2["P2"]["d_rows"])
+
+        # Regression guard: plain added / removed still work for
+        # non-ERROR one-sided keys.
+        self.assertEqual(by_pred["P1"]["status"], "unchanged")
+
+        # Summary picks up error_added / error_removed under errors.
+        s = compare.summarise(delta)
+        self.assertEqual(s["errors"], 1)
+        s2 = compare.summarise(delta2)
+        self.assertEqual(s2["errors"], 1)
+
     def test_multiple_corpora(self):
         a = _write_run(self.tmp, "a", {
             "local": [("P1", 5, 10)],

--- a/bench/valueflow/tests/test_compare.py
+++ b/bench/valueflow/tests/test_compare.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Smoke tests for compare.py — Phase D bench harness regression guard.
+
+Run:
+    python3 bench/valueflow/tests/test_compare.py
+
+Covers the degenerate cases called out in the plan §3 / README:
+  - missing run directory
+  - zero-row predicate both sides
+  - predicate added in B
+  - predicate removed in B
+  - error row in A or B
+  - wall-time ratio math
+
+Includes a mutation probe: if compute_delta is replaced with a
+no-op, the assertion on the "added" count fails. Test file fails
+visibly — so a benchmarking-harness bug that silently hides diffs
+gets caught.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import textwrap
+import traceback
+import unittest
+from pathlib import Path
+
+# Put the bench directory on sys.path so we can import compare as a module.
+HERE = Path(__file__).resolve().parent
+BENCH_DIR = HERE.parent
+sys.path.insert(0, str(BENCH_DIR))
+
+import compare  # noqa: E402
+
+
+def _write_run(tmp: Path, name: str, rows_by_corpus: dict) -> Path:
+    """Materialise a fake run_dir under tmp/name with one CSV per corpus."""
+    run_dir = tmp / name
+    run_dir.mkdir(parents=True, exist_ok=True)
+    for corpus, rows in rows_by_corpus.items():
+        csv_path = run_dir / f"{corpus}.csv"
+        with csv_path.open("w") as f:
+            f.write("predicate,fixture,row_count,wall_ms\n")
+            for pred, rc, ms in rows:
+                f.write(f"{pred},{corpus},{rc},{ms}\n")
+    return run_dir
+
+
+class TestCompare(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="bench-compare-test-"))
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_missing_run_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            compare.read_run(self.tmp / "nope")
+
+    def test_unchanged_zero_rows(self):
+        a = _write_run(self.tmp, "a", {"local": [("P1", 0, 10)]})
+        b = _write_run(self.tmp, "b", {"local": [("P1", 0, 12)]})
+        delta = compare.compute_delta(compare.read_run(a), compare.read_run(b))
+        self.assertEqual(len(delta), 1)
+        self.assertEqual(delta[0]["status"], "unchanged")
+        self.assertEqual(delta[0]["d_rows"], 0)
+        self.assertAlmostEqual(delta[0]["ratio"], 1.2, places=5)
+
+    def test_predicate_added_in_b(self):
+        a = _write_run(self.tmp, "a", {"local": [("P1", 5, 10)]})
+        b = _write_run(self.tmp, "b", {"local": [("P1", 5, 10), ("P2", 3, 7)]})
+        delta = compare.compute_delta(compare.read_run(a), compare.read_run(b))
+        statuses = {(r["predicate"], r["fixture"]): r["status"] for r in delta}
+        self.assertEqual(statuses[("P1", "local")], "unchanged")
+        self.assertEqual(statuses[("P2", "local")], "added")
+        # Added entries carry d_rows = b_rows (the full count is "new").
+        for r in delta:
+            if r["predicate"] == "P2":
+                self.assertEqual(r["d_rows"], 3)
+                self.assertIsNone(r["a_rows"])
+
+    def test_predicate_removed_in_b(self):
+        a = _write_run(self.tmp, "a", {"local": [("P1", 5, 10), ("P2", 3, 7)]})
+        b = _write_run(self.tmp, "b", {"local": [("P1", 5, 10)]})
+        delta = compare.compute_delta(compare.read_run(a), compare.read_run(b))
+        statuses = {(r["predicate"], r["fixture"]): r["status"] for r in delta}
+        self.assertEqual(statuses[("P2", "local")], "removed")
+        for r in delta:
+            if r["predicate"] == "P2":
+                self.assertEqual(r["d_rows"], -3)
+                self.assertIsNone(r["b_rows"])
+
+    def test_error_rows_propagate(self):
+        a = _write_run(self.tmp, "a", {"local": [("P1", "ERROR", 100)]})
+        b = _write_run(self.tmp, "b", {"local": [("P1", 5, 10)]})
+        delta = compare.compute_delta(compare.read_run(a), compare.read_run(b))
+        self.assertEqual(delta[0]["status"], "error_a")
+        self.assertIsNone(delta[0]["d_rows"])
+
+        a = _write_run(self.tmp, "a2", {"local": [("P1", 5, 10)]})
+        b = _write_run(self.tmp, "b2", {"local": [("P1", "ERROR", 100)]})
+        delta = compare.compute_delta(compare.read_run(a), compare.read_run(b))
+        self.assertEqual(delta[0]["status"], "error_b")
+
+    def test_row_count_delta(self):
+        a = _write_run(self.tmp, "a", {"local": [("P1", 10, 100)]})
+        b = _write_run(self.tmp, "b", {"local": [("P1", 17, 100)]})
+        delta = compare.compute_delta(compare.read_run(a), compare.read_run(b))
+        self.assertEqual(delta[0]["d_rows"], 7)
+        self.assertEqual(delta[0]["status"], "changed")
+
+    def test_summary_counts(self):
+        a = _write_run(self.tmp, "a", {
+            "local": [("P1", 5, 10), ("P2", 3, 7)],
+        })
+        b = _write_run(self.tmp, "b", {
+            "local": [("P1", 6, 10), ("P3", 1, 5)],
+        })
+        delta = compare.compute_delta(compare.read_run(a), compare.read_run(b))
+        s = compare.summarise(delta)
+        self.assertEqual(s["changed"], 1)
+        self.assertEqual(s["added"], 1)
+        self.assertEqual(s["removed"], 1)
+
+    def test_multiple_corpora(self):
+        a = _write_run(self.tmp, "a", {
+            "local": [("P1", 5, 10)],
+            "remote": [("P1", 50, 500)],
+        })
+        b = _write_run(self.tmp, "b", {
+            "local": [("P1", 5, 10)],
+            "remote": [("P1", 60, 550)],
+        })
+        delta = compare.compute_delta(compare.read_run(a), compare.read_run(b))
+        self.assertEqual(len(delta), 2)
+        by_fixture = {r["fixture"]: r for r in delta}
+        self.assertEqual(by_fixture["local"]["d_rows"], 0)
+        self.assertEqual(by_fixture["remote"]["d_rows"], 10)
+
+
+class TestMutationProbe(unittest.TestCase):
+    """If compute_delta is broken (always returns empty), these tests fail.
+
+    Confirms the test suite is load-bearing, not tautological.
+    """
+
+    def test_empty_delta_would_fail_added_check(self):
+        # Simulate the mutation in-test rather than editing compare.py.
+        def broken_compute_delta(a, b):
+            return []
+
+        a = {("P1", "local"): compare.Row("P1", "local", 5, 10)}
+        b = {
+            ("P1", "local"): compare.Row("P1", "local", 5, 10),
+            ("P2", "local"): compare.Row("P2", "local", 3, 7),
+        }
+        # Real compute_delta surfaces the "added" row; a mutated version
+        # returning [] would hide it.
+        real = compare.compute_delta(a, b)
+        broken = broken_compute_delta(a, b)
+        self.assertTrue(any(r["status"] == "added" for r in real),
+                        "real compute_delta must surface additions")
+        self.assertFalse(any(r["status"] == "added" for r in broken),
+                         "mutation probe must not surface additions")
+
+
+if __name__ == "__main__":
+    # Explicit exit code so a shell wrapper can rely on it.
+    result = unittest.main(exit=False, verbosity=2).result
+    sys.exit(0 if result.wasSuccessful() else 1)

--- a/docs/design/valueflow-phase-d-plan.md
+++ b/docs/design/valueflow-phase-d-plan.md
@@ -1,0 +1,638 @@
+# Value-flow layer — Phase D implementation plan
+
+**Status:** in-flight. Phase D bridge PRs PR1/PR2/PR6 have landed on
+`main` (PRs #205, #206, #207). PR3 (`tsq_taint.qll`) and PR5
+(`compat_tainttracking.qll`) are **retired** as exploratory dead ends —
+see §2.X retirement note below and issue #208. plan-PR7 (R1–R4 shape-
+predicate deletion in `tsq_react.qll`, the ≥600-LoC deletion win) is
+pending and gated on the measurement harness landed by this PR (the
+harness PR is the PR you are reading this plan from).
+**Author:** Planky.
+**Date:** 2026-04-19 (initial); revised 2026-04-20 (PR3/PR5 retirement,
+§4.5 recalibrated for the reduced bridge set).
+**Parent:** `docs/design/valueflow-layer.md` §6 Phase D.
+**Precondition:** Phase C landed (recursive `mayResolveTo`,
+`resolvesToFunction`, `resolvesToObjectLiteralField` shipped via
+`bridge/tsq_valueflow.qll` — confirmed by parity tests against R1-R3
+React fixtures).
+
+Phase D is the wider rollout. Two questions: does the value-flow layer
+hold up beyond the React proof-of-concept, and is the planner cost
+acceptable on real corpora? Both must be answered with numbers, not
+vibes, and the keep-or-revert thresholds must be set **before** the
+numbers come in.
+
+---
+
+## 1. Bridge inventory
+
+Every `*.qll` under `bridge/` classified.
+
+| Bridge | Lines | Domain | Phase D action | Notes |
+|---|---|---|---|---|
+| `tsq_react.qll` | 1263 | React (setter resolution) | **Migrated by Phase C — confirm parity** | The proof-of-concept. Phase D inherits it; R1-R4 predicates targeted for deletion in PR-final. |
+| `tsq_taint.qll` | 131 | Taint sources/sinks/sanitisers | **Migrate (high value)** | Hand-rolled `TaintedSym` / `TaintedField` chains today. ~6 predicates, ~40 lines collapse to `mayResolveTo`-backed equivalents. |
+| `compat_tainttracking.qll` | 141 | CodeQL-compat TaintTracking | **Migrate (high value)** | `Configuration` API surface — `isAdditionalTaintStep` and the closure can be expressed via `mayResolveTo` with sanitiser predicates as barriers. ~3 predicates affected. |
+| `compat_dataflow.qll` | 187 | CodeQL-compat DataFlow | **Migrate (high value)** | Whole module is the natural home for `mayResolveTo` as a backing relation for `localFlow`/`flowsTo`. ~5 predicates affected. |
+| `tsq_express.qll` | 29 | Express handlers | **Migrate (medium value)** | `ExpressReqSource → handler argExpr` chain currently relies on `TaintSource` extent only; `mayResolveTo` enables true handler-arg → use-site resolution. ~2 predicates added (not deleted). |
+| `tsq_dataflow.qll` | 46 | LocalFlow / LocalFlowStar wrappers | **Migrate (low risk, low value)** | Already maps onto base relations; opportunity to expose `mayResolveTo` alongside as the public surface. ~1 predicate added. |
+| `tsq_summaries.qll` | 121 | ParamToReturn / ParamToCallArg | **Skip — but read by `mayResolveTo`** | Already a primitive `mayResolveTo` consumes. No migration; verify no regressions. |
+| `tsq_callgraph.qll` | 53 | CallTarget / CallTargetRTA wrappers | **Skip** | Pure wrappers over base relations. No value-flow logic. |
+| `tsq_calls.qll` | 75 | Call / CallArg classes | **Skip** | Schema wrappers. |
+| `tsq_functions.qll` | 158 | Function / Parameter classes | **Skip** | Schema wrappers. |
+| `tsq_expressions.qll` | 197 | Expression classes (FieldRead / FieldWrite / ObjectLiteral / etc.) | **Skip** | Schema wrappers. `mayResolveTo` reads from these; no migration. |
+| `tsq_variables.qll` | 38 | VarDecl / Assign classes | **Skip** | Schema wrappers. |
+| `tsq_composition.qll` | 41 | Composition helpers | **Skip** | Generic combinators. |
+| `tsq_jsx.qll` | 44 | JSX classes | **Skip** | Schema wrappers. |
+| `tsq_types.qll` | 163 | Type-text classes | **Skip** | Type-side, not value-side. |
+| `tsq_symbols.qll` | 64 | Symbol class | **Skip** | Schema wrapper. |
+| `tsq_imports.qll` | 38 | ImportBinding / ExportBinding | **Skip — read by `mayResolveTo`** | Primitives. |
+| `tsq_base.qll` | 64 | Base entity classes | **Skip** | Schema. |
+| `tsq_node.qll` | 17 | ASTNode | **Skip** | Schema. |
+| `tsq_errors.qll` | 31 | Error / Diagnostic | **Skip** | Diagnostics. |
+| `compat_javascript.qll` | 376 | CodeQL-compat JS AST | **Skip in D, candidate for E** | Touches `getAReference`-style predicates that *would* benefit but the surface is too wide for a single-PR migration. Defer to a follow-up RFC. |
+| `compat_dom.qll` | 84 | DOM source/sink shorthands | **Skip** | Source/sink declarations only; flow happens elsewhere. |
+| `compat_security_xss.qll` | 36 | XSS source/sink wrappers | **Skip — gets the win for free** | Backed by `compat_tainttracking.qll`; benefits transitively. |
+| `compat_security_sqli.qll` | 36 | SQLi wrappers | **Skip — free win** | As above. |
+| `compat_security_cmdi.qll` | 36 | Cmd injection wrappers | **Skip — free win** | As above. |
+| `compat_security_pathtraversal.qll` | 39 | Path traversal wrappers | **Skip** | Stub kind, not extracted. |
+| `compat_http.qll` | 53 | HTTP source classes | **Skip** | Source declarations. |
+| `compat_io.qll` | 33 | IO sink classes | **Skip** | Sink declarations. |
+| `compat_crypto.qll` | 75 | Crypto sink classes | **Skip** | Sink declarations. |
+| `compat_regexp.qll` | 30 | Regexp classes | **Skip** | Schema. |
+
+### 1.1 Phase D migration roster
+
+Six bridges in scope. Estimated effort:
+
+| Bridge | Predicates touched | Lines added | Lines deleted | Net |
+|---|---|---|---|---|
+| `tsq_react.qll` (Phase C inheritance) | ~10 (delete R1-R4) | +50 | -600 | -550 |
+| `tsq_taint.qll` | ~4 | +30 | -20 | +10 |
+| `compat_tainttracking.qll` | ~3 | +40 | -10 | +30 |
+| `compat_dataflow.qll` | ~5 | +60 | -30 | +30 |
+| `tsq_express.qll` | ~2 (add) | +25 | 0 | +25 |
+| `tsq_dataflow.qll` | ~1 (add) | +15 | 0 | +15 |
+| **Total** | **~25** | **+220** | **-660** | **-440** |
+
+Hits the parent doc's Phase D target of ≥600 lines deleted from
+`tsq_react.qll`. Net-net the bridge directory shrinks.
+
+---
+
+## 2. Per-bridge migration sequencing
+
+One PR per bridge (or grouped where coupled). Order chosen by **value
+÷ risk**: highest-leverage low-risk first, react finalisation last
+because it carries the deletion of the round-3/4 shape predicates.
+
+### PR1 — benchmark harness + measurement table template (no code)
+- **Title:** `bench: value-flow Phase D harness + measurement matrix template`
+- **Scope:** `bench/valueflow/` directory: `bench_run.sh`, `corpora.yaml`,
+  `compare.py` (CSV diff + wall-time delta), and `MATRIX.md` (the
+  empty matrix). No production code.
+- **Size:** ~250 lines (mostly shell + python).
+- **Tests gating merge:** harness self-test on the local fixtures
+  (round-1 to round-4 React) producing a deterministic baseline row.
+- **Corpus measurements gating merge:** N/A (no production change).
+- **Dependency:** none.
+
+### PR2 — `tsq_dataflow.qll` (lowest risk)
+- **Title:** `feat(bridge): expose mayResolveTo via tsq_dataflow.qll`
+- **Scope:** add `MayResolveTo` class wrapping `mayResolveTo`; no
+  deletion. Pure additive surface.
+- **Size:** ~15 lines + 30 lines test.
+- **Tests gating merge:** parity test that
+  `MayResolveTo(v, s).getSource()` matches `mayResolveTo(v, s)` on
+  round-1 fixture.
+- **Corpus measurements gating merge:** matrix row complete; row count
+  parity = identical (additive, never returned by existing queries);
+  wall ≤ 1.1x.
+- **Dependency:** PR1.
+
+### PR3 — `tsq_express.qll` (additive, isolated)
+- **Title:** `feat(bridge): handler-arg → use-site resolution via mayResolveTo`
+- **Scope:** add `ExpressHandlerArgUse` predicate using
+  `mayResolveTo(useExpr, handlerArgExpr)`. Additive.
+- **Size:** ~25 lines + 50 lines fixture/test.
+- **Tests gating merge:** new fixture
+  `testdata/express_arg_use_basic` showing handler-arg flow into a
+  query string concat sink.
+- **Corpus measurements gating merge:** matrix row complete on jitsi
+  (Express-heavy); wall ≤ 1.5x; zero new cap-hits.
+- **Dependency:** PR1.
+
+### PR4 — `tsq_taint.qll` (medium-value, medium-risk)
+- **Title:** `refactor(bridge): tsq_taint TaintedSym/TaintedField via mayResolveTo`
+- **Scope:** rewrite `TaintedSym` and `TaintedField` to defer to
+  `mayResolveTo` with taint-source predicates as the start set. Delete
+  the hand-rolled chain predicates.
+- **Size:** ~30 added / ~20 deleted.
+- **Tests gating merge:** all `compat_security_*_test.go` green;
+  `TestTaintMonotone` green.
+- **Corpus measurements gating merge:** matrix rows for jitsi +
+  Mastodon; row count parity bit-identical OR diff approved as
+  improvement (review process below); wall ≤ 2x; maxrss ≤ 1.5x;
+  zero new cap-hits.
+- **Dependency:** PR1, PR2.
+
+### PR5 — `compat_dataflow.qll` (high-value, medium-risk)
+- **Title:** `refactor(bridge): compat DataFlow.localFlow backed by mayResolveTo`
+- **Scope:** `DataFlow.localFlow` and `DataFlow.localFlowStep` rewritten
+  to call `mayResolveTo` with depth=1; `DataFlow::Node.getASuccessor`
+  routes through it.
+- **Size:** ~60 added / ~30 deleted.
+- **Tests gating merge:** `compat_test.go` and any existing CodeQL
+  parity tests green.
+- **Corpus measurements gating merge:** matrix rows for jitsi + Mastodon
+  + any CodeQL-compat fixture; row count diff approved; wall ≤ 2x.
+- **Dependency:** PR4.
+
+### PR6 — `compat_tainttracking.qll` (rides on PR5)
+- **Title:** `refactor(bridge): compat TaintTracking Configuration uses mayResolveTo`
+- **Scope:** `Configuration.hasFlow(source, sink)` closure backed by
+  `mayResolveTo` chain with `isSanitizer`/`isBarrier` predicates as
+  cut-edges.
+- **Size:** ~40 added / ~10 deleted.
+- **Tests gating merge:** the four `compat_security_*` modules
+  (XSS/SQLi/cmdi/path) all return identical alert sets on Mastodon.
+- **Corpus measurements gating merge:** matrix rows for Mastodon
+  (XSS-heavy); row count diff approved; wall ≤ 2x.
+- **Dependency:** PR5.
+
+### PR7 — react R1-R4 deletion + CHANGELOG + HOWTO
+- **Title:** `feat(bridge): delete R1-R4 setter shape predicates; add HOWTO`
+- **Scope:** delete `setStateUpdaterCallsFn_outerCtx`,
+  `_innerCtx`, `contextSymLinkSame`, `contextSymLinkCrossFile`,
+  `objectLiteralField{Own,SpreadD1,SpreadD2,VarIndirect}`, and the R1
+  prop-pass cascade. CHANGELOG entry with deprecation policy
+  (§6). New `bridge/HOWTO.md` (§7).
+- **Size:** ~50 added / ~600 deleted.
+- **Tests gating merge:** every fixture in `testdata/setstate_*` and
+  `testdata/issue88_*` returns identical alerts.
+- **Corpus measurements gating merge:** the **whole matrix**, all
+  bridges × all corpora, complete and meeting keep criteria (§4).
+- **Dependency:** PR2-PR6, all green.
+
+### 2.X — PR3 / PR5 retirement note (2026-04-20, issue #208)
+
+PR3 (`tsq_taint.qll` rewrite) and PR5 (`compat_tainttracking.qll`
+rewrite) are **retired as exploratory dead ends** — not merely blocked.
+Full context lives in GitHub issue #208 and in the wiki under "Phase D
+PR3 — `tsq_taint.qll` additive wrapper (BLOCKED, 2026-04-20)" plus the
+"option #3 system-rewrite investigation" sub-section. Brief summary:
+
+- `MayResolveTo(v, s)` is an **expression-level** relation with a hard
+  base-case constraint `s ∈ ExprValueSource` (ObjectLiteral / Array /
+  Arrow / Function / Class / primitives / JSX element). FieldRead,
+  Identifier, Call, MemberExpression are **excluded**.
+- Every `TaintSource` rule head in `extract/rules/frameworks.go`
+  (Express, HTTP, Koa, Fastify, Lambda, Next.js) emits on a FieldRead
+  expression (`req.query`, `req.body`, `event.*`). So
+  `MayResolveTo(_, taintSourceExpr)` has **zero rows on the schema** —
+  not on specific fixtures, on *any* extraction.
+- Three investigation passes (plan-doc literal sketch, carrier-only
+  variant, system-rewrite of `TaintAlert`) all hit the same structural
+  wall. PR5 rides on the same machinery and inherits the same gap.
+
+Future unblock paths (none in scope for a bridge-only PR):
+
+(i) extend `ExprValueSource` to seed on FieldRead for a dedicated
+carrier variant — project-wide semantic change with large blast
+radius;
+(ii) introduce a new expression-level `TaintCarry(from, to)` IDB peer
+to `FlowStar`, seeded at taint sources and recursed via `FlowStep` —
+net-new rule set living alongside `MayResolveTo`;
+(iii) accept the dichotomy — taint's symbol-level propagation is a
+legitimate separate graph and `MayResolveTo`'s expression-level
+closure was never designed to subsume it.
+
+**Chosen path:** (iii) for this Phase. Phase D delivers its line-
+deletion win via plan-PR7 (React R1–R4 shape-predicate deletion)
+without needing PR3/PR5. Taint-layer migration is deferrable Phase E
+work at minimum and arguably a separate project.
+
+PR4 (`compat_dataflow.qll`) is **deferred but not retired** — it does
+not share the taint-schema gap and remains measurable under the
+existing harness; revisit in Phase E or as a standalone follow-up.
+
+---
+
+## 3. The measurement matrix
+
+Filled in as PRs land. Row count is `wc -l` of CSV alert output;
+wall is median of 3 cold runs; plan shape is `OK` (no cap-hit log)
+or `CAP@<step>` (which join step blew); maxrss in MB from
+`/usr/bin/time -v`.
+
+### 3.1 Template
+
+| Bridge \ Corpus | local fixtures | jitsi | Mastodon | (NAS-misc) |
+|---|---|---|---|---|
+| `tsq_dataflow` | rows: B / A · wall: B / A · plan: B / A · rss: B / A | … | … | … |
+| `tsq_express` | … | … | … | … |
+| `tsq_taint` | … | … | … | … |
+| `compat_dataflow` | … | … | … | … |
+| `compat_tainttracking` | … | … | … | … |
+| `tsq_react` (final) | … | … | … | … |
+
+`B` = before (last commit on `main` prior to this PR). `A` = after
+(this PR's HEAD). Cells are filled by `bench/valueflow/compare.py`
+output and committed to the PR description.
+
+### 3.2 Corpora roster
+
+- **local fixtures** — `testdata/` (round-1 to round-4 React, issue88,
+  setstate_*) — fast, deterministic, used as the CI gate.
+- **jitsi** — `audiograb@100.80.10.45:~/corpora/jitsi/` — Express +
+  taint heavy.
+- **Mastodon** — `audiograb@100.80.10.45:~/corpora/mastodon/` — React
+  + cross-file imports + the historic planner-stress reference.
+- **NAS-misc** — anything else available under
+  `audiograb@100.80.10.45:~/corpora/`. Discover at PR1 time; list
+  inline in the PR. Treat as bonus signal, not gating.
+
+---
+
+## 4. Keep-or-revert criteria — set IN ADVANCE
+
+These thresholds are written before any number arrives. Do not
+renegotiate after measurements come in. Numbers are per-bridge unless
+stated.
+
+### 4.1 Row count parity
+
+- **Default expectation:** CSV output bit-identical before vs after.
+- **If diff is non-empty:** the PR description must categorise every
+  added / removed alert into one of:
+  - `IMPROVEMENT` — new true positive previously missed (R1-R4 had
+    a known shape gap, e.g. wrapped-arrow or props-field-read).
+    Reviewer signs off as `IMPROVEMENT-OK`.
+  - `REGRESSION-FN` — a previously-found alert no longer fires.
+    **Auto-blocking.** Investigate, fix, or document why the
+    previous alert was a false positive (with the offending fixture
+    snippet pasted). Reviewer countersigns.
+  - `REGRESSION-FP` — a new alert that on inspection is a false
+    positive. Tolerated up to **5%** of the after-set per bridge per
+    corpus; over 5% blocks merge.
+- **Review process:** PR template includes a `Diff Triage` section.
+  Two-reviewer rule for any PR with ≥1 diff entry: one owner, one
+  independent (peepercat or Cain on the React PR; subagent + Cain
+  for the rest).
+
+### 4.2 Wall time
+
+- **≤ 2x current** at result parity → green, merge.
+- **2-5x** → yellow, investigation required (open a janky issue with
+  flame graph and join trace), merge only with explicit Cain sign-off.
+- **> 5x** → red, **auto-revert the migration PR**. Layer stays
+  available for opt-in but bridge stays on the legacy path.
+
+### 4.3 Plan shape
+
+- **Zero new cap-hits — non-negotiable.** A single new
+  `cap-hit @ step N` log line in the matrix blocks merge. No
+  exceptions.
+- **Eliminating an existing cap-hit** is the *win condition* — a
+  bridge migration that turns a `CAP@2` into `OK` is the headline
+  Phase D outcome and should be called out explicitly in the PR title.
+
+### 4.4 maxrss
+
+- **≤ 1.5x current** → green.
+- **1.5x-2x** → yellow, investigate, requires Cain sign-off.
+- **> 2x** → red, revert.
+
+### 4.5 Aggregate keep-or-revert (plan-PR7 / final)
+
+**Revised 2026-04-20 for the reduced bridge set.** Original §4.5
+targeted ≥4 of 6 bridges and ≥400 net LoC deleted across `bridge/`.
+With PR3/PR5 retired (issue #208 — structural schema gap between the
+expression-level `MayResolveTo` and the symbol-level taint graph) the
+six-bridge arithmetic no longer applies. The remaining migration set
+is:
+
+| Bridge PR | Status | Effect on §4.5 ledger |
+|---|---|---|
+| PR1 (`tsq_dataflow.qll` additive surface, #205) | **LANDED** | +15 LoC additive; no deletion |
+| PR2 (`tsq_express.qll` `ExpressHandlerArgUse`, #206) | **LANDED** | +25 LoC additive; no deletion |
+| PR3 (`tsq_taint.qll` rewrite) | **RETIRED** (#208) | ledger-neutral |
+| PR4 (`compat_dataflow.qll`) | **DEFERRED** — not re-scoped in this revision; see retirement note | ledger-neutral for this Phase |
+| PR5 (`compat_tainttracking.qll`) | **RETIRED** (#208) | ledger-neutral |
+| PR6 (`tsq_react.qll` Phase-A wrapper deletion, #207) | **LANDED** | −3 LoC (identity alias) |
+| plan-PR7 (R1–R4 shape-predicate deletion in `tsq_react.qll`) | **PENDING** (gated on this harness PR) | target −600 LoC |
+
+Bridges-migrated fraction is now expressed over the **four in-scope
+bridges** (PR1, PR2, PR6, plan-PR7). PR3/PR5 do not count toward either
+numerator or denominator — they are not "red" bridges, they are out of
+the measurable set entirely, and retiring them is a scope correction
+not a failure.
+
+**Recalibrated keep criteria — the layer is kept iff:**
+
+- **All four in-scope bridge PRs green** (PR1 ✓, PR2 ✓, PR6 ✓, plan-PR7
+  pending measurement). A red on plan-PR7 reverts plan-PR7 only; PR1/
+  PR2/PR6 stay landed because they are additive / pure-deletion-of-
+  identity-alias and carry no regression risk.
+- **plan-PR7 green on Mastodon** — non-negotiable. Mastodon is the
+  planner-stress reference and the R1–R4 shape predicates are the only
+  remaining ≥50-LoC deletion win in the Phase D roster.
+- **Net LoC deleted across `bridge/` ≥ 500** (revised down from 600).
+  The ~600 estimate in §1.1 assumed the full PR3/PR4/PR5 rewrites were
+  in scope. With those out, plan-PR7 is nearly the whole ledger; a
+  modest underperformance (e.g. 550 LoC) still satisfies the revised
+  bar. If plan-PR7 lands less than 500 LoC of net deletion, it has
+  failed to justify the measurement-harness overhead and the layer
+  question becomes "was Phase D worth it" rather than "was plan-PR7
+  worth it" — open a postmortem.
+- **At least one cap-hit eliminated on Mastodon** vs the pre-Phase-C
+  baseline — unchanged. This is the qualitative headline.
+
+If any of the above fails: **revert plan-PR7 only**, keep PR1/PR2/PR6
+and the `bridge/tsq_valueflow.qll` layer in tree (it remains useful
+even without the R1–R4 deletion — PR2's `ExpressHandlerArgUse` uses
+it), file a postmortem in the wiki under
+`Wiki/Tech/tsq-valueflow-phase-d-postmortem.md`, and scope a Phase E
+RFC covering (i) the `compat_dataflow` migration (PR4 deferred, not
+retired — still measurable), (ii) any new expression-level taint IDB
+that would unblock the PR3/PR5 direction.
+
+**Honest framing.** The original §4.5 criteria were over-calibrated for
+a six-bridge plan that turned out to have a schema-level incompatibility
+blocking two of the bridges. Retiring §4.5's original arithmetic is not
+moving the goalposts — it is updating the ledger to match what is
+measurable. The line-deletion target is revised down because the
+line-deletion scope is smaller; the Mastodon and cap-hit criteria are
+preserved because those don't depend on bridge count.
+
+
+---
+
+## 5. The benchmark harness
+
+Modelled on `andryo@fungoid.xyz:~/janky-bench/` — a scripted run that
+produces a comparable artefact each time, committed to its own git
+history for trend analysis.
+
+### 5.1 Layout
+
+```
+bench/valueflow/
+├── bench_run.sh           # entrypoint: `./bench_run.sh <run_id> <bridge>`
+├── corpora.yaml           # paths, fetch instructions, fingerprints
+├── compare.py             # CSV diff + wall/rss/plan-shape extraction
+├── results/               # per-run artefact directory (git-tracked)
+│   └── run_NNN/
+│       ├── manifest.yaml  # commit SHA, bridge, corpus, timestamp
+│       ├── before.csv
+│       ├── after.csv
+│       ├── before.timing
+│       ├── after.timing
+│       ├── before.plan
+│       ├── after.plan
+│       └── diff.md        # human-readable summary
+└── MATRIX.md              # the §3 matrix, regenerated from results/
+```
+
+### 5.2 Script contract
+
+`./bench_run.sh run_007 tsq_taint`:
+1. Resolve corpora list from `corpora.yaml`.
+2. For each corpus, on the parent commit (Phase D base): run query,
+   capture CSV / timing / plan log.
+3. Check out PR head; rerun.
+4. Diff via `compare.py`. Write `diff.md`.
+5. Update `MATRIX.md` row.
+6. Stage files in `bench/valueflow/results/run_007/` and print a
+   `git commit` command. **Does not auto-commit** — human inspects
+   first.
+
+### 5.3 Persistence
+
+`bench/valueflow/results/` is git-tracked **inside the tsq repo** —
+not a separate `tsq-bench` repo. Rationale: tsq is a single project,
+and putting the bench in-repo keeps commit SHAs aligned with the
+binary that produced them. Trend analysis = `git log
+bench/valueflow/results/run_*/`.
+
+### 5.4 Cain-nas access
+
+Corpora live on `audiograb@100.80.10.45`. `bench_run.sh` either
+shells out (default) or pulls a tarball to local scratch
+(`--cache-corpus`). All runs done from cain's box; the NAS does not
+run the binary.
+
+---
+
+## 6. User-facing migration guide — round-3/4 deprecation
+
+The R3/R4 shape predicates (`resolveToObjectExpr*`,
+`contextSymLink{Same,CrossFile}`, `setStateUpdaterCallsFn_{outerCtx,
+innerCtx}`, the `objectLiteralField*` family) are deleted in PR7.
+Anyone with downstream queries calling these breaks at parse time.
+
+### 6.1 Policy
+
+- **No thin-wrapper deprecation period.** The R3/R4 predicates were
+  internal-shaped (each tied to a specific desugarer-output shape
+  that is no longer emitted post-Phase-C). Wrapping them in
+  `mayResolveTo`-backed reimplementations costs more than it saves
+  and creates a trust hazard (callers think they're calling the
+  precise predicate; they're actually getting `mayResolveTo` semantics).
+- **Hard removal in PR7**, with a CHANGELOG entry naming each deleted
+  predicate and the `mayResolveTo` invocation that replaces it.
+- **Pre-removal grep on internal queries:** before PR7 merges, grep
+  every `*.ql` and `*.qll` under `tsq/` for the deleted names and
+  migrate inline as part of PR7.
+- **External / community queries:** known to be zero today (the
+  predicates are tsq-internal). If this changes before PR7 lands,
+  treat it as new context and reopen this section.
+
+### 6.2 CHANGELOG entry template
+
+```
+### Removed (breaking)
+
+- `resolveToObjectExprOwn`, `resolveToObjectExprSpreadD1`,
+  `resolveToObjectExprSpreadD2`, `resolveToObjectExprVarIndirect`
+  — replaced by `mayResolveTo` from `bridge/tsq_valueflow.qll`.
+- `contextSymLinkSame`, `contextSymLinkCrossFile` — replaced by
+  `mayResolveTo` chain through `useContext` call result.
+- `setStateUpdaterCallsFn_outerCtx`, `_innerCtx` — fold both into a
+  single `mayResolveTo`-backed predicate; see migration table below.
+
+Migration: `<old-predicate>(args)` → `mayResolveTo(<expr>, <source>)`
+plus the equivalent shape filter. Worked examples in `bridge/HOWTO.md`.
+```
+
+---
+
+## 7. Bridge author documentation — `bridge/HOWTO.md` sketch
+
+A new doc lands with PR7. Sketch:
+
+### 7.1 Sections
+
+1. **When to reach for `mayResolveTo`.**
+   - You're asking "what value can flow into expression `e`?"
+   - You're asking "what function does callee `c` resolve to?"
+   - You're walking variable / parameter / return / field-write chains
+     and would otherwise enumerate syntactic shapes.
+2. **When to write a custom rule.**
+   - Domain-specific *recognition* (this call is a React `useState`,
+     this call is an Express handler). `mayResolveTo` answers
+     "where", not "what kind".
+   - Sanitiser / barrier semantics — these are cut-edges, not
+     resolution edges.
+3. **Soundness / precision pitfalls.**
+   - `mayResolveTo` is may-flow (under-approximate refutation, over-
+     approximate proof). Absence does not prove non-flow.
+   - Default depth bound `MayResolveDepth = 5`. Raising it costs
+     planner time roughly linearly in the number of recursive seeds;
+     measure before raising.
+   - Field sensitivity is field-name-only (per parent doc §5). Two
+     different objects with the same field name are conflated.
+   - Reassignments are insensitive — multiple writes to a symbol all
+     count as live.
+4. **How to size your rule against the planner.**
+   - Always anchor `mayResolveTo` against a small extent (your
+     domain class) on at least one side. `mayResolveTo(_, _)` with
+     both sides free is a Cartesian.
+   - If your bridge introduces a new IDB head that recurses through
+     `mayResolveTo`, expect to need a custom seeding step. See the
+     `tsq_react.qll` `useStateSetterCall` pattern (Phase C) for the
+     canonical wiring.
+   - Run your bridge through `bench/valueflow/bench_run.sh` against
+     local fixtures *before* submitting. The harness output is the
+     PR's mandatory measurement section.
+
+### 7.2 Worked example
+
+A 30-line walkthrough: "I want to know if any value passed to
+`crypto.createHmac(secret)` came from a `req.body` field." Show the
+full `mayResolveTo` chain, the depth bound, the sanitiser cut, and
+the matrix row before/after.
+
+---
+
+## 8. Sequencing inside Phase D — PRs in order
+
+| # | Title | Scope | Dependency | Gate to merge |
+|---|---|---|---|---|
+| PR1 | `bench: value-flow Phase D harness + matrix template` | `bench/valueflow/` only | none | self-test green |
+| PR2 | `feat(bridge): expose mayResolveTo via tsq_dataflow.qll` | additive class | PR1 | matrix row green |
+| PR3 | `feat(bridge): handler-arg → use-site resolution via mayResolveTo` | additive predicate | PR1 | matrix row green; jitsi |
+| PR4 | `refactor(bridge): tsq_taint via mayResolveTo` | rewrite + delete | PR1, PR2 | matrix rows; no FP > 5%; no new cap-hits |
+| PR5 | `refactor(bridge): compat DataFlow.localFlow via mayResolveTo` | rewrite | PR4 | matrix rows; CodeQL parity tests |
+| PR6 | `refactor(bridge): compat TaintTracking via mayResolveTo` | rewrite | PR5 | matrix rows; all 4 security modules parity on Mastodon |
+| PR7 | `feat(bridge): delete R1-R4 + CHANGELOG + HOWTO` | deletion + docs | PR2-PR6 | full matrix; aggregate criteria §4.5 |
+
+Cadence target: PR1 in week 1; PR2/PR3 in week 2 (parallel,
+worktrees); PR4/PR5/PR6 sequential weeks 3-5; PR7 week 6. Total: ~6
+weeks if no surprises, ~10 weeks with realistic slack.
+
+---
+
+## 9. Test strategy
+
+**The matrix IS the test.** Every migration PR fills its row of §3
+and the numbers must meet §4. CI assertions:
+
+- **Bit-identical CSV diff in CI** for the round-1 to round-4 React
+  fixtures (and equivalent fixtures for non-React bridges:
+  `testdata/express_arg_use_basic`, `testdata/taint_basic_chain`,
+  `testdata/compat_xss_basic`). CI fails on any byte-diff unless the
+  PR carries an explicit `expected-diff/<bridge>.md` artefact that
+  the reviewer signed (commit-tracked counter-signature).
+- **Plan-shape assertion in CI:** parse the plan log, assert
+  `cap-hit count == baseline`. Any increase fails the build.
+- **Existing test suites stay green:** `go test ./... -race` across
+  all 17+ packages. Non-negotiable.
+- **The benchmark harness output is a PR artefact**, not a CI
+  assertion — wall-time variance on shared CI infra is too high.
+  Wall and rss numbers come from `bench_run.sh` on Cain's box,
+  posted in the PR description, reviewer-checked.
+
+---
+
+## 10. Rollback story
+
+### 10.1 Migration PR rollback (mechanical)
+
+`git revert <PR-N>` per bridge. Each migration PR is one commit on
+`main`, no squash-merging across bridges. Reverting a single bridge
+does not affect the others. The `bridge/tsq_valueflow.qll` layer
+stays in tree.
+
+### 10.2 Layer rollback (harder)
+
+If Phase D measurements show `mayResolveTo` is fundamentally too
+imprecise or too slow on real corpora and *no* migrated bridge
+survives §4 thresholds:
+
+1. **PR-final (PR7) is reverted first** — restores R1-R4 React shape
+   predicates.
+2. **PR2-PR6 reverted** in reverse dependency order.
+3. **`bridge/tsq_valueflow.qll`** stays as opt-in for ≥ 4 weeks
+   post-revert. Rationale: any new bridge work that started against
+   it during Phase D needs a grace period to migrate off. After 4
+   weeks with no callers, delete.
+4. **`ql/system/valueflow.go`** (the recursive Datalog rules) — same
+   4-week grace; deletion gated on zero `bridge/*.qll` references.
+5. **Phase B planner work stays.** Recursive-IDB cardinality + (#166)
+   disjunction fix are general planner improvements; they do not
+   revert.
+
+### 10.3 Pre-flight rule
+
+To make the rollback story actually work: **bridges must call
+`mayResolveTo` only after their measurement matrix row is green**.
+No bridge flips to `mayResolveTo` speculatively before its numbers
+land. This gates the rollback blast radius to one PR at a time.
+
+---
+
+## 11. What Phase D explicitly does NOT do
+
+- **No new bridges.** A GraphQL resolver bridge, a Redux action
+  bridge, a Vue.js bridge — all interesting, all out of scope. Phase
+  D is infrastructure consolidation, not product expansion.
+- **No `compat_javascript.qll` migration.** The CodeQL-compat JS AST
+  surface is too wide for a single PR; defer to a Phase E RFC.
+- **No soundness or precision improvements.** SSA-form, k-CFA
+  context sensitivity, prototype-chain walking — all parent doc §5
+  v2-stretch items. Phase D measures the v1 dial; v2 is a follow-up.
+- **No additional planner work.** Phase B is done. If recursive-IDB
+  cardinality estimation regresses on a Phase D corpus, that's a
+  Phase B bug fix, not a Phase D scope expansion.
+- **No type-system extensions.** `Effect` (getters/setters), promise
+  resolution, dynamic dispatch beyond RTA — all deferred per parent
+  doc §5.
+- **No janky-style benchmark of the planner itself.** `bench/valueflow/`
+  measures bridges. The planner has its own benchmarks (`ql/eval/
+  *_bench_test.go`); not touched here.
+- **No Discord-bot integration of the matrix.** Cain has flagged
+  bench dashboards as a "later" item; not Phase D.
+
+---
+
+## 12. Open questions surfaced by this plan
+
+1. **Recursive cardinality on the Express corpus.** `mayResolveTo`
+   recursion through Express middleware chains is a depth pattern
+   we have no fixture for. Risk that the Phase B sizing estimator
+   under-predicts and we eat a Mastodon-scale cap-hit on jitsi at
+   PR3. Mitigation: synthetic 5-deep middleware fixture before PR3
+   opens.
+2. **CodeQL-compat parity vs. CodeQL-compat fidelity.** Our
+   `DataFlow.localFlow` will return *more* edges than CodeQL's
+   (no SSA). PR5 will produce a non-empty `IMPROVEMENT` diff against
+   any corpus that exercises reassignment. Need a policy: do we
+   declare CodeQL-compat parity as "set-equal modulo SSA" or as
+   "subset-of"? Affects whether PR5's diff is `IMPROVEMENT-OK` or
+   `REGRESSION-FP`.
+3. **Bench-run determinism.** `bench_run.sh` output must be
+   byte-stable across runs to make the matrix meaningful. CSV
+   ordering, timestamp suppression, and goroutine-scheduler
+   non-determinism all need pinning. Open question whether tsq's
+   current output is deterministic enough; spike needed before PR1.


### PR DESCRIPTION
بسم الله الرحمن الرحيم

Built on @gjdoalfnrxu's Claude credits. Thanks, chief.

---

## Summary

Lands the Phase D cross-corpus measurement harness — the unblocker for plan-PR7 (R1–R4 shape-predicate deletion in `tsq_react.qll`, the ~600 LoC subsumption-thesis deletion win). Without this PR, plan-PR7 has no way to land its "Mastodon green" §4.5 criterion.

Three parts:

1. **Plan doc committed** (`docs/design/valueflow-phase-d-plan.md`).
   - Status header updated to reflect PR1/PR2/PR6 landed, PR3/PR5 retired, plan-PR7 pending.
   - New §2.X retirement note pulling the issue #208 analysis into the plan itself (expression-level `MayResolveTo` vs symbol-level taint — zero rows on the schema for `TaintSource` FieldRead expressions, all three investigation paths blocked identically).
   - §4.5 rewritten for the reduced bridge set: fraction now over **4 in-scope bridges** (PR1/PR2/PR6/plan-PR7), net-LoC target revised from 600 → 500, Mastodon-green and cap-hit criteria preserved.

2. **Harness skeleton** (`bench/valueflow/`):
   - `bench_run.sh` — driver: takes `<run_id> <corpus|--all>`, builds tsq, extracts per corpus, runs the four value-flow bridge queries, emits `predicate,fixture,row_count,wall_ms` CSV per corpus plus `manifest.yaml`.
   - `corpora.yaml` — schema `name, path, notes`. `local_fixtures` (in-tree) and `mastodon` (`audiograb@100.80.10.45:~/setstate-bench/corpus/mastodon`, ~200MB, rsync-to-scratch on first use).
   - `compare.py` — two-run diff. Honest delta: added / removed / changed / error explicitly; never silently drops a key present in either run.
   - `tests/test_compare.py` — 9 unit tests: missing run, zero-row, predicate added, predicate removed, error propagation, summary counts, multiple corpora, and a mutation probe that fails if `compute_delta` is replaced with `[]`.
   - `tests/smoke_bench_run.sh` — shell smoke for the driver's argument-validation and corpora.yaml parse path.
   - `README.md` with a **"What the harness CANNOT detect"** section (precision regressions at constant row count, plan-shape cap-hits, wrong-path shortcuts, maxrss — documented rather than silently missing).

3. **MVP run** (`bench/valueflow/results/run_001/`):
   - SHA `506a7d5` (current main tip post-Phase-D-PR6).
   - Corpus: `local_fixtures` (Mastodon reachable but deferred to run_002 on the plan-PR7 branch where the diff is meaningful).
   - Baseline: `mayResolveToRec` 481 / `mayResolveTo_all` 695 / `mayResolveTo_dataflow` 481 / `resolvesToFunctionDirect` 49 rows.
   - `mayResolveToRec == mayResolveTo_dataflow == 481` confirms the Phase D PR1 parity claim (the `tsq_dataflow` wrapper exposes the same system relation).
   - Sanity check passes; all four predicates non-zero.

## Scope cuts

None against the briefing. Mastodon not included in the MVP run (briefing explicitly allowed fixture fallback — reachable but kept out of run_001 so the PR stays small and the first cross-SHA diff is meaningful).

Deliberate out-of-scope: maxrss capture, plan-log parsing (cap-hit detection), `/usr/bin/time -v` integration, CI wiring. All listed as follow-ups in `README.md` so a reviewer can see what's missing without having to reverse-engineer from the code.

## Test plan

- [x] `python3 bench/valueflow/tests/test_compare.py` → 9/9 passing, including mutation probe
- [x] `bash bench/valueflow/tests/smoke_bench_run.sh` → OK
- [x] `bench/valueflow/bench_run.sh run_001 local_fixtures` → sanity OK, non-zero rows
- [x] `python3 bench/valueflow/compare.py results/run_001 results/run_001` → all 4 predicates "unchanged" (self-diff is a no-op)
- [x] `git grep -n` for Discord usernames / real names in the diff → clean
- [ ] Reviewer: sanity-check §4.5 recalibration is honest (not a goalpost move)
- [ ] Reviewer: confirm the "CANNOT detect" section in README covers the blind spots you actually care about