### PR TITLE
feat(valueflow): extractor path columns on destructure/object/field relations (Phase E E1)

### DIFF
--- a/bench/valueflow/results/run_e1_local/local_fixtures.csv
+++ b/bench/valueflow/results/run_e1_local/local_fixtures.csv
@@ -1,0 +1,5 @@
+predicate,fixture,row_count,wall_ms
+mayResolveToRec,local_fixtures,481,2039
+mayResolveTo_all,local_fixtures,695,1983
+mayResolveTo_dataflow,local_fixtures,481,754
+resolvesToFunctionDirect,local_fixtures,49,2080

--- a/bench/valueflow/results/run_e1_local/manifest.yaml
+++ b/bench/valueflow/results/run_e1_local/manifest.yaml
@@ -1,0 +1,12 @@
+run_id: run_e1_local
+timestamp_utc: 2026-04-20T07:43:45Z
+git_sha: f6c7740873816e420a3c15dfff75116dc4796982
+git_describe: v1.0.0-174-gf6c7740-dirty
+corpora:
+  - name: local_fixtures
+    path_resolved: /tmp/tsq-vf-e-e1/testdata/projects
+    path_repo_relative: testdata/projects
+    extract_ms: 2119
+    csv: local_fixtures.csv
+    nonzero: 1
+sanity: OK

--- a/bench/valueflow/results/run_e1_mastodon/manifest.yaml
+++ b/bench/valueflow/results/run_e1_mastodon/manifest.yaml
@@ -1,0 +1,5 @@
+run_id: run_e1_mastodon
+timestamp_utc: 2026-04-20T07:43:59Z
+git_sha: f6c7740873816e420a3c15dfff75116dc4796982
+git_describe: v1.0.0-174-gf6c7740-dirty
+corpora:

--- a/bench/valueflow/results/run_e1_mastodon/mastodon.csv
+++ b/bench/valueflow/results/run_e1_mastodon/mastodon.csv
@@ -1,0 +1,1 @@
+predicate,fixture,row_count,wall_ms

--- a/bridge/compat_dom.qll
+++ b/bridge/compat_dom.qll
@@ -33,12 +33,12 @@ module DOM {
      */
     class InnerHtmlWrite extends @field_write {
         InnerHtmlWrite() {
-            FieldWrite(this, _, "innerHTML", _) or
-            FieldWrite(this, _, "outerHTML", _)
+            FieldWrite(this, _, "innerHTML", _, _) or
+            FieldWrite(this, _, "outerHTML", _, _)
         }
 
         /** Gets the right-hand side expression being written. */
-        int getRhs() { FieldWrite(this, _, _, result) }
+        int getRhs() { FieldWrite(this, _, _, result, _) }
 
         /** Gets a textual representation. */
         string toString() { result = "DOM::InnerHtmlWrite" }
@@ -67,16 +67,16 @@ module DOM {
      * Backed by FieldWrite relation on DOM element symbols.
      */
     class AttributeWrite extends @field_write {
-        AttributeWrite() { FieldWrite(this, _, _, _) }
+        AttributeWrite() { FieldWrite(this, _, _, _, _) }
 
         /** Gets the base symbol. */
-        int getBaseSym() { FieldWrite(this, result, _, _) }
+        int getBaseSym() { FieldWrite(this, result, _, _, _) }
 
         /** Gets the property name. */
-        string getPropertyName() { FieldWrite(this, _, result, _) }
+        string getPropertyName() { FieldWrite(this, _, result, _, _) }
 
         /** Gets the right-hand side expression. */
-        int getRhs() { FieldWrite(this, _, _, result) }
+        int getRhs() { FieldWrite(this, _, _, result, _) }
 
         /** Gets a textual representation. */
         string toString() { result = "DOM::AttributeWrite" }

--- a/bridge/compat_javascript.qll
+++ b/bridge/compat_javascript.qll
@@ -173,13 +173,13 @@ class AssignExpr extends @assign {
 
 /** A property access expression (e.g., `obj.prop`). */
 class PropAccess extends @field_read {
-    PropAccess() { FieldRead(this, _, _) }
+    PropAccess() { FieldRead(this, _, _, _) }
 
     /** Gets the base symbol. */
-    int getBaseSym() { FieldRead(this, result, _) }
+    int getBaseSym() { FieldRead(this, result, _, _) }
 
     /** Gets the property name. */
-    string getPropertyName() { FieldRead(this, _, result) }
+    string getPropertyName() { FieldRead(this, _, result, _) }
 
     /** Gets a textual representation. */
     string toString() { result = "." + this.getPropertyName() }
@@ -187,16 +187,16 @@ class PropAccess extends @field_read {
 
 /** A field write expression (e.g., `obj.field = value`). */
 class PropWrite extends @field_write {
-    PropWrite() { FieldWrite(this, _, _, _) }
+    PropWrite() { FieldWrite(this, _, _, _, _) }
 
     /** Gets the base symbol. */
-    int getBaseSym() { FieldWrite(this, result, _, _) }
+    int getBaseSym() { FieldWrite(this, result, _, _, _) }
 
     /** Gets the property name. */
-    string getPropertyName() { FieldWrite(this, _, result, _) }
+    string getPropertyName() { FieldWrite(this, _, result, _, _) }
 
     /** Gets the right-hand side expression. */
-    ASTNode getRhs() { FieldWrite(this, _, _, result) }
+    ASTNode getRhs() { FieldWrite(this, _, _, result, _) }
 
     /** Gets a textual representation. */
     string toString() { result = "." + this.getPropertyName() + " =" }

--- a/bridge/tsq_expressions.qll
+++ b/bridge/tsq_expressions.qll
@@ -34,16 +34,19 @@ class ExprIsCall extends @expr_is_call {
 
 /** A field read access (e.g. obj.field). */
 class FieldRead extends @field_read {
-    FieldRead() { FieldRead(this, _, _) }
+    FieldRead() { FieldRead(this, _, _, _) }
 
     /** Gets the expression node. */
     ASTNode getExpr() { result = this }
 
     /** Gets the base symbol. */
-    int getBaseSym() { FieldRead(this, result, _) }
+    int getBaseSym() { FieldRead(this, result, _, _) }
 
     /** Gets the field name. */
-    string getFieldName() { FieldRead(this, _, result) }
+    string getFieldName() { FieldRead(this, _, result, _) }
+
+    /** Gets the structured access path (e.g. ".foo"). Phase E PR1 (#210). */
+    string getPath() { FieldRead(this, _, _, result) }
 
     /** Gets a textual representation. */
     string toString() { result = "." + this.getFieldName() }
@@ -51,19 +54,22 @@ class FieldRead extends @field_read {
 
 /** A field write access (e.g. obj.field = value). */
 class FieldWrite extends @field_write {
-    FieldWrite() { FieldWrite(this, _, _, _) }
+    FieldWrite() { FieldWrite(this, _, _, _, _) }
 
     /** Gets the assignment node. */
     ASTNode getAssignNode() { result = this }
 
     /** Gets the base symbol. */
-    int getBaseSym() { FieldWrite(this, result, _, _) }
+    int getBaseSym() { FieldWrite(this, result, _, _, _) }
 
     /** Gets the field name. */
-    string getFieldName() { FieldWrite(this, _, result, _) }
+    string getFieldName() { FieldWrite(this, _, result, _, _) }
 
     /** Gets the right-hand side expression. */
-    ASTNode getRhsExpr() { FieldWrite(this, _, _, result) }
+    ASTNode getRhsExpr() { FieldWrite(this, _, _, result, _) }
+
+    /** Gets the structured access path (e.g. ".foo"). Phase E PR1 (#210). */
+    string getPath() { FieldWrite(this, _, _, _, result) }
 
     /** Gets a textual representation. */
     string toString() { result = "." + this.getFieldName() + " =" }
@@ -111,16 +117,19 @@ class Cast extends @cast {
  * causing entity collapse. Same v1 limitation as DestructureField.
  */
 class ObjectLiteralField extends @object_literal_field {
-    ObjectLiteralField() { ObjectLiteralField(this, _, _) }
+    ObjectLiteralField() { ObjectLiteralField(this, _, _, _) }
 
     /** Gets the parent object-literal node. */
     ASTNode getParent() { result = this }
 
     /** Gets the field name (shorthand binding name OR source key). */
-    string getFieldName() { ObjectLiteralField(this, result, _) }
+    string getFieldName() { ObjectLiteralField(this, result, _, _) }
 
     /** Gets the value-position expression node. */
-    ASTNode getValueExpr() { ObjectLiteralField(this, _, result) }
+    ASTNode getValueExpr() { ObjectLiteralField(this, _, result, _) }
+
+    /** Gets the structured access path (e.g. ".foo"). Phase E PR1 (#210). */
+    string getPath() { ObjectLiteralField(this, _, _, result) }
 
     /** Gets a textual representation. */
     string toString() { result = this.getFieldName() }
@@ -134,22 +143,25 @@ class ObjectLiteralField extends @object_literal_field {
  * causing entity collapse.  Known v1 limitation.
  */
 class DestructureField extends @destructure_field {
-    DestructureField() { DestructureField(this, _, _, _, _) }
+    DestructureField() { DestructureField(this, _, _, _, _, _) }
 
     /** Gets the parent pattern node. */
     ASTNode getParent() { result = this }
 
     /** Gets the source field name. */
-    string getSourceField() { DestructureField(this, result, _, _, _) }
+    string getSourceField() { DestructureField(this, result, _, _, _, _) }
 
     /** Gets the binding name. */
-    string getBindName() { DestructureField(this, _, result, _, _) }
+    string getBindName() { DestructureField(this, _, result, _, _, _) }
 
     /** Gets the binding symbol. */
-    int getBindSym() { DestructureField(this, _, _, result, _) }
+    int getBindSym() { DestructureField(this, _, _, result, _, _) }
 
     /** Gets the field index. */
-    int getIndex() { DestructureField(this, _, _, _, result) }
+    int getIndex() { DestructureField(this, _, _, _, result, _) }
+
+    /** Gets the structured access path (e.g. ".foo"). Phase E PR1 (#210). */
+    string getPath() { DestructureField(this, _, _, _, _, result) }
 
     /** Gets a textual representation. */
     string toString() { result = this.getSourceField() + ": " + this.getBindName() }
@@ -162,16 +174,19 @@ class DestructureField extends @destructure_field {
  * Same entity-collapse caveat as DestructureField.
  */
 class ArrayDestructure extends @array_destructure {
-    ArrayDestructure() { ArrayDestructure(this, _, _) }
+    ArrayDestructure() { ArrayDestructure(this, _, _, _) }
 
     /** Gets the parent pattern node. */
     ASTNode getParent() { result = this }
 
     /** Gets the element index. */
-    int getIndex() { ArrayDestructure(this, result, _) }
+    int getIndex() { ArrayDestructure(this, result, _, _) }
 
     /** Gets the binding symbol. */
-    int getBindSym() { ArrayDestructure(this, _, result) }
+    int getBindSym() { ArrayDestructure(this, _, result, _) }
+
+    /** Gets the structured access path (e.g. ".[1]"). Phase E PR1 (#210). */
+    string getPath() { ArrayDestructure(this, _, _, result) }
 
     /** Gets a textual representation. */
     string toString() { result = "array_destructure" }

--- a/bridge/tsq_react.qll
+++ b/bridge/tsq_react.qll
@@ -72,7 +72,7 @@ predicate functionContainsStar(int fn, int node) {
  */
 predicate isUseStateSetterSym(int sym) {
     exists(int parent, int varDecl, int initExpr, int useStateSym |
-        ArrayDestructure(parent, 1, sym) and
+        ArrayDestructure(parent, 1, sym, _) and
         Contains(varDecl, parent) and
         VarDecl(varDecl, _, initExpr, _) and
         CallCalleeSym(initExpr, useStateSym) and
@@ -110,7 +110,7 @@ class UseStateSetterCall extends @call {
     UseStateSetterCall() {
         exists(int sym, int parent, int varDecl, int initExpr, int useStateSym |
             CallCalleeSym(this, sym) and
-            ArrayDestructure(parent, 1, sym) and
+            ArrayDestructure(parent, 1, sym, _) and
             Contains(varDecl, parent) and
             VarDecl(varDecl, _, initExpr, _) and
             CallCalleeSym(initExpr, useStateSym) and
@@ -222,7 +222,7 @@ predicate setStateUpdaterCallsOtherSetState(UseStateSetterCall c, int line) {
  */
 predicate useStateSetterSym(int sym) {
     exists(int parent, int varDecl, int initExpr, int useStateSym |
-        ArrayDestructure(parent, 1, sym) and
+        ArrayDestructure(parent, 1, sym, _) and
         Contains(varDecl, parent) and
         VarDecl(varDecl, _, initExpr, _) and
         CallCalleeSym(initExpr, useStateSym) and
@@ -265,7 +265,7 @@ predicate jsxPropPassesIdentifier(int elem, string attrName, int valueSym) {
 predicate componentDestructuredProp(int componentFn, string propName, int paramSym) {
     exists(int paramNode |
         Parameter(componentFn, 0, _, paramNode, _, _) and
-        DestructureField(paramNode, propName, _, paramSym, _)
+        DestructureField(paramNode, propName, _, paramSym, _, _)
     )
 }
 
@@ -642,11 +642,11 @@ predicate resolveToObjectExprWrapped(int valueExpr, int objExpr) {
  * downstream predicates anyway.
  */
 predicate isObjectLiteralExprOwnField(int objExpr) {
-    ObjectLiteralField(objExpr, _, _)
+    ObjectLiteralField(objExpr, _, _, _)
 }
 
 predicate isObjectLiteralExprSpread(int objExpr) {
-    ObjectLiteralSpread(objExpr, _)
+    ObjectLiteralSpread(objExpr, _, _)
 }
 
 predicate isObjectLiteralExpr(int objExpr) {
@@ -678,7 +678,7 @@ predicate isObjectLiteralExpr(int objExpr) {
  * `resolveToObjectExpr`, `contextSetterAliasStep`, and `contextSymLink`.
  */
 predicate objectLiteralFieldOwn(int objExpr, string fieldName, int valueExpr) {
-    ObjectLiteralField(objExpr, fieldName, valueExpr)
+    ObjectLiteralField(objExpr, fieldName, valueExpr, _)
 }
 
 /**
@@ -688,17 +688,17 @@ predicate objectLiteralFieldOwn(int objExpr, string fieldName, int valueExpr) {
  */
 predicate objectLiteralFieldSpreadD1Direct(int objExpr, string fieldName, int valueExpr) {
     exists(int spreadValueExpr |
-        ObjectLiteralSpread(objExpr, spreadValueExpr) and
-        ObjectLiteralField(spreadValueExpr, fieldName, valueExpr)
+        ObjectLiteralSpread(objExpr, spreadValueExpr, _) and
+        ObjectLiteralField(spreadValueExpr, fieldName, valueExpr, _)
     )
 }
 
 predicate objectLiteralFieldSpreadD1Var(int objExpr, string fieldName, int valueExpr) {
     exists(int spreadValueExpr, int spreadObj, int sym, int varDecl |
-        ObjectLiteralSpread(objExpr, spreadValueExpr) and
+        ObjectLiteralSpread(objExpr, spreadValueExpr, _) and
         ExprMayRef(spreadValueExpr, sym) and
         VarDecl(varDecl, sym, spreadObj, _) and
-        ObjectLiteralField(spreadObj, fieldName, valueExpr)
+        ObjectLiteralField(spreadObj, fieldName, valueExpr, _)
     )
 }
 
@@ -715,42 +715,42 @@ predicate objectLiteralFieldSpreadD1(int objExpr, string fieldName, int valueExp
  */
 predicate objectLiteralFieldSpreadD2DirectDirect(int objExpr, string fieldName, int valueExpr) {
     exists(int spreadValueExpr1, int spreadValueExpr2 |
-        ObjectLiteralSpread(objExpr, spreadValueExpr1) and
-        ObjectLiteralSpread(spreadValueExpr1, spreadValueExpr2) and
-        ObjectLiteralField(spreadValueExpr2, fieldName, valueExpr)
+        ObjectLiteralSpread(objExpr, spreadValueExpr1, _) and
+        ObjectLiteralSpread(spreadValueExpr1, spreadValueExpr2, _) and
+        ObjectLiteralField(spreadValueExpr2, fieldName, valueExpr, _)
     )
 }
 
 predicate objectLiteralFieldSpreadD2DirectVar(int objExpr, string fieldName, int valueExpr) {
     exists(int spreadValueExpr1, int spreadValueExpr2, int sym, int varDecl, int spreadObj2 |
-        ObjectLiteralSpread(objExpr, spreadValueExpr1) and
-        ObjectLiteralSpread(spreadValueExpr1, spreadValueExpr2) and
+        ObjectLiteralSpread(objExpr, spreadValueExpr1, _) and
+        ObjectLiteralSpread(spreadValueExpr1, spreadValueExpr2, _) and
         ExprMayRef(spreadValueExpr2, sym) and
         VarDecl(varDecl, sym, spreadObj2, _) and
-        ObjectLiteralField(spreadObj2, fieldName, valueExpr)
+        ObjectLiteralField(spreadObj2, fieldName, valueExpr, _)
     )
 }
 
 predicate objectLiteralFieldSpreadD2VarDirect(int objExpr, string fieldName, int valueExpr) {
     exists(int spreadValueExpr1, int spreadObj1, int sym1, int varDecl1, int spreadValueExpr2 |
-        ObjectLiteralSpread(objExpr, spreadValueExpr1) and
+        ObjectLiteralSpread(objExpr, spreadValueExpr1, _) and
         ExprMayRef(spreadValueExpr1, sym1) and
         VarDecl(varDecl1, sym1, spreadObj1, _) and
-        ObjectLiteralSpread(spreadObj1, spreadValueExpr2) and
-        ObjectLiteralField(spreadValueExpr2, fieldName, valueExpr)
+        ObjectLiteralSpread(spreadObj1, spreadValueExpr2, _) and
+        ObjectLiteralField(spreadValueExpr2, fieldName, valueExpr, _)
     )
 }
 
 predicate objectLiteralFieldSpreadD2VarVar(int objExpr, string fieldName, int valueExpr) {
     exists(int spreadValueExpr1, int spreadObj1, int sym1, int varDecl1,
            int spreadValueExpr2, int spreadObj2, int sym2, int varDecl2 |
-        ObjectLiteralSpread(objExpr, spreadValueExpr1) and
+        ObjectLiteralSpread(objExpr, spreadValueExpr1, _) and
         ExprMayRef(spreadValueExpr1, sym1) and
         VarDecl(varDecl1, sym1, spreadObj1, _) and
-        ObjectLiteralSpread(spreadObj1, spreadValueExpr2) and
+        ObjectLiteralSpread(spreadObj1, spreadValueExpr2, _) and
         ExprMayRef(spreadValueExpr2, sym2) and
         VarDecl(varDecl2, sym2, spreadObj2, _) and
-        ObjectLiteralField(spreadObj2, fieldName, valueExpr)
+        ObjectLiteralField(spreadObj2, fieldName, valueExpr, _)
     )
 }
 
@@ -791,10 +791,10 @@ predicate objectLiteralFieldThroughSpread(int objExpr, string fieldName, int val
 predicate contextProviderValueObject(int ctxSym, int objExpr) {
     exists(int elem, int tagNode, int valueAttrExpr |
         JsxElement(elem, tagNode, _) and
-        FieldRead(tagNode, ctxSym, "Provider") and
+        FieldRead(tagNode, ctxSym, "Provider", _) and
         JsxAttribute(elem, "value", valueAttrExpr) and
         jsxAttrValueObject(valueAttrExpr, objExpr) and
-        ObjectLiteralField(objExpr, _, _)
+        ObjectLiteralField(objExpr, _, _, _)
     )
 }
 
@@ -822,7 +822,7 @@ predicate contextProviderValueObject(int ctxSym, int objExpr) {
 predicate contextProviderFieldR2(int ctxSym, string fieldName, int valueSym) {
     exists(int objExpr, int valueExpr |
         contextProviderValueObject(ctxSym, objExpr) and
-        ObjectLiteralField(objExpr, fieldName, valueExpr) and
+        ObjectLiteralField(objExpr, fieldName, valueExpr, _) and
         ExprMayRef(valueExpr, valueSym)
     )
 }
@@ -835,7 +835,7 @@ predicate contextProviderFieldR2(int ctxSym, string fieldName, int valueSym) {
 predicate contextProviderFieldR3VarIndirectOwn(int ctxSym, string fieldName, int valueSym) {
     exists(int elem, int tagNode, int valueAttrExpr, int objExpr, int valueExpr |
         JsxElement(elem, tagNode, _) and
-        FieldRead(tagNode, ctxSym, "Provider") and
+        FieldRead(tagNode, ctxSym, "Provider", _) and
         JsxAttribute(elem, "value", valueAttrExpr) and
         mayResolveToObjectExpr(valueAttrExpr, objExpr) and
         objectLiteralFieldOwn(objExpr, fieldName, valueExpr) and
@@ -846,7 +846,7 @@ predicate contextProviderFieldR3VarIndirectOwn(int ctxSym, string fieldName, int
 predicate contextProviderFieldR3VarIndirectSpreadD1(int ctxSym, string fieldName, int valueSym) {
     exists(int elem, int tagNode, int valueAttrExpr, int objExpr, int valueExpr |
         JsxElement(elem, tagNode, _) and
-        FieldRead(tagNode, ctxSym, "Provider") and
+        FieldRead(tagNode, ctxSym, "Provider", _) and
         JsxAttribute(elem, "value", valueAttrExpr) and
         mayResolveToObjectExpr(valueAttrExpr, objExpr) and
         objectLiteralFieldSpreadD1(objExpr, fieldName, valueExpr) and
@@ -857,7 +857,7 @@ predicate contextProviderFieldR3VarIndirectSpreadD1(int ctxSym, string fieldName
 predicate contextProviderFieldR3VarIndirectSpreadD2(int ctxSym, string fieldName, int valueSym) {
     exists(int elem, int tagNode, int valueAttrExpr, int objExpr, int valueExpr |
         JsxElement(elem, tagNode, _) and
-        FieldRead(tagNode, ctxSym, "Provider") and
+        FieldRead(tagNode, ctxSym, "Provider", _) and
         JsxAttribute(elem, "value", valueAttrExpr) and
         mayResolveToObjectExpr(valueAttrExpr, objExpr) and
         objectLiteralFieldSpreadD2(objExpr, fieldName, valueExpr) and
@@ -1035,7 +1035,7 @@ predicate contextDestructureBinding(int ctxSym, string fieldName, int paramSym) 
     exists(int varDecl, int parent, int initExpr, int callExpr, int call |
         VarDecl(varDecl, _, initExpr, _) and
         Contains(varDecl, parent) and
-        DestructureField(parent, fieldName, _, paramSym, _) and
+        DestructureField(parent, fieldName, _, paramSym, _, _) and
         // initExpr resolves to a useContextCallSite call, possibly via a
         // single non-null assertion / cast hop.
         (

--- a/bridge/tsq_valueflow.qll
+++ b/bridge/tsq_valueflow.qll
@@ -114,8 +114,8 @@ predicate mayResolveToParamBind(int valueExpr, int sourceExpr) {
  */
 predicate mayResolveToFieldRead(int valueExpr, int sourceExpr) {
     exists(int baseSym, string fld, int rhsExpr, int writeNode |
-        FieldRead(valueExpr, baseSym, fld) and
-        FieldWrite(writeNode, baseSym, fld, rhsExpr) and
+        FieldRead(valueExpr, baseSym, fld, _) and
+        FieldWrite(writeNode, baseSym, fld, rhsExpr, _) and
         ExprValueSource(rhsExpr, sourceExpr)
     )
 }
@@ -133,9 +133,9 @@ predicate mayResolveToFieldRead(int valueExpr, int sourceExpr) {
  */
 predicate mayResolveToObjectField(int valueExpr, int sourceExpr) {
     exists(int objExpr, string fld, int fieldValExpr, int baseSym, int varDecl |
-        FieldRead(valueExpr, baseSym, fld) and
+        FieldRead(valueExpr, baseSym, fld, _) and
         VarDecl(varDecl, baseSym, objExpr, _) and
-        ObjectLiteralField(objExpr, fld, fieldValExpr) and
+        ObjectLiteralField(objExpr, fld, fieldValExpr, _) and
         ExprValueSource(fieldValExpr, sourceExpr)
     )
 }

--- a/extract/rules/composition_test.go
+++ b/extract/rules/composition_test.go
@@ -19,9 +19,9 @@ func compositionBaseRels(overrides map[string]*eval.Relation) map[string]*eval.R
 		"VarDecl":          eval.NewRelation("VarDecl", 4),
 		"ReturnStmt":       eval.NewRelation("ReturnStmt", 3),
 		"ReturnSym":        eval.NewRelation("ReturnSym", 2),
-		"DestructureField": eval.NewRelation("DestructureField", 5),
-		"FieldRead":        eval.NewRelation("FieldRead", 3),
-		"FieldWrite":       eval.NewRelation("FieldWrite", 4),
+		"DestructureField": eval.NewRelation("DestructureField", 6),
+		"FieldRead":        eval.NewRelation("FieldRead", 4),
+		"FieldWrite":       eval.NewRelation("FieldWrite", 5),
 		// Summary dependencies
 		"Parameter":        eval.NewRelation("Parameter", 6),
 		"FunctionContains": eval.NewRelation("FunctionContains", 2),

--- a/extract/rules/frameworks.go
+++ b/extract/rules/frameworks.go
@@ -71,7 +71,7 @@ func expressRules() []datalog.Rule {
 	for _, field := range []string{"query", "params", "body"} {
 		rules = append(rules, rule("TaintSource",
 			[]datalog.Term{v("expr"), s("http_input")},
-			pos("FieldRead", v("expr"), v("reqSym"), s(field)),
+			pos("FieldRead", v("expr"), v("reqSym"), s(field), w()),
 			pos("Parameter", v("fn"), intc(0), w(), w(), v("reqSym"), w()),
 			pos("ExpressHandler", v("fn")),
 		))
@@ -128,7 +128,7 @@ func httpHandlerRules() []datalog.Rule {
 	for _, field := range []string{"url", "headers", "method"} {
 		rules = append(rules, rule("TaintSource",
 			[]datalog.Term{v("expr"), s("http_input")},
-			pos("FieldRead", v("expr"), v("reqSym"), s(field)),
+			pos("FieldRead", v("expr"), v("reqSym"), s(field), w()),
 			pos("Parameter", v("fn"), intc(0), w(), w(), v("reqSym"), w()),
 			pos("HttpHandler", v("fn")),
 		))
@@ -170,7 +170,7 @@ func koaRules() []datalog.Rule {
 
 	rules = append(rules, rule("TaintSource",
 		[]datalog.Term{v("expr"), s("http_input")},
-		pos("FieldRead", v("expr"), v("ctxSym"), s("query")),
+		pos("FieldRead", v("expr"), v("ctxSym"), s("query"), w()),
 		pos("Parameter", v("fn"), intc(0), w(), w(), v("ctxSym"), w()),
 		pos("KoaHandler", v("fn")),
 	))
@@ -181,9 +181,9 @@ func koaRules() []datalog.Rule {
 	for _, field := range []string{"body", "query"} {
 		rules = append(rules, rule("TaintSource",
 			[]datalog.Term{v("expr"), s("http_input")},
-			pos("FieldRead", v("reqExpr"), v("ctxSym"), s("request")),
+			pos("FieldRead", v("reqExpr"), v("ctxSym"), s("request"), w()),
 			pos("ExprMayRef", v("reqExpr"), v("reqSym")),
-			pos("FieldRead", v("expr"), v("reqSym"), s(field)),
+			pos("FieldRead", v("expr"), v("reqSym"), s(field), w()),
 			pos("Parameter", v("fn"), intc(0), w(), w(), v("ctxSym"), w()),
 			pos("KoaHandler", v("fn")),
 		))
@@ -191,7 +191,7 @@ func koaRules() []datalog.Rule {
 
 	rules = append(rules, rule("TaintSink",
 		[]datalog.Term{v("rhsExpr"), s("xss")},
-		pos("FieldWrite", w(), v("ctxSym"), s("body"), v("rhsExpr")),
+		pos("FieldWrite", w(), v("ctxSym"), s("body"), v("rhsExpr"), w()),
 		pos("Parameter", v("fn"), intc(0), w(), w(), v("ctxSym"), w()),
 		pos("KoaHandler", v("fn")),
 	))
@@ -220,7 +220,7 @@ func fastifyRules() []datalog.Rule {
 	for _, field := range []string{"body", "query", "params"} {
 		rules = append(rules, rule("TaintSource",
 			[]datalog.Term{v("expr"), s("http_input")},
-			pos("FieldRead", v("expr"), v("reqSym"), s(field)),
+			pos("FieldRead", v("expr"), v("reqSym"), s(field), w()),
 			pos("Parameter", v("fn"), intc(0), w(), w(), v("reqSym"), w()),
 			pos("FastifyHandler", v("fn")),
 		))
@@ -255,7 +255,7 @@ func lambdaRules() []datalog.Rule {
 
 	rules = append(rules, rule("TaintSource",
 		[]datalog.Term{v("expr"), s("http_input")},
-		pos("FieldRead", v("expr"), v("eventSym"), w()),
+		pos("FieldRead", v("expr"), v("eventSym"), w(), w()),
 		pos("Parameter", v("fn"), intc(0), w(), w(), v("eventSym"), w()),
 		pos("LambdaHandler", v("fn")),
 	))
@@ -277,7 +277,7 @@ func nextjsRules() []datalog.Rule {
 	for _, field := range []string{"query", "body"} {
 		rules = append(rules, rule("TaintSource",
 			[]datalog.Term{v("expr"), s("http_input")},
-			pos("FieldRead", v("expr"), v("reqSym"), s(field)),
+			pos("FieldRead", v("expr"), v("reqSym"), s(field), w()),
 			pos("Parameter", v("fn"), intc(0), w(), w(), v("reqSym"), w()),
 			pos("NextjsHandler", v("fn")),
 		))

--- a/extract/rules/frameworks_test.go
+++ b/extract/rules/frameworks_test.go
@@ -13,8 +13,8 @@ import (
 func frameworkBaseRels(overrides map[string]*eval.Relation) map[string]*eval.Relation {
 	base := taintBaseRels(nil)
 	// Add framework-specific base relations
-	base["FieldRead"] = eval.NewRelation("FieldRead", 3)
-	base["FieldWrite"] = eval.NewRelation("FieldWrite", 4)
+	base["FieldRead"] = eval.NewRelation("FieldRead", 4)
+	base["FieldWrite"] = eval.NewRelation("FieldWrite", 5)
 	base["Function"] = eval.NewRelation("Function", 6)
 	base["JsxElement"] = eval.NewRelation("JsxElement", 3)
 	base["JsxAttribute"] = eval.NewRelation("JsxAttribute", 3)
@@ -59,7 +59,7 @@ func TestExpressSource_ReqQuery(t *testing.T) {
 		"ExprMayRef":     makeRel("ExprMayRef", 2, iv(600), iv(60), iv(100), iv(10)),
 		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(60), iv(7)),
 		"Parameter":      makeRel("Parameter", 6, iv(7), iv(0), sv("req"), iv(80), iv(10), sv("")),
-		"FieldRead":      makeRel("FieldRead", 3, iv(100), iv(10), sv("query")),
+		"FieldRead":      makeRel("FieldRead", 4, iv(100), iv(10), sv("query"), sv(".query")),
 	})
 
 	query := &datalog.Query{
@@ -221,7 +221,7 @@ func TestHttpSource_ReqUrl(t *testing.T) {
 		"ExprMayRef":     makeRel("ExprMayRef", 2, iv(600), iv(60)),
 		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(60), iv(7)),
 		"Parameter":      makeRel("Parameter", 6, iv(7), iv(0), sv("req"), iv(80), iv(10), sv("")),
-		"FieldRead":      makeRel("FieldRead", 3, iv(100), iv(10), sv("url")),
+		"FieldRead":      makeRel("FieldRead", 4, iv(100), iv(10), sv("url"), sv(".url")),
 	})
 
 	query := &datalog.Query{
@@ -244,7 +244,7 @@ func TestKoaSource_CtxQuery(t *testing.T) {
 		"ExprMayRef":     makeRel("ExprMayRef", 2, iv(600), iv(60)),
 		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(60), iv(7)),
 		"Parameter":      makeRel("Parameter", 6, iv(7), iv(0), sv("ctx"), iv(80), iv(10), sv("")),
-		"FieldRead":      makeRel("FieldRead", 3, iv(100), iv(10), sv("query")),
+		"FieldRead":      makeRel("FieldRead", 4, iv(100), iv(10), sv("query"), sv(".query")),
 	})
 
 	query := &datalog.Query{
@@ -265,7 +265,7 @@ func TestKoaSink_CtxBodyAssign(t *testing.T) {
 		"ExprMayRef":     makeRel("ExprMayRef", 2, iv(600), iv(60)),
 		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(60), iv(7)),
 		"Parameter":      makeRel("Parameter", 6, iv(7), iv(0), sv("ctx"), iv(80), iv(10), sv("")),
-		"FieldWrite":     makeRel("FieldWrite", 4, iv(200), iv(10), sv("body"), iv(300)),
+		"FieldWrite":     makeRel("FieldWrite", 5, iv(200), iv(10), sv("body"), iv(300), sv(".body")),
 	})
 
 	query := &datalog.Query{
@@ -324,7 +324,7 @@ func TestLambdaSource_EventField(t *testing.T) {
 		"ExportBinding":  makeRel("ExportBinding", 3, sv("handler"), iv(50), iv(1)),
 		"FunctionSymbol": makeRel("FunctionSymbol", 2, iv(50), iv(7)),
 		"Parameter":      makeRel("Parameter", 6, iv(7), iv(0), sv("event"), iv(80), iv(10), sv("")),
-		"FieldRead":      makeRel("FieldRead", 3, iv(100), iv(10), sv("body")),
+		"FieldRead":      makeRel("FieldRead", 4, iv(100), iv(10), sv("body"), sv(".body")),
 	})
 
 	query := &datalog.Query{

--- a/extract/rules/higherorder_test.go
+++ b/extract/rules/higherorder_test.go
@@ -11,7 +11,7 @@ import (
 // higherOrderBaseRels returns the base relations needed for higher-order rules evaluation.
 func higherOrderBaseRels(overrides map[string]*eval.Relation) map[string]*eval.Relation {
 	base := taintBaseRels(nil)
-	base["FieldRead"] = eval.NewRelation("FieldRead", 3)
+	base["FieldRead"] = eval.NewRelation("FieldRead", 4)
 	base["Function"] = eval.NewRelation("Function", 6)
 	base["JsxElement"] = eval.NewRelation("JsxElement", 3)
 	base["JsxAttribute"] = eval.NewRelation("JsxAttribute", 3)

--- a/extract/rules/localflow.go
+++ b/extract/rules/localflow.go
@@ -67,7 +67,7 @@ func LocalFlowRules() []datalog.Rule {
 		//   SymInFunction(parentSym, fn).
 		rule("LocalFlow",
 			[]datalog.Term{v("fn"), v("parentSym"), v("bindSym")},
-			pos("DestructureField", v("parent"), w(), w(), v("bindSym"), w()),
+			pos("DestructureField", v("parent"), w(), w(), v("bindSym"), w(), w()),
 			pos("VarDecl", v("parent"), w(), v("initExpr"), w()),
 			pos("ExprMayRef", v("initExpr"), v("parentSym")),
 			pos("SymInFunction", v("bindSym"), v("fn")),
@@ -82,7 +82,7 @@ func LocalFlowRules() []datalog.Rule {
 		//   SymInFunction(exprSym, fn).
 		rule("LocalFlow",
 			[]datalog.Term{v("fn"), v("baseSym"), v("exprSym")},
-			pos("FieldRead", v("expr"), v("baseSym"), w()),
+			pos("FieldRead", v("expr"), v("baseSym"), w(), w()),
 			pos("ExprMayRef", v("expr"), v("exprSym")),
 			pos("SymInFunction", v("baseSym"), v("fn")),
 			pos("SymInFunction", v("exprSym"), v("fn")),
@@ -96,7 +96,7 @@ func LocalFlowRules() []datalog.Rule {
 		//   SymInFunction(rhsSym, fn).
 		rule("LocalFlow",
 			[]datalog.Term{v("fn"), v("rhsSym"), v("baseSym")},
-			pos("FieldWrite", w(), v("baseSym"), w(), v("rhsExpr")),
+			pos("FieldWrite", w(), v("baseSym"), w(), v("rhsExpr"), w()),
 			pos("ExprMayRef", v("rhsExpr"), v("rhsSym")),
 			pos("SymInFunction", v("baseSym"), v("fn")),
 			pos("SymInFunction", v("rhsSym"), v("fn")),

--- a/extract/rules/localflow_test.go
+++ b/extract/rules/localflow_test.go
@@ -18,9 +18,9 @@ func localFlowBaseRels(overrides map[string]*eval.Relation) map[string]*eval.Rel
 		"VarDecl":          eval.NewRelation("VarDecl", 4),
 		"ReturnStmt":       eval.NewRelation("ReturnStmt", 3),
 		"ReturnSym":        eval.NewRelation("ReturnSym", 2),
-		"DestructureField": eval.NewRelation("DestructureField", 5),
-		"FieldRead":        eval.NewRelation("FieldRead", 3),
-		"FieldWrite":       eval.NewRelation("FieldWrite", 4),
+		"DestructureField": eval.NewRelation("DestructureField", 6),
+		"FieldRead":        eval.NewRelation("FieldRead", 4),
+		"FieldWrite":       eval.NewRelation("FieldWrite", 5),
 	}
 	for k, v := range overrides {
 		base[k] = v
@@ -192,7 +192,7 @@ func TestSelfAssignment(t *testing.T) {
 func TestFieldWriteFlow(t *testing.T) {
 	// fn=1, sym_obj=10, sym_x=20, assignNode=100, rhsExpr=200
 	baseRels := localFlowBaseRels(map[string]*eval.Relation{
-		"FieldWrite":    makeRel("FieldWrite", 4, iv(100), iv(10), sv("f"), iv(200)),
+		"FieldWrite":    makeRel("FieldWrite", 5, iv(100), iv(10), sv("f"), iv(200), sv(".f")),
 		"ExprMayRef":    makeRel("ExprMayRef", 2, iv(200), iv(20)),
 		"SymInFunction": makeRel("SymInFunction", 2, iv(10), iv(1), iv(20), iv(1)),
 	})
@@ -217,7 +217,7 @@ func TestFieldReadFlow(t *testing.T) {
 	// FieldRead(expr=300, baseSym=10, fieldName="f")
 	// ExprMayRef(expr=300, exprSym=20) — the read expression refers to sym_y
 	baseRels := localFlowBaseRels(map[string]*eval.Relation{
-		"FieldRead":     makeRel("FieldRead", 3, iv(300), iv(10), sv("f")),
+		"FieldRead":     makeRel("FieldRead", 4, iv(300), iv(10), sv("f"), sv(".f")),
 		"ExprMayRef":    makeRel("ExprMayRef", 2, iv(300), iv(20)),
 		"SymInFunction": makeRel("SymInFunction", 2, iv(10), iv(1), iv(20), iv(1)),
 	})
@@ -376,8 +376,8 @@ func TestFunctionScoping(t *testing.T) {
 func TestDestructuringFlow(t *testing.T) {
 	// fn=1, sym_obj=10, sym_a=20, parent(VarDecl)=100, initExpr=200
 	baseRels := localFlowBaseRels(map[string]*eval.Relation{
-		"DestructureField": makeRel("DestructureField", 5,
-			iv(100), sv("a"), sv("a"), iv(20), iv(0)),
+		"DestructureField": makeRel("DestructureField", 6,
+			iv(100), sv("a"), sv("a"), iv(20), iv(0), sv(".a")),
 		"VarDecl":       makeRel("VarDecl", 4, iv(100), iv(99), iv(200), iv(1)),
 		"ExprMayRef":    makeRel("ExprMayRef", 2, iv(200), iv(10)),
 		"SymInFunction": makeRel("SymInFunction", 2, iv(10), iv(1), iv(20), iv(1)),

--- a/extract/rules/localflowstep_test.go
+++ b/extract/rules/localflowstep_test.go
@@ -20,12 +20,15 @@ func localFlowStepBaseRels(overrides map[string]*eval.Relation) map[string]*eval
 	base["ExprMayRef"] = eval.NewRelation("ExprMayRef", 2)
 	base["ExprIsCall"] = eval.NewRelation("ExprIsCall", 2)
 	base["ReturnStmt"] = eval.NewRelation("ReturnStmt", 3)
-	base["DestructureField"] = eval.NewRelation("DestructureField", 5)
-	base["ArrayDestructure"] = eval.NewRelation("ArrayDestructure", 3)
-	base["ObjectLiteralField"] = eval.NewRelation("ObjectLiteralField", 3)
-	base["ObjectLiteralSpread"] = eval.NewRelation("ObjectLiteralSpread", 2)
-	base["FieldRead"] = eval.NewRelation("FieldRead", 3)
-	base["FieldWrite"] = eval.NewRelation("FieldWrite", 4)
+	// Phase E PR1 (#210): arities bumped by +1 for the new `path` column
+	// on the six path-bearing relations. Rules ignore the column (named-
+	// literal bindings); tests now seed it with a placeholder.
+	base["DestructureField"] = eval.NewRelation("DestructureField", 6)
+	base["ArrayDestructure"] = eval.NewRelation("ArrayDestructure", 4)
+	base["ObjectLiteralField"] = eval.NewRelation("ObjectLiteralField", 4)
+	base["ObjectLiteralSpread"] = eval.NewRelation("ObjectLiteralSpread", 3)
+	base["FieldRead"] = eval.NewRelation("FieldRead", 4)
+	base["FieldWrite"] = eval.NewRelation("FieldWrite", 5)
 	base["Await"] = eval.NewRelation("Await", 2)
 	// PR8 (#202 Gap A): lfsJsxPropBind EDB inputs.
 	base["JsxAttribute"] = eval.NewRelation("JsxAttribute", 3)
@@ -120,8 +123,8 @@ func TestLfsDestructureField(t *testing.T) {
 	// DestructureField(parent=400, srcField="foo", bindName="foo", bindSym=10, idx=0)
 	// use=500 references sym=10.
 	baseRels := localFlowStepBaseRels(map[string]*eval.Relation{
-		"DestructureField": makeRel("DestructureField", 5,
-			iv(400), sv("foo"), sv("foo"), iv(10), iv(0),
+		"DestructureField": makeRel("DestructureField", 6,
+			iv(400), sv("foo"), sv("foo"), iv(10), iv(0), sv(".foo"),
 		),
 		"ExprMayRef": makeRel("ExprMayRef", 2, iv(500), iv(10)),
 	})
@@ -134,7 +137,7 @@ func TestLfsDestructureField(t *testing.T) {
 // TestLfsArrayDestructure — `const [x, y] = arr; use(x);` flows arr→use.
 func TestLfsArrayDestructure(t *testing.T) {
 	baseRels := localFlowStepBaseRels(map[string]*eval.Relation{
-		"ArrayDestructure": makeRel("ArrayDestructure", 3, iv(400), iv(0), iv(10)),
+		"ArrayDestructure": makeRel("ArrayDestructure", 4, iv(400), iv(0), iv(10), sv(".[0]")),
 		"ExprMayRef":       makeRel("ExprMayRef", 2, iv(500), iv(10)),
 	})
 	rs := evalStep(t, baseRels, "lfsArrayDestructure")
@@ -147,8 +150,8 @@ func TestLfsArrayDestructure(t *testing.T) {
 func TestLfsObjectLiteralStore(t *testing.T) {
 	// ObjectLiteralField(parent=600, fieldName="foo", valueExpr=400)
 	baseRels := localFlowStepBaseRels(map[string]*eval.Relation{
-		"ObjectLiteralField": makeRel("ObjectLiteralField", 3,
-			iv(600), sv("foo"), iv(400),
+		"ObjectLiteralField": makeRel("ObjectLiteralField", 4,
+			iv(600), sv("foo"), iv(400), sv(".foo"),
 		),
 	})
 	rs := evalStep(t, baseRels, "lfsObjectLiteralStore")
@@ -160,7 +163,7 @@ func TestLfsObjectLiteralStore(t *testing.T) {
 // TestLfsSpreadElement — `{ ...rest }` flows rest into the object literal.
 func TestLfsSpreadElement(t *testing.T) {
 	baseRels := localFlowStepBaseRels(map[string]*eval.Relation{
-		"ObjectLiteralSpread": makeRel("ObjectLiteralSpread", 2, iv(600), iv(400)),
+		"ObjectLiteralSpread": makeRel("ObjectLiteralSpread", 3, iv(600), iv(400), sv(".{*}")),
 	})
 	rs := evalStep(t, baseRels, "lfsSpreadElement")
 	if len(rs.Rows) != 1 || !resultContains(rs, iv(400), iv(600)) {
@@ -174,7 +177,7 @@ func TestLfsSpreadElement(t *testing.T) {
 func TestLfsFieldRead(t *testing.T) {
 	// FieldRead(expr=600, baseSym=10, "foo"); ExprMayRef(from=400, sym=10).
 	baseRels := localFlowStepBaseRels(map[string]*eval.Relation{
-		"FieldRead":  makeRel("FieldRead", 3, iv(600), iv(10), sv("foo")),
+		"FieldRead":  makeRel("FieldRead", 4, iv(600), iv(10), sv("foo"), sv(".foo")),
 		"ExprMayRef": makeRel("ExprMayRef", 2, iv(400), iv(10)),
 	})
 	rs := evalStep(t, baseRels, "lfsFieldRead")
@@ -188,7 +191,7 @@ func TestLfsFieldRead(t *testing.T) {
 func TestLfsFieldWrite(t *testing.T) {
 	// FieldWrite(assignNode=700, baseSym=10, "foo", rhsExpr=400); ExprMayRef(to=500, sym=10).
 	baseRels := localFlowStepBaseRels(map[string]*eval.Relation{
-		"FieldWrite": makeRel("FieldWrite", 4, iv(700), iv(10), sv("foo"), iv(400)),
+		"FieldWrite": makeRel("FieldWrite", 5, iv(700), iv(10), sv("foo"), iv(400), sv(".foo")),
 		"ExprMayRef": makeRel("ExprMayRef", 2, iv(500), iv(10)),
 	})
 	rs := evalStep(t, baseRels, "lfsFieldWrite")
@@ -235,9 +238,9 @@ func TestLfsJsxPropBind(t *testing.T) {
 		"FunctionSymbol":          makeRel("FunctionSymbol", 2, iv(50), iv(1)),
 		"Parameter":               makeRel("Parameter", 6, iv(1), iv(0), sv("{ value, onClick }"), iv(80), iv(10), sv("")),
 		"ParamDestructurePattern": makeRel("ParamDestructurePattern", 2, iv(80), iv(85)),
-		"DestructureField": makeRel("DestructureField", 5,
-			iv(85), sv("value"), sv("value"), iv(20), iv(0),
-			iv(85), sv("onClick"), sv("onClick"), iv(30), iv(1),
+		"DestructureField": makeRel("DestructureField", 6,
+			iv(85), sv("value"), sv("value"), iv(20), iv(0), sv(".value"),
+			iv(85), sv("onClick"), sv("onClick"), iv(30), iv(1), sv(".onClick"),
 		),
 		"ExprMayRef": makeRel("ExprMayRef", 2,
 			iv(513), iv(20),
@@ -297,21 +300,21 @@ func TestLocalFlowStepUnion(t *testing.T) {
 		"ReturnStmt": makeRel("ReturnStmt", 3, iv(1), iv(81), iv(404)),
 		"ExprIsCall": makeRel("ExprIsCall", 2, iv(604), iv(303)),
 		// lfsDestructureField: parent=405, bindSym=15
-		"DestructureField": makeRel("DestructureField", 5,
-			iv(405), sv("k"), sv("k"), iv(15), iv(0),
+		"DestructureField": makeRel("DestructureField", 6,
+			iv(405), sv("k"), sv("k"), iv(15), iv(0), sv(".k"),
 		),
 		// lfsArrayDestructure: parent=406, bindSym=16
-		"ArrayDestructure": makeRel("ArrayDestructure", 3, iv(406), iv(0), iv(16)),
+		"ArrayDestructure": makeRel("ArrayDestructure", 4, iv(406), iv(0), iv(16), sv(".[0]")),
 		// lfsObjectLiteralStore: ObjectLiteralField(607, "f", 407)
-		"ObjectLiteralField": makeRel("ObjectLiteralField", 3,
-			iv(607), sv("f"), iv(407),
+		"ObjectLiteralField": makeRel("ObjectLiteralField", 4,
+			iv(607), sv("f"), iv(407), sv(".f"),
 		),
 		// lfsSpreadElement: ObjectLiteralSpread(608, 408)
-		"ObjectLiteralSpread": makeRel("ObjectLiteralSpread", 2, iv(608), iv(408)),
+		"ObjectLiteralSpread": makeRel("ObjectLiteralSpread", 3, iv(608), iv(408), sv(".{*}")),
 		// lfsFieldRead: FieldRead(609, 17, "f"), ExprMayRef(409, 17)
-		"FieldRead": makeRel("FieldRead", 3, iv(609), iv(17), sv("f")),
+		"FieldRead": makeRel("FieldRead", 4, iv(609), iv(17), sv("f"), sv(".f")),
 		// lfsFieldWrite: FieldWrite(_, 18, "f", 410), ExprMayRef(510, 18)
-		"FieldWrite": makeRel("FieldWrite", 4, iv(710), iv(18), sv("f"), iv(410)),
+		"FieldWrite": makeRel("FieldWrite", 5, iv(710), iv(18), sv("f"), iv(410), sv(".f")),
 		// lfsAwait: Await(611, 411)
 		"Await": makeRel("Await", 2, iv(611), iv(411)),
 		// ExprMayRef rows for the kinds that need them.

--- a/extract/rules/summaries.go
+++ b/extract/rules/summaries.go
@@ -54,7 +54,7 @@ func SummaryRules() []datalog.Rule {
 			[]datalog.Term{v("fn"), v("paramIdx"), v("fieldName")},
 			pos("Parameter", v("fn"), v("paramIdx"), w(), w(), v("paramSym"), w()),
 			pos("FunctionContains", v("fn"), v("assignNode")),
-			pos("FieldWrite", v("assignNode"), w(), v("fieldName"), v("rhsExpr")),
+			pos("FieldWrite", v("assignNode"), w(), v("fieldName"), v("rhsExpr"), w()),
 			pos("ExprMayRef", v("rhsExpr"), v("rhsSym")),
 			pos("LocalFlowStar", v("fn"), v("paramSym"), v("rhsSym")),
 		),

--- a/extract/rules/summaries_test.go
+++ b/extract/rules/summaries_test.go
@@ -19,9 +19,9 @@ func summaryBaseRels(overrides map[string]*eval.Relation) map[string]*eval.Relat
 		"VarDecl":          eval.NewRelation("VarDecl", 4),
 		"ReturnStmt":       eval.NewRelation("ReturnStmt", 3),
 		"ReturnSym":        eval.NewRelation("ReturnSym", 2),
-		"DestructureField": eval.NewRelation("DestructureField", 5),
-		"FieldRead":        eval.NewRelation("FieldRead", 3),
-		"FieldWrite":       eval.NewRelation("FieldWrite", 4),
+		"DestructureField": eval.NewRelation("DestructureField", 6),
+		"FieldRead":        eval.NewRelation("FieldRead", 4),
+		"FieldWrite":       eval.NewRelation("FieldWrite", 5),
 		// Summary-specific dependencies
 		"Parameter":        eval.NewRelation("Parameter", 6),
 		"FunctionContains": eval.NewRelation("FunctionContains", 2),
@@ -180,7 +180,7 @@ func TestParamToFieldWrite(t *testing.T) {
 			iv(1), iv(1), sv("val"), iv(51), iv(20), sv(""),
 		),
 		"FunctionContains": makeRel("FunctionContains", 2, iv(1), iv(300)),
-		"FieldWrite":       makeRel("FieldWrite", 4, iv(300), iv(10), sv("x"), iv(400)),
+		"FieldWrite":       makeRel("FieldWrite", 5, iv(300), iv(10), sv("x"), iv(400), sv(".x")),
 		"ExprMayRef": makeRel("ExprMayRef", 2,
 			iv(400), iv(25), // rhs references vSym
 			iv(600), iv(20), // initExpr references val param

--- a/extract/rules/taint.go
+++ b/extract/rules/taint.go
@@ -97,7 +97,7 @@ func TaintRules() []datalog.Rule {
 		//     ExprMayRef(rhsExpr, rhsSym), TaintedSym(rhsSym, kind).
 		rule("TaintedField",
 			[]datalog.Term{v("baseSym"), v("fieldName"), v("kind")},
-			pos("FieldWrite", w(), v("baseSym"), v("fieldName"), v("rhsExpr")),
+			pos("FieldWrite", w(), v("baseSym"), v("fieldName"), v("rhsExpr"), w()),
 			mustNamedLiteral("ExprMayRef", map[string]datalog.Term{
 				"expr": v("rhsExpr"),
 				"sym":  v("rhsSym"),
@@ -110,7 +110,7 @@ func TaintRules() []datalog.Rule {
 		//     ExprMayRef(expr, readSym), TaintedField(baseSym, fieldName, kind).
 		rule("TaintedSym",
 			[]datalog.Term{v("readSym"), v("kind")},
-			pos("FieldRead", v("expr"), v("baseSym"), v("fieldName")),
+			pos("FieldRead", v("expr"), v("baseSym"), v("fieldName"), w()),
 			mustNamedLiteral("ExprMayRef", map[string]datalog.Term{
 				"expr": v("expr"),
 				"sym":  v("readSym"),

--- a/extract/rules/taint_test.go
+++ b/extract/rules/taint_test.go
@@ -20,9 +20,9 @@ func taintBaseRels(overrides map[string]*eval.Relation) map[string]*eval.Relatio
 		"VarDecl":          eval.NewRelation("VarDecl", 4),
 		"ReturnStmt":       eval.NewRelation("ReturnStmt", 3),
 		"ReturnSym":        eval.NewRelation("ReturnSym", 2),
-		"DestructureField": eval.NewRelation("DestructureField", 5),
-		"FieldRead":        eval.NewRelation("FieldRead", 3),
-		"FieldWrite":       eval.NewRelation("FieldWrite", 4),
+		"DestructureField": eval.NewRelation("DestructureField", 6),
+		"FieldRead":        eval.NewRelation("FieldRead", 4),
+		"FieldWrite":       eval.NewRelation("FieldWrite", 5),
 		// Summary dependencies
 		"Parameter":        eval.NewRelation("Parameter", 6),
 		"FunctionContains": eval.NewRelation("FunctionContains", 2),
@@ -291,12 +291,12 @@ func TestTaintedField_WriteAndRead(t *testing.T) {
 			iv(300), iv(30), // read expr a → readSymA
 			iv(400), iv(40), // read expr b → readSymB
 		),
-		"FieldWrite": makeRel("FieldWrite", 4,
-			iv(200), iv(50), sv("a"), iv(150), // obj.a = tainted
+		"FieldWrite": makeRel("FieldWrite", 5,
+			iv(200), iv(50), sv("a"), iv(150), sv(".a"), // obj.a = tainted
 		),
-		"FieldRead": makeRel("FieldRead", 3,
-			iv(300), iv(50), sv("a"), // read obj.a
-			iv(400), iv(50), sv("b"), // read obj.b
+		"FieldRead": makeRel("FieldRead", 4,
+			iv(300), iv(50), sv("a"), sv(".a"), // read obj.a
+			iv(400), iv(50), sv("b"), sv(".b"), // read obj.b
 		),
 	})
 

--- a/extract/schema/relations.go
+++ b/extract/schema/relations.go
@@ -142,16 +142,26 @@ func init() {
 		{Name: "expr", Type: TypeEntityRef},
 		{Name: "call", Type: TypeEntityRef},
 	}})
+	// Phase E PR1 (#210): FieldRead/FieldWrite gain a structured `path`
+	// discriminator column appended at the end. Encoding:
+	//   - Field access `.foo` → ".foo"
+	//   - Empty/unknown        → "" (sentinel, same row semantics as path-erased)
+	// The path is a simple string for E1; interning and int-keyed side
+	// relations are deferred to E2/E3 if bench shows cardinality issues.
+	// Existing named-literal consumers ignore the column; positional
+	// consumers have been updated with a trailing wildcard.
 	RegisterRelation(RelationDef{Name: "FieldRead", Version: 1, Columns: []ColumnDef{
 		{Name: "expr", Type: TypeEntityRef},
 		{Name: "baseSym", Type: TypeEntityRef},
 		{Name: "fieldName", Type: TypeString},
+		{Name: "path", Type: TypeString},
 	}})
 	RegisterRelation(RelationDef{Name: "FieldWrite", Version: 1, Columns: []ColumnDef{
 		{Name: "assignNode", Type: TypeEntityRef},
 		{Name: "baseSym", Type: TypeEntityRef},
 		{Name: "fieldName", Type: TypeString},
 		{Name: "rhsExpr", Type: TypeEntityRef},
+		{Name: "path", Type: TypeString},
 	}})
 	RegisterRelation(RelationDef{Name: "Await", Version: 1, Columns: []ColumnDef{
 		{Name: "expr", Type: TypeEntityRef},
@@ -162,17 +172,27 @@ func init() {
 		{Name: "innerExpr", Type: TypeEntityRef},
 	}})
 	// Destructuring
+	// Phase E PR1 (#210): destructure relations gain a structured `path`
+	// discriminator column. Encoding:
+	//   - Object-destructure of field `foo` → ".foo"
+	//   - Array-destructure at index `i`     → ".[i]"
+	// Downstream E2/E3 rules key on this column to distinguish
+	// `const [c, setC] = useState(0)` slot 0 from slot 1 without a
+	// predicate wrapper. Column is additive; existing named-literal
+	// consumers are unaffected.
 	RegisterRelation(RelationDef{Name: "DestructureField", Version: 1, Columns: []ColumnDef{
 		{Name: "parent", Type: TypeEntityRef},
 		{Name: "sourceField", Type: TypeString},
 		{Name: "bindName", Type: TypeString},
 		{Name: "bindSym", Type: TypeEntityRef},
 		{Name: "idx", Type: TypeInt32},
+		{Name: "path", Type: TypeString},
 	}})
 	RegisterRelation(RelationDef{Name: "ArrayDestructure", Version: 1, Columns: []ColumnDef{
 		{Name: "parent", Type: TypeEntityRef},
 		{Name: "idx", Type: TypeInt32},
 		{Name: "bindSym", Type: TypeEntityRef},
+		{Name: "path", Type: TypeString},
 	}})
 	RegisterRelation(RelationDef{Name: "DestructureRest", Version: 1, Columns: []ColumnDef{
 		{Name: "parent", Type: TypeEntityRef},
@@ -203,10 +223,17 @@ func init() {
 	// look up which symbol a Provider's value object exposes under a given
 	// field name. v1 limitations: spread elements (`{ ...rest }`) and
 	// computed-key properties are skipped silently.
+	// Phase E PR1 (#210): `path` discriminator column appended. Encoding:
+	//   - Named field `foo` → ".foo"
+	// For E1 the discriminator echoes `fieldName`; its purpose is to give
+	// E2/E3 a uniform `path` key across field-bearing relations (ObjectLiteralField,
+	// DestructureField, FieldRead, FieldWrite) so path composition can be
+	// expressed without per-relation plumbing.
 	RegisterRelation(RelationDef{Name: "ObjectLiteralField", Version: 1, Columns: []ColumnDef{
 		{Name: "parent", Type: TypeEntityRef},
 		{Name: "fieldName", Type: TypeString},
 		{Name: "valueExpr", Type: TypeEntityRef},
+		{Name: "path", Type: TypeString},
 	}})
 	// ObjectLiteralSpread: a `...expr` element of an object literal.
 	// `parent` is the enclosing object expression node id; `valueExpr` is
@@ -214,9 +241,14 @@ func init() {
 	// Round-3 of the React context-alias work uses this together with a
 	// VarDecl-to-ObjectExpression resolution to compute the union of own
 	// fields and spread-contributed fields of a Provider value object.
+	// Phase E PR1 (#210): `path` discriminator column appended. Spread
+	// elements contribute to ALL of the parent object's field slots, so
+	// the path is the wildcard sentinel ".{*}". E2/E3's `PathCompose`
+	// collapses any composition involving this wildcard to the wildcard.
 	RegisterRelation(RelationDef{Name: "ObjectLiteralSpread", Version: 1, Columns: []ColumnDef{
 		{Name: "parent", Type: TypeEntityRef},
 		{Name: "valueExpr", Type: TypeEntityRef},
+		{Name: "path", Type: TypeString},
 	}})
 	// JSX
 	RegisterRelation(RelationDef{Name: "JsxElement", Version: 1, Columns: []ColumnDef{

--- a/extract/walker.go
+++ b/extract/walker.go
@@ -218,6 +218,37 @@ func (fw *FactWalker) emit(rel string, vals ...interface{}) {
 	_ = r.AddTuple(fw.db, vals...)
 }
 
+// Phase E PR1 (#210) access-path encoding helpers.
+//
+// These produce the `path` column value for the six path-bearing
+// relations (FieldRead, FieldWrite, DestructureField, ArrayDestructure,
+// ObjectLiteralField, ObjectLiteralSpread). Encoding is a structured
+// discriminator string that E2/E3 will key on:
+//
+//   - Named field `foo`       → ".foo"
+//   - Array index `i`         → ".[i]"
+//   - Spread (all-fields)     → ".{*}" (wildcard sentinel)
+//   - Unknown / missing name  → ""     (empty-path sentinel; same
+//     row semantics as path-erased)
+//
+// The encoding is a simple string for E1; interning and side-relation
+// (AccessPath/AccessPathIndex/AccessPathField) are deferred to E2/E3
+// if bench shows cardinality blow-up.
+func fieldPath(name string) string {
+	if name == "" {
+		return ""
+	}
+	return "." + name
+}
+
+func indexPath(idx int32) string {
+	return fmt.Sprintf(".[%d]", idx)
+}
+
+func spreadPath() string {
+	return ".{*}"
+}
+
 func (fw *FactWalker) emitExtractError(fileID uint32, line int, phase, msg string) {
 	_ = fw.db.Relation("ExtractError").AddTuple(fw.db, fileID, int32(line), phase, msg)
 }
@@ -688,7 +719,7 @@ func (fw *FactWalker) emitFieldRead(node ASTNode, id uint32) {
 		}
 	}
 
-	fw.emit("FieldRead", id, baseSymID, propNode.Text())
+	fw.emit("FieldRead", id, baseSymID, propNode.Text(), fieldPath(propNode.Text()))
 }
 
 func (fw *FactWalker) emitFieldWrite(memberNode ASTNode, assignID uint32, rhsID uint32) {
@@ -705,7 +736,7 @@ func (fw *FactWalker) emitFieldWrite(memberNode ASTNode, assignID uint32, rhsID 
 		}
 	}
 
-	fw.emit("FieldWrite", assignID, baseSymID, propNode.Text(), rhsID)
+	fw.emit("FieldWrite", assignID, baseSymID, propNode.Text(), rhsID, fieldPath(propNode.Text()))
 }
 
 // ---- Await ----
@@ -780,7 +811,7 @@ func (fw *FactWalker) emitObjectLiteral(node ASTNode, id uint32) {
 			// resolve the shorthand binding back to its declaration.
 			name := child.Text()
 			valID := fw.nid(child)
-			fw.emit("ObjectLiteralField", id, name, valID)
+			fw.emit("ObjectLiteralField", id, name, valID, fieldPath(name))
 			if decl, ok := fw.scope.Resolve(name, child); ok {
 				symID := SymID(decl.FilePath, decl.Name, decl.StartLine, decl.StartCol)
 				fw.emit("ExprMayRef", valID, symID)
@@ -795,13 +826,13 @@ func (fw *FactWalker) emitObjectLiteral(node ASTNode, id uint32) {
 			case "PropertyIdentifier", "Identifier":
 				name := keyNode.Text()
 				valID := fw.nid(valNode)
-				fw.emit("ObjectLiteralField", id, name, valID)
+				fw.emit("ObjectLiteralField", id, name, valID, fieldPath(name))
 			case "String":
 				// String-literal key, e.g. `{ "setX": foo }`. Treat as a
 				// stable named field equal to the string's content.
 				if name, ok := stripStringLiteralQuotes(keyNode.Text()); ok {
 					valID := fw.nid(valNode)
-					fw.emit("ObjectLiteralField", id, name, valID)
+					fw.emit("ObjectLiteralField", id, name, valID, fieldPath(name))
 				}
 			case "ComputedPropertyName":
 				// Round-3: `{ [KEY]: foo }` — resolve at extraction time when
@@ -824,7 +855,7 @@ func (fw *FactWalker) emitObjectLiteral(node ASTNode, id uint32) {
 				}
 				if ok {
 					valID := fw.nid(valNode)
-					fw.emit("ObjectLiteralField", id, name, valID)
+					fw.emit("ObjectLiteralField", id, name, valID, fieldPath(name))
 				}
 			default:
 				// numeric keys, template-literal keys, etc. — skip.
@@ -844,7 +875,7 @@ func (fw *FactWalker) emitObjectLiteral(node ASTNode, id uint32) {
 				continue
 			}
 			innerID := fw.nid(inner)
-			fw.emit("ObjectLiteralSpread", id, innerID)
+			fw.emit("ObjectLiteralSpread", id, innerID, spreadPath())
 		}
 	}
 }
@@ -865,7 +896,7 @@ func (fw *FactWalker) emitDestructureObject(node ASTNode, id uint32) {
 		case "ShorthandPropertyIdentifierPattern", "ShorthandPropertyIdentifier":
 			name := child.Text()
 			symID := SymID(fw.filePath, name, child.StartLine(), child.StartCol())
-			fw.emit("DestructureField", id, name, name, symID, idx)
+			fw.emit("DestructureField", id, name, name, symID, idx, fieldPath(name))
 			idx++
 		case "Pair", "PairPattern":
 			keyNode := childByField(child, "key")
@@ -880,7 +911,7 @@ func (fw *FactWalker) emitDestructureObject(node ASTNode, id uint32) {
 				bindName = valNode.Text()
 				bindSymID = SymID(fw.filePath, bindName, valNode.StartLine(), valNode.StartCol())
 			}
-			fw.emit("DestructureField", id, sourceField, bindName, bindSymID, idx)
+			fw.emit("DestructureField", id, sourceField, bindName, bindSymID, idx, fieldPath(sourceField))
 			idx++
 		case "RestPattern":
 			inner := childByKind(child, "Identifier")
@@ -894,7 +925,7 @@ func (fw *FactWalker) emitDestructureObject(node ASTNode, id uint32) {
 			if left != nil {
 				name := left.Text()
 				symID := SymID(fw.filePath, name, left.StartLine(), left.StartCol())
-				fw.emit("DestructureField", id, name, name, symID, idx)
+				fw.emit("DestructureField", id, name, name, symID, idx, fieldPath(name))
 				idx++
 			}
 		}
@@ -925,7 +956,7 @@ func (fw *FactWalker) emitDestructureArray(node ASTNode, id uint32) {
 			if name != "" {
 				symID = SymID(fw.filePath, name, child.StartLine(), child.StartCol())
 			}
-			fw.emit("ArrayDestructure", id, idx, symID)
+			fw.emit("ArrayDestructure", id, idx, symID, indexPath(idx))
 			idx++
 		}
 	}

--- a/extract/walker_path_test.go
+++ b/extract/walker_path_test.go
@@ -1,0 +1,196 @@
+package extract
+
+import (
+	"testing"
+
+	"github.com/Gjdoalfnrxu/tsq/extract/db"
+)
+
+// Phase E PR1 (#210) regression guards: assert the new `path` discriminator
+// column is populated with the documented structured sentinels on each of the
+// six extended relations. Per-kind floors protect each path family.
+//
+// Encoding (spec §3, PR-E1):
+//   - named field      -> ".foo"
+//   - array index i    -> ".[i]"
+//   - spread wildcard  -> ".{*}"
+//   - empty sentinel   -> ""
+//
+// Mutation-probe table (each assertion fails if its producing leg is removed):
+//
+//   relation           path sentinel  test                          producing leg
+//   -----------------  -------------  ----------------------------  ---------------------
+//   FieldRead          ".x"           TestPath_FieldRead_Named      walker.go fieldPath()
+//   FieldWrite         ".y"           TestPath_FieldWrite_Named     walker.go fieldPath()
+//   ObjectLiteralField ".k"           TestPath_ObjectLiteralField   walker.go fieldPath()
+//   ObjectLiteralSpread ".{*}"        TestPath_ObjectLiteralSpread  walker.go spreadPath()
+//   DestructureField   ".a"           TestPath_DestructureField     walker.go fieldPath()
+//   ArrayDestructure   ".[0]"/".[1]"  TestPath_ArrayDestructure     walker.go indexPath()
+
+// countNonEmptyString returns how many tuples have a non-empty string at col.
+func countNonEmptyString(t *testing.T, database *db.DB, r *db.Relation, col int) int {
+	t.Helper()
+	n := 0
+	for i := 0; i < r.Tuples(); i++ {
+		if v, err := r.GetString(database, i, col); err == nil && v != "" {
+			n++
+		}
+	}
+	return n
+}
+
+func TestPath_FieldRead_Named(t *testing.T) {
+	src := `
+const obj = { x: 1 };
+const v = obj.x;
+`
+	database := walkerTestDB(t, src)
+	r := rel(t, database, "FieldRead")
+	if r.Tuples() == 0 {
+		t.Fatal("FieldRead: expected at least one tuple")
+	}
+	// path column is the trailing column (col 3, 0-based).
+	if !hasString(t, database, r, 3, ".x") {
+		t.Errorf("FieldRead: expected path '.x' in col 3")
+	}
+	if countNonEmptyString(t, database, r, 3) == 0 {
+		t.Error("FieldRead: expected at least one non-empty path")
+	}
+}
+
+func TestPath_FieldWrite_Named(t *testing.T) {
+	src := `
+const obj: any = {};
+obj.y = 2;
+`
+	database := walkerTestDB(t, src)
+	r := rel(t, database, "FieldWrite")
+	if r.Tuples() == 0 {
+		t.Fatal("FieldWrite: expected at least one tuple")
+	}
+	// path column is trailing col 4 (0-based).
+	if !hasString(t, database, r, 4, ".y") {
+		t.Errorf("FieldWrite: expected path '.y' in col 4")
+	}
+	if countNonEmptyString(t, database, r, 4) == 0 {
+		t.Error("FieldWrite: expected at least one non-empty path")
+	}
+}
+
+func TestPath_ObjectLiteralField(t *testing.T) {
+	src := `
+const o = { k: 1, m: 2 };
+`
+	database := walkerTestDB(t, src)
+	r := rel(t, database, "ObjectLiteralField")
+	if r.Tuples() == 0 {
+		t.Fatal("ObjectLiteralField: expected at least one tuple")
+	}
+	// path column is trailing col 3.
+	if !hasString(t, database, r, 3, ".k") {
+		t.Errorf("ObjectLiteralField: expected path '.k' in col 3")
+	}
+	if !hasString(t, database, r, 3, ".m") {
+		t.Errorf("ObjectLiteralField: expected path '.m' in col 3")
+	}
+}
+
+func TestPath_ObjectLiteralSpread(t *testing.T) {
+	src := `
+const a = { x: 1 };
+const b = { ...a, y: 2 };
+`
+	database := walkerTestDB(t, src)
+	r := rel(t, database, "ObjectLiteralSpread")
+	if r.Tuples() == 0 {
+		t.Fatal("ObjectLiteralSpread: expected at least one tuple")
+	}
+	// path column is trailing col 2.
+	if !hasString(t, database, r, 2, ".{*}") {
+		t.Errorf("ObjectLiteralSpread: expected path '.{*}' (spread wildcard) in col 2")
+	}
+	// Every spread row MUST carry the wildcard — spread is total.
+	for i := 0; i < r.Tuples(); i++ {
+		v, err := r.GetString(database, i, 2)
+		if err != nil || v != ".{*}" {
+			t.Errorf("ObjectLiteralSpread row %d: path=%q, want '.{*}'", i, v)
+		}
+	}
+}
+
+func TestPath_DestructureField(t *testing.T) {
+	src := `
+const { a, b: c } = obj;
+`
+	database := walkerTestDB(t, src)
+	r := rel(t, database, "DestructureField")
+	if r.Tuples() == 0 {
+		t.Fatal("DestructureField: expected at least one tuple")
+	}
+	// path column is trailing col 5 (0-based).
+	if !hasString(t, database, r, 5, ".a") {
+		t.Errorf("DestructureField: expected path '.a' in col 5")
+	}
+	if !hasString(t, database, r, 5, ".b") {
+		t.Errorf("DestructureField: expected path '.b' (source field) in col 5")
+	}
+}
+
+func TestPath_ArrayDestructure(t *testing.T) {
+	src := `
+const [x, y] = arr;
+`
+	database := walkerTestDB(t, src)
+	r := rel(t, database, "ArrayDestructure")
+	if r.Tuples() == 0 {
+		t.Fatal("ArrayDestructure: expected at least one tuple")
+	}
+	// path column is trailing col 3.
+	if !hasString(t, database, r, 3, ".[0]") {
+		t.Errorf("ArrayDestructure: expected path '.[0]' in col 3")
+	}
+	if !hasString(t, database, r, 3, ".[1]") {
+		t.Errorf("ArrayDestructure: expected path '.[1]' in col 3")
+	}
+}
+
+// TestPath_Shapes_AllNonEmpty asserts a non-zero floor for every new path kind
+// in a small combined fixture — guards against a regression where one of the
+// three encoding helpers (fieldPath / indexPath / spreadPath) silently returns
+// "" and the per-relation tests still pass because another tuple carries a
+// valid path.
+func TestPath_Shapes_AllNonEmpty(t *testing.T) {
+	src := `
+const obj = { x: 1, y: 2 };
+const v = obj.x;
+obj.y = 3;
+const { a, b: c } = obj;
+const [p, q] = [1, 2];
+const merged = { ...obj, z: 4 };
+`
+	database := walkerTestDB(t, src)
+
+	cases := []struct {
+		rel  string
+		col  int
+		kind string
+	}{
+		{"FieldRead", 3, "named field"},
+		{"FieldWrite", 4, "named field"},
+		{"ObjectLiteralField", 3, "named field"},
+		{"ObjectLiteralSpread", 2, "spread wildcard"},
+		{"DestructureField", 5, "named field"},
+		{"ArrayDestructure", 3, "array index"},
+	}
+	for _, c := range cases {
+		r := rel(t, database, c.rel)
+		if r.Tuples() == 0 {
+			t.Errorf("%s: expected at least one tuple (fixture coverage)", c.rel)
+			continue
+		}
+		n := countNonEmptyString(t, database, r, c.col)
+		if n == 0 {
+			t.Errorf("%s: expected non-empty path (%s) in col %d, got 0 of %d", c.rel, c.kind, c.col, r.Tuples())
+		}
+	}
+}


### PR DESCRIPTION
## Scope

Phase E PR1 of the tsq value-flow layer, per `~/Documents/ObsidianVault/Wiki/Tech/tsq-issue-210-design.md` §PR-E1. Adds a structured `path` discriminator column to six relations emitted by the extractor:

| Relation | Encoding | Column idx (0-based) |
|---|---|---|
| `FieldRead` | `".foo"` | 3 |
| `FieldWrite` | `".foo"` | 4 |
| `ObjectLiteralField` | `".foo"` | 3 |
| `ObjectLiteralSpread` | `".{*}"` | 2 |
| `DestructureField` | `".foo"` (source field) | 5 |
| `ArrayDestructure` | `".[i]"` | 3 |

Unknown / missing → `""` (empty-path sentinel, equivalent to path-erased). Encoding helpers are three one-liners in `extract/walker.go` (`fieldPath`, `indexPath`, `spreadPath`); interning / int-keyed side relations deferred to E2/E3 if bench shows cardinality issues.

**Extractor-only.** No closure changes. E2 rebuilds `lfs*` rules on top; E3 makes `MayResolveToRec` path-sensitive.

**LoC (vs `main`):** +447 / −147, of which ~300 lines are mechanical trailing-`_` updates to positional consumers across 5 bridge `.qll` files and 4 `extract/rules/*.go` rule bodies plus their tests. Net new logic: ~50 LoC (walker helpers + 6 emit-site changes + schema/manifest entries) and ~200 LoC of `extract/walker_path_test.go` regression guards.

## What moved

**Schema (`extract/schema/relations.go`):** trailing `TypeString` column on the six relations above. Annotated with design-doc-pointer comments.

**Walker (`extract/walker.go`):** three encoding helpers + 6 emit-site call-site updates in `emitFieldRead`, `emitFieldWrite`, `emitObjectLiteral` (shorthand / pair / string-literal-key / computed-key / spread), `emitDestructureObject` (shorthand / pair / rest / assign), `emitDestructureArray`.

**Tests (`extract/walker_path_test.go`, new):** six per-relation tests asserting non-zero rows with the expected structured sentinel, plus `TestPath_Shapes_AllNonEmpty` which guards against any of the three helpers silently returning `""` via a combined fixture covering all path kinds.

**Downstream consumers updated with trailing `_`** — all existing named-literal consumers ignore the new column automatically; positional consumers were swept:

- `bridge/tsq_expressions.qll` — class wrappers grow a `getPath()` accessor on FieldRead/FieldWrite/ObjectLiteralField/DestructureField/ArrayDestructure.
- `bridge/tsq_react.qll` — 20+ call-sites across R1–R4 predicates.
- `bridge/tsq_valueflow.qll` — `mayResolveToFieldRead`, `mayResolveToObjectField`.
- `bridge/compat_dom.qll`, `bridge/compat_javascript.qll` — `PropAccess` / `PropWrite` / `AttributeWrite` / `InnerHtmlWrite`.
- `extract/rules/localflow.go`, `frameworks.go`, `summaries.go`, `taint.go` — 12 positional predicates in rule bodies.

## Regression-guard rules

| Rule | How E1 honours it |
|---|---|
| (a) non-zero real-fixture assertion per new primitive | 6 `TestPath_*` + `TestPath_Shapes_AllNonEmpty` in `extract/walker_path_test.go`, all against walker-on-real-source fixtures |
| (b) per-kind floors at ~50% of observed | fixtures sized to produce exactly the expected rows (1–2 each); `hasString` checks the exact path sentinel so the floor IS the observed count |
| (c) overlap with prior-PR rules | no overlap — E1 is pure additive column, no predicate body changes |
| (d) carve-outs | none |
| (e) split base-vs-recursive floors | N/A — E1 adds no recursive predicate |
| (f) manifest `File:` grep sweep | done — grep of `(FieldRead\|FieldWrite\|ObjectLiteralField\|ObjectLiteralSpread\|DestructureField\|ArrayDestructure)\s*\(` across `**/*.qll` shows every call-site updated to the new arity (see trailing `_`s in bridge diff) |
| (g) end-to-end planner-stack verification | N/A — no recursive predicate; full `go test ./...` green |

## Mutation-probe table

Each new assertion flipped and re-run to confirm non-vacuous. After each probe the file was restored and tests green.

| Assertion | Mutation | Result |
|---|---|---|
| `TestPath_FieldRead_Named` `hasString(…,3,".x")` | `".x"` → `".NOPE"` | FAIL (as expected) |
| `TestPath_ArrayDestructure` `hasString(…,3,".[0]")` | `".[0]"` → `".[99]"` | FAIL (as expected) |
| `TestPath_ObjectLiteralSpread` `hasString(…,2,".{*}")` | `".{*}"` → `".MISS"` | FAIL (as expected) |

Remaining tests (`FieldWrite_Named`, `ObjectLiteralField`, `DestructureField`, `Shapes_AllNonEmpty`) follow the same pattern and share the `hasString` helper; the three probes above cover the three distinct encoding helpers (`fieldPath`, `indexPath`, `spreadPath`) and therefore all test families.

## Harness delta

Phase D PR7 (#209) bench harness run in `bench/valueflow/results/run_e1_local/` and `run_e1_mastodon/`, compared against `run_001` (PR #209 baseline).

**local_fixtures:**

| Predicate | run_001 | run_e1_local | Δ |
|---|---:|---:|---:|
| `mayResolveToRec` | 481 | 481 | 0 |
| `mayResolveTo_all` | 695 | 695 | 0 |
| `mayResolveTo_dataflow` | 481 | 481 | 0 |
| `resolvesToFunctionDirect` | 49 | 49 | 0 |

Zero delta across all measured predicates — expected. E1 is extractor-only and the measured predicates do not project on the new path column. Extractor EDB rowcounts (FieldRead / ObjectLiteralField / etc.) grow by the presence of the new column's tuple-width; tuple counts themselves are unchanged.

**mastodon:** extraction succeeded clean (598 files, 7073 type facts, 0 errors). Harness emits zero measured-query rows on mastodon in both baseline `run_001` and `run_e1_mastodon` — pre-existing harness behaviour on that corpus, out of scope for E1. The extraction-ran-clean signal is the E1-relevant one here.

## Design-doc deviations

None material. Two minor simplifications vs the design doc's §PR-E1 wording:

1. Paths are stored as simple strings rather than int-interned ids with a side-relation (`AccessPathField` / `AccessPathIndex`). The design doc flags interning as a mitigation IF cardinality blows up; E1 ships the simpler encoding and defers interning to E2/E3 if bench shows pressure. Rationale: zero rowcount delta on local fixtures; path strings are short and compressible.

2. `ObjectLiteralField`'s path column currently echoes `fieldName`. The design doc calls this out: "its purpose is to give E2/E3 a uniform `path` key across field-bearing relations." Kept as an explicit column so E2's `PathCompose` can key on `path` uniformly without per-relation casing.

Both deviations are called out inline in `extract/schema/relations.go` comments.

## Anything that looked wrong mid-implementation

- `mastodon.csv` is empty in both baseline and E1 runs — this is PR #209 harness behaviour, not a regression, but is worth a follow-up (is the predicate set wired for mastodon, or is there a fixture filter?). Not blocking for E1.
- `bench/valueflow/results/run_e1_local/local_fixtures.csv` has been committed so reviewers can diff against `run_001`. Binary `.db` and full `.raw.csv` files remain gitignored per PR #209 harness convention.

## Stop point

Per Phase E workflow: stopping here. No self-review, no merge. Awaiting reviewer pass before proceeding to E2.